### PR TITLE
Reduce memory allocation by using static compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ or
 
 try running BEAM with our simple [getting started guide](http://beam.readthedocs.io/en/latest/users.html#getting-started) 
 
-or 
+or  
 
 check out the [developer guide](http://beam.readthedocs.io/en/latest/developers.html) to start getting serious about power using or contributing.
 

--- a/src/main/scala/beam/agentsim/agents/vehicles/PassengerSchedule.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/PassengerSchedule.scala
@@ -29,9 +29,21 @@ case class PassengerSchedule(schedule: TreeMap[BeamLeg, Manifest]) {
 
 }
 
+//Specialized copy of Ordering.by[Tuple2] so we can control compare
+//Also has the benefit of not requiring allocation of a Tuple2, which turned out to be costly at scale
+object BeamLegOrdering extends Ordering[BeamLeg] {
+  def compare(a:BeamLeg, b:BeamLeg): Int = {
+    val compare1 = java.lang.Long.compare(a.startTime, b.startTime)
+    if (compare1 != 0) return compare1
+    val compare2 = java.lang.Long.compare(a.duration, b.duration)
+    if (compare2 != 0) return compare2
+    0
+  }
+}
+
 
 object PassengerSchedule {
-  def apply(): PassengerSchedule = new PassengerSchedule(TreeMap[BeamLeg, Manifest]()(Ordering.by(x=>(x.startTime,x.duration))))
+  def apply(): PassengerSchedule = new PassengerSchedule(TreeMap[BeamLeg, Manifest]()(BeamLegOrdering))
 }
 
 case class VehiclePersonId(vehicleId: Id[Vehicle], personId: Id[Person])

--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -55,11 +55,11 @@ object BeamAgentScheduler {
     // Compare is on 3 levels with higher priority (i.e. front of the queue) for:
     //   smaller tick => then higher priority value => then lower triggerId
     def compare(that: ScheduledTrigger): Int =
-    that.triggerWithId.trigger.tick compare triggerWithId.trigger.tick match {
+    java.lang.Double.compare(that.triggerWithId.trigger.tick, triggerWithId.trigger.tick) match {
       case 0 =>
-        priority compare that.priority match {
+        java.lang.Integer.compare(priority, that.priority) match {
           case 0 =>
-            that.triggerWithId.triggerId compare triggerWithId.triggerId
+            java.lang.Long.compare(that.triggerWithId.triggerId, triggerWithId.triggerId)
           case c => c
         }
       case c => c


### PR DESCRIPTION
Also, remove the Tuple2 creation, used only for comparison purposes

This is pending a full test, but otherwise preliminary findings found a 33% reduction in memory footprint when used against sf-light.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/313)
<!-- Reviewable:end -->
