### PR TITLE
Refactored file DiscreteProbabilityDistribution

### DIFF
--- a/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
@@ -1,6 +1,8 @@
 package beam.agentsim.agents.choice.logit;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
 import java.util.TreeMap;
@@ -8,55 +10,74 @@ import java.util.TreeMap;
 
 public class DiscreteProbabilityDistribution {
 
-	private LinkedHashMap<String,Double> pdf;
-	private NavigableMap<Double, String> cdf;
+  public static final double PRECISION = 1e-6;
 
-	public DiscreteProbabilityDistribution(){ }
-	
-	public void addElement(String element, Double probability){
-		if(this.pdf==null)this.pdf = new LinkedHashMap<String,Double>();
-		this.pdf.put(element,probability);
-		this.cdf = null;
-	}
-	
-	public void setPDF(LinkedHashMap<String,Double> pdf){
-		this.pdf = pdf;
-		this.cdf = null;
-	}
-	
-	private void createCDF() {
-		if(this.pdf == null || this.pdf.size()==0){
-			throw new RuntimeException("Cannot create a CDF based on a missing or empty PDF");
-		}
-		// First ensure the distribution is scaled to 1
-		double scalingFactor = 0.0;
-	    for (Double value : this.pdf.values()){
-	    	if(!Double.isNaN(value) && value >1e-6)scalingFactor += value;
-	    }
-		if(scalingFactor==0.0){
-			throw new RuntimeException("Cannot create a CDF based on a PDF without any non-zero probability density");
-		}
-		this.cdf = new TreeMap<Double, String>();
-		
-		double cumulProb = 0.0;
-		String lastKey = null;
-	    for (String key : this.pdf.keySet()){
-	    	double theProb = Double.isInfinite(this.pdf.get(key)) ? 1.0 : this.pdf.get(key) / scalingFactor;
-	    	if(theProb>1e-6){
-				cumulProb += theProb;
-				this.cdf.put(cumulProb, key);
-				lastKey = key;
-	    	}
-	    }
-		this.cdf.remove(this.cdf.lastKey());
-		this.cdf.put(1.0,lastKey);
-	}
+  private LinkedHashMap<String, Double> pdf;
+  private NavigableMap<Double, String> cdf;
 
-	public String sample(Random rand){
-		if(this.cdf == null)createCDF();
-	   return this.cdf.ceilingEntry(rand.nextDouble()).getValue();
-	}
-	public LinkedHashMap<String,Double> getProbabilityDensityMap(){
-		return this.pdf;
-	}
+  public void setPDF(Map<String, Double> pdf) {
+    this.pdf = new LinkedHashMap<>(pdf);
+    cdf = null;
+  }
+
+  private void createCDF() {
+    if (pdf == null || pdf.isEmpty()) {
+      throw new RuntimeException("Cannot create a CDF based on a missing or empty PDF");
+    }
+
+    final double scalingFactor = getScalingFactor();
+
+    final String lastKey = updateCumulativeProbabilityAndReturnLastKey(scalingFactor);
+
+    cdf = new TreeMap<>();
+    cdf.remove(cdf.lastKey());
+    cdf.put(1.0, lastKey);
+  }
+
+  private String updateCumulativeProbabilityAndReturnLastKey(final double scalingFactor) {
+    String lastKey = null;
+
+    double cumulativeProb = 0.0d;
+    for (Map.Entry<String, Double> entry : pdf.entrySet()) {
+      final String key = entry.getKey();
+      final Double value = entry.getValue();
+
+      double theProb = Double.isInfinite(value) ? 1.0d : value / scalingFactor;
+      if (theProb > PRECISION) {
+        cumulativeProb += theProb;
+        cdf.put(cumulativeProb, key);
+        lastKey = key;
+      }
+    }
+
+    return lastKey;
+  }
+
+  private double getScalingFactor() {
+    double scalingFactor = 0.0;
+    for (Double value : pdf.values()) {
+      if (isNumber(value) && value > PRECISION) {
+        scalingFactor += value;
+      }
+    }
+    if (scalingFactor == 0.0d) {
+      throw new RuntimeException("Cannot create a CDF based on a PDF without any non-zero probability density");
+    }
+    return scalingFactor;
+  }
+
+  public String sample(Random rand) {
+    if (cdf == null) {
+      createCDF();
+    }
+    return cdf.ceilingEntry(rand.nextDouble()).getValue();
+  }
+
+  public Map<String, Double> getProbabilityDensityMap() {
+    return Collections.unmodifiableMap(pdf);
+  }
+
+  private static boolean isNumber(double value) {
+    return !Double.isNaN(value);
+  }
 }

--- a/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
@@ -81,3 +81,4 @@ public class DiscreteProbabilityDistribution {
     return !Double.isNaN(value);
   }
 }
+

--- a/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
@@ -66,13 +66,6 @@ public class DiscreteProbabilityDistribution {
     return scalingFactor;
   }
 
-  public String sample(Random rand) {
-    if (cdf == null) {
-      createCDF();
-    }
-    return cdf.ceilingEntry(rand.nextDouble()).getValue();
-  }
-
   Map<String, Double> getProbabilityDensityMap() {
     return Collections.unmodifiableMap(pdf);
   }
