### PR TITLE
Replace blocking 'sleep' with non-blocking scheduling an Akka event.

### DIFF
--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -139,12 +139,10 @@ class BeamAgentScheduler(val beamConfig: BeamConfig,  stopTick: Double, val maxW
         if (awaitingResponse.isEmpty || (nowInSeconds + 1) - awaitingResponse.keySet().first() + 1 < maxWindow) {
           self ! DoSimStep(nowInSeconds + 1.0)
         } else {
-          Thread.sleep(10)
-          self ! DoSimStep(nowInSeconds)
+          context.system.scheduler.scheduleOnce(FiniteDuration(10, TimeUnit.MILLISECONDS), self, DoSimStep(nowInSeconds))
         }
       } else {
-        Thread.sleep(10)
-        self ! DoSimStep(nowInSeconds)
+        context.system.scheduler.scheduleOnce(FiniteDuration(10, TimeUnit.MILLISECONDS), self, DoSimStep(nowInSeconds))
       }
 
     case ProcessingFinished(it) =>
@@ -157,8 +155,7 @@ class BeamAgentScheduler(val beamConfig: BeamConfig,  stopTick: Double, val maxW
         log.info(s"Stopping BeamAgentScheduler @ tick $nowInSeconds")
         eventSubscriberRef ! EndIteration(currentIter)
       } else {
-        Thread.sleep(10)
-        self ! DoSimStep(nowInSeconds)
+        context.system.scheduler.scheduleOnce(FiniteDuration(10, TimeUnit.MILLISECONDS), self, DoSimStep(nowInSeconds))
       }
 
     case notice@CompletionNotice(triggerId: Long, newTriggers: Seq[ScheduleTrigger]) =>

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -1,12 +1,9 @@
 package beam.agentsim.agents
 
 import java.io.File
-import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.pattern.ask
 import akka.testkit.{EventFilter, ImplicitSender, TestActorRef, TestFSMRef, TestKit}
-import akka.util.Timeout
 import beam.agentsim.agents.PersonAgent._
 import beam.agentsim.agents.modalBehaviors.ModeChoiceCalculator
 import beam.agentsim.events.{AgentsimEventsBus, EventsSubscriber}
@@ -19,6 +16,7 @@ import glokka.Registry
 import glokka.Registry.Created
 import org.matsim.api.core.v01.Id
 import org.matsim.api.core.v01.events.ActivityEndEvent
+import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler
 import org.matsim.core.api.experimental.events.EventsManager
 import org.matsim.core.events.EventsUtils
 import org.matsim.core.population.PopulationUtils
@@ -29,15 +27,13 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpecLike, MustMatchers}
 
-import scala.concurrent.Await
-
 /**
   * Created by sfeygin on 2/7/17.
   */