@@ -80,5 +73,12 @@ public class DiscreteProbabilityDistribution {
   private static boolean isNumber(double value) {
     return !Double.isNaN(value);
   }
-}
 
+  public String sample(Random rand) {
+    if (cdf == null) {
+      createCDF();
+    }
+    return cdf.ceilingEntry(rand.nextDouble()).getValue();
+  }
+
+}

--- a/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
@@ -10,12 +10,12 @@ import java.util.TreeMap;
 
 public class DiscreteProbabilityDistribution {
 
-  public static final double PRECISION = 1e-6d;
+  private static final double PRECISION = 1e-6d;
 
   private LinkedHashMap<String, Double> pdf;
   private NavigableMap<Double, String> cdf;
 
-  public void setPDF(Map<String, Double> pdf) {
+  void setPDF(Map<String, Double> pdf) {
     this.pdf = new LinkedHashMap<>(pdf);
     cdf = null;
   }
@@ -37,15 +37,15 @@ public class DiscreteProbabilityDistribution {
   private String updateCumulativeProbabilityAndReturnLastKey(final double scalingFactor) {
     String lastKey = null;
 
-    double cumulativeProb = 0.0d;
+    double cumulativeProbability = 0.0d;
     for (Map.Entry<String, Double> entry : pdf.entrySet()) {
       final String key = entry.getKey();
       final Double value = entry.getValue();
 
       double theProb = Double.isInfinite(value) ? 1.0d : value / scalingFactor;
       if (theProb > PRECISION) {
-        cumulativeProb += theProb;
-        cdf.put(cumulativeProb, key);
+        cumulativeProbability += theProb;
+        cdf.put(cumulativeProbability, key);
         lastKey = key;
       }
     }
@@ -73,7 +73,7 @@ public class DiscreteProbabilityDistribution {
     return cdf.ceilingEntry(rand.nextDouble()).getValue();
   }
 
-  public Map<String, Double> getProbabilityDensityMap() {
+  Map<String, Double> getProbabilityDensityMap() {
     return Collections.unmodifiableMap(pdf);
   }
 

--- a/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/DiscreteProbabilityDistribution.java
@@ -10,7 +10,7 @@ import java.util.TreeMap;
 
 public class DiscreteProbabilityDistribution {
 
-  public static final double PRECISION = 1e-6;
+  public static final double PRECISION = 1e-6d;
 
   private LinkedHashMap<String, Double> pdf;
   private NavigableMap<Double, String> cdf;

--- a/src/main/java/beam/agentsim/agents/choice/logit/NestedLogit.java
+++ b/src/main/java/beam/agentsim/agents/choice/logit/NestedLogit.java
@@ -1,5 +1,6 @@
 package beam.agentsim.agents.choice.logit;
 
+import java.util.Map;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.JDOMException;
@@ -187,7 +188,8 @@ public class NestedLogit implements AbstractLogit{
 		if(this.cdf==null){
 			return null;
 		}else{
-			return sumMarginalProbsOfNest(this,nestName,this.cdf.getProbabilityDensityMap());
+			LinkedHashMap<String, Double> probabilityDensityMap = new LinkedHashMap<>(cdf.getProbabilityDensityMap());
+			return sumMarginalProbsOfNest(this,nestName, probabilityDensityMap);
 		}
 	}
 	@Override


### PR DESCRIPTION
Techniques applied for refactoring:
- Extracted method: getScalingFactor, updateCumulativeProbabilityAndReturnLastKey
- Extracted constant: PRECISION (repeated in the code)
- Minor formatting issues
- `this` keyword redudancy:
  it is a common doubt when and when should not use `this` keyword. 
  I suggest using it only when there is a name collision. this way we can have a common standard in the whole team
  Improvement: make the code cleaner and resolve ambiguity rule
- Performance improvement
```Java
for (String key : this.pdf.keySet()){
    double theProb = Double.isInfinite(this.pdf.get(key)) 
        ? 1.0 
        : this.pdf.get(key) / scalingFactor;
```
  Problem: Traversing keySet and getting the value twice
  
  Replaced by
```Java
   for (Map.Entry<String, Double> entry : pdf.entrySet()) {
      final String key = entry.getKey();
      final Double value = entry.getValue();
```
  Improvement: don't have to lookup twice twice + traversal. The traversal itself already give the key and the value
- Solid fixing: Open-closed principle
```Java
  public void setPDF(Map<String, Double> pdf) {
...
  public Map<String, Double> getProbabilityDensityMap() {
```
- Defensive copy / returning unmodifiable version of the map
added code
```Java
  public void setPDF(Map<String, Double> pdf) {
    this.pdf = new LinkedHashMap<>(pdf);
```
```Java
  public Map<String, Double> getProbabilityDensityMap() {
    return Collections.unmodifiableMap(pdf);
  }
```
Improvement: Avoid unpredictable behaviours like described in the following example
```Java
  Map<String, Double> pdf = new LinkedHashMap<>();
  pdf.put("a", 1.0d);

  object.setPDF(pdf);  
  pdf.put("b", 2.0d);  // the external caller or possible external thread affect set up the previous line
```