-class PersonAgentSpec extends TestKit(ActorSystem("testsystem"))
-  with MustMatchers with FunSpecLike with ImplicitSender with MockitoSugar {
+class PersonAgentSpec extends TestKit(ActorSystem("testsystem", ConfigFactory.parseString("""
+  akka.loggers = ["akka.testkit.TestEventListener"]
+  """))) with MustMatchers with FunSpecLike with ImplicitSender with MockitoSugar {
 
-  private implicit val timeout = Timeout(60, TimeUnit.SECONDS)
   private val agentSimEventsBus = new AgentsimEventsBus
   val config = BeamConfig(ConfigFactory.parseFile(new File("test/input/beamville/beam.conf")).resolve())
 
@@ -52,7 +48,6 @@ class PersonAgentSpec extends TestKit(ActorSystem("testsystem"))
 
   describe("A PersonAgent FSM") {
 
-    // FIXME
     it("should allow scheduler to set the first activity") {
       val houseIdDummy = Id.create("dummy",classOf[Household])
       val homeActivity = PopulationUtils.createActivityFromLinkId("home", Id.createLinkId(1))
@@ -79,17 +74,21 @@ class PersonAgentSpec extends TestKit(ActorSystem("testsystem"))
       val householdId  =  Id.create("dummyHousehold", classOf[Household])
       val bodyVehicle = Id.create("dummyBody", classOf[Vehicle])
       val props = PersonAgent.props(services, Id.createPersonId(name), householdId, plan, bodyVehicle)
-      val future = registry ? Registry.Register(name, props)
-      val result = Await.result(future, timeout.duration).asInstanceOf[AnyRef]
-      val ok = result.asInstanceOf[Created]
+      registry ! Registry.Register(name, props)
+      val ok = expectMsgType[Created]
       ok.name mustEqual name
     }
 
     it("should publish events that can be received by a MATSim EventsManager") {
       val houseIdDummy = Id.create("dummy",classOf[Household])
       val events: EventsManager = EventsUtils.createEventsManager()
+      events.addHandler(new ActivityEndEventHandler {
+        override def handleEvent(event: ActivityEndEvent): Unit = {
+          system.log.info("events-subscriber received actend event!")
+        }
+        override def reset(iteration: Int): Unit = {}
+      })
       val eventSubscriber: ActorRef = TestActorRef(new EventsSubscriber(events), "events-subscriber1")
-      val actEndDummy = new ActivityEndEvent(0, Id.createPersonId(0), Id.createLinkId(0), Id.create(0, classOf[ActivityFacility]), "dummy")
       agentSimEventsBus.subscribe(eventSubscriber, ActivityEndEvent.EVENT_TYPE)
 
       val plan = PopulationUtils.getFactory.createPlan()
@@ -102,11 +101,11 @@ class PersonAgentSpec extends TestKit(ActorSystem("testsystem"))
 
       val personAgentRef = TestFSMRef(new PersonAgent(services, Id.create("dummyAgent", classOf[PersonAgent]), houseIdDummy, plan, Id.create("dummyBody", classOf[Vehicle]), PersonData()))
       val beamAgentSchedulerRef = TestActorRef[BeamAgentScheduler](SchedulerProps(config, stopTick = 1000000.0, maxWindow = 10.0))
+      beamAgentSchedulerRef ! ScheduleTrigger(InitializeTrigger(0.0), personAgentRef)
 
-      beamAgentSchedulerRef ! ScheduleTrigger(InitializeTrigger(0.0),personAgentRef)
-      beamAgentSchedulerRef ! StartSchedule(0)
-
-      EventFilter.info(message = "events-subscriber received actend event!", occurrences = 1)
+      EventFilter.info(message = "events-subscriber received actend event!", occurrences = 1) intercept {
+        beamAgentSchedulerRef ! StartSchedule(0)
+      }
     }
 
     it("should be able to route legs"){

--- a/src/test/scala/beam/sim/BeamAgentSchedulerSpec.scala
+++ b/src/test/scala/beam/sim/BeamAgentSchedulerSpec.scala
@@ -42,32 +42,6 @@ class BeamAgentSchedulerSpec extends TestKit(ActorSystem("beam-actor-system")) w
     }
 
     it("should dispatch triggers in chronological order") {
-      val beamAgentSchedulerRef = system.actorOf(SchedulerProps(config, stopTick = 100.0, maxWindow = 100.0))
-      beamAgentSchedulerRef ! ScheduleTrigger(InitializeTrigger(0.0), self)
-      beamAgentSchedulerRef ! ScheduleTrigger(ReportState(1.0), self)
-      beamAgentSchedulerRef ! ScheduleTrigger(ReportState(10.0), self)
-      beamAgentSchedulerRef ! ScheduleTrigger(ReportState(5.0), self)
-      beamAgentSchedulerRef ! ScheduleTrigger(ReportState(15.0), self)
-      beamAgentSchedulerRef ! ScheduleTrigger(ReportState(9.0), self)
-      beamAgentSchedulerRef ! StartSchedule(0)
-      expectMsg(TriggerWithId(InitializeTrigger(0.0), 1))
-      beamAgentSchedulerRef ! completed(1)
-      expectMsg(TriggerWithId(ReportState(1.0), 2))
-      beamAgentSchedulerRef ! completed(2)
-      expectMsg(TriggerWithId(ReportState(5.0), 4))
-      beamAgentSchedulerRef ! completed(4)
-      expectMsg(TriggerWithId(ReportState(9.0), 6))
-      beamAgentSchedulerRef ! completed(6)
-      expectMsg(TriggerWithId(ReportState(10.0), 3))
-      beamAgentSchedulerRef ! completed(3)
-      expectMsg(TriggerWithId(ReportState(15.0), 5))
-      beamAgentSchedulerRef ! completed(5)
-    }
-
-    ignore("should work even on a single thread") {
-      // FIXME: The difference to the previous test is that this one uses a single-threaded environment.
-      // FIXME: This does not work. I think because the scheduler works by sending messages to itself without
-      // FIXME: increasing the time, essentially an infinite recursion.
       val beamAgentSchedulerRef = TestActorRef[BeamAgentScheduler](SchedulerProps(config, stopTick = 100.0, maxWindow = 100.0))
       beamAgentSchedulerRef ! ScheduleTrigger(InitializeTrigger(0.0), self)
       beamAgentSchedulerRef ! ScheduleTrigger(ReportState(1.0), self)


### PR DESCRIPTION
Now the single-threaded test works without hanging, and can replace the regular one.