### PR TITLE
BeamEventsLogger clean up - iteration 1

### DIFF
--- a/src/main/java/beam/agentsim/events/handling/BeamEventsFileFormats.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsFileFormats.java
@@ -1,8 +1,35 @@
 package beam.agentsim.events.handling;
 
+import java.util.Optional;
+
 /**
  * BEAM
  */
 public enum BeamEventsFileFormats {
-    xml, csv, xmlgz, csvgz
+    XML("xml"), CSV("csv"), XML_GZ("xml.gz"), CSV_GZ("csv.gz");
+
+    private final String suffix;
+
+    BeamEventsFileFormats(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public static Optional<BeamEventsFileFormats> from(String format) {
+        BeamEventsFileFormats fmt = null;
+        if (format.equalsIgnoreCase(XML.suffix)) {
+            fmt = BeamEventsFileFormats.XML;
+        } else if (format.equalsIgnoreCase(XML_GZ.suffix)) {
+            fmt = BeamEventsFileFormats.XML_GZ;
+        } else if (format.equalsIgnoreCase(CSV.suffix)) {
+            fmt = BeamEventsFileFormats.CSV;
+        } else if (format.equalsIgnoreCase(CSV_GZ.suffix)) {
+            fmt = BeamEventsFileFormats.CSV_GZ;
+        }
+        return Optional.ofNullable(fmt);
+    }
+
 }

--- a/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
@@ -78,14 +78,10 @@ class BeamEventsLogger {
     }
 
     private LoggerLevels getDefaultLevel() {
-        final String defaultWritingLevel = beamOutputEvents().defaultWritingLevel();
+        final String defaultWritingLevel = beamServices.beamConfig().beam().outputs().events().defaultWritingLevel();
         return "".equals(defaultWritingLevel)
                 ? OFF
                 : LoggerLevels.valueOf(defaultWritingLevel);
-    }
-
-    private beam.sim.config.BeamConfig.Beam.Outputs.Events beamOutputEvents() {
-        return beamServices.beamConfig().beam().outputs().events();
     }
 
     void iterationEnds() {
@@ -109,7 +105,7 @@ class BeamEventsLogger {
 
             for (BeamEventsFileFormats fmt : eventsFileFormatsArray) {
                 BeamEventsWriterBase newWriter = null;
-                if (beamOutputEvents().explodeIntoFiles()) {
+                if (beamServices.beamConfig().beam().outputs().events().explodeIntoFiles()) {
                     for (Class<?> eventTypeToLog : getAllEventsToLog()) {
                         newWriter = createEventWriterForClassAndFormat(eventsFileBasePath, eventTypeToLog, fmt);
                         writers.add(newWriter);
@@ -169,7 +165,7 @@ class BeamEventsLogger {
 
     private void setEventsFileFormats() {
         eventsFileFormatsArray.clear();
-        String eventsFileFormats = beamOutputEvents().fileOutputFormats();
+        String eventsFileFormats = beamServices.beamConfig().beam().outputs().events().fileOutputFormats();
         for (String format : eventsFileFormats.split(",")) {
             BeamEventsFileFormats.from(format)
                     .ifPresent(eventsFileFormatsArray::add);
@@ -199,7 +195,8 @@ class BeamEventsLogger {
     private void overrideDefaultLoggerSetup() {
         Class<?> theClass = null;
 
-        for (String classAndLevel : beamOutputEvents().overrideWritingLevels().split(",")) {
+        for (String classAndLevel : beamServices.beamConfig().beam().outputs().events().overrideWritingLevels()
+                .split(",")) {
             String[] splitClassLevel = classAndLevel.split(":");
             String classString = splitClassLevel[0].trim();
             String levelString = splitClassLevel[1].trim();

--- a/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
@@ -1,97 +1,115 @@
 package beam.agentsim.events.handling;
 
 import beam.agentsim.events.LoggerLevels;
-import beam.agentsim.events.ModeChoiceEvent;
-import beam.agentsim.events.PathTraversalEvent;
-import beam.agentsim.events.ReplanningEvent;
-import beam.sim.BeamServices;
+    import beam.sim.BeamServices;
 import beam.utils.DebugLib;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.Event;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static beam.agentsim.events.LoggerLevels.OFF;
 
-/**
- * BEAM
- */
+class BeamEventsLogger {
 
-public class BeamEventsLogger {
     private final EventsManager eventsManager;
     private final MatsimServices matsimServices;
-    // create multimap to store key and values
-    Multimap<Class, String> eventFieldsToDropWhenShort = ArrayListMultimap.create();
-    private ArrayList<BeamEventsWriterBase> writers = new ArrayList<>();
-    private HashMap<Class<?>, LoggerLevels> levels = new HashMap<>();
-    private LoggerLevels defaultLevel;
-    private HashSet<Class<?>> allLoggableEvents = new HashSet<>(), eventsToLog = new HashSet<>();
-    private BeamServices beamServices;
-    private String eventsFileFormats;
-    private ArrayList<BeamEventsFileFormats> eventsFileFormatsArray = new ArrayList<>();
-    private Multimap<Class, String> eventFieldsToAddWhenVerbose = ArrayListMultimap.create();
-    private List<String> eventFields = null;
+    private final LoggerLevels defaultLevel;
+    private final BeamServices beamServices;
 
-    public BeamEventsLogger(BeamServices beamServices, MatsimServices matsimServices, EventsManager eventsManager) {
+    private final Multimap<Class, String> eventFieldsToDropWhenShort = ArrayListMultimap.create();
+    private final List<BeamEventsWriterBase> writers = new ArrayList<>();
+    private final Map<Class<?>, LoggerLevels> levels = new HashMap<>();
+    private final Set<Class<?>> allLoggableEvents = new HashSet<>();
+    private final Set<Class<?>> eventsToLog = new HashSet<>();
+    private final List<BeamEventsFileFormats> eventsFileFormatsArray = new ArrayList<>();
 
+    BeamEventsLogger(BeamServices beamServices, MatsimServices matsimServices, EventsManager eventsManager) {
         this.beamServices = beamServices;
         this.matsimServices = matsimServices;
         this.eventsManager = eventsManager;
+
         setEventsFileFormats();
 
-        // Registry of BEAM events that can be logged by BeamEventLogger
-        allLoggableEvents.add(PathTraversalEvent.class);
-        allLoggableEvents.add(ModeChoiceEvent.class);
-        allLoggableEvents.add(ReplanningEvent.class);
+        registryBeamLoggableEvents();
 
-        // Registry of MATSim events that can be logged by BeamEventLogger
-        allLoggableEvents.add(ActivityEndEvent.class);
-        allLoggableEvents.add(PersonDepartureEvent.class);
-        allLoggableEvents.add(PersonEntersVehicleEvent.class);
-        allLoggableEvents.add(VehicleEntersTrafficEvent.class);
-        allLoggableEvents.add(LinkLeaveEvent.class);
-        allLoggableEvents.add(LinkEnterEvent.class);
-        allLoggableEvents.add(VehicleLeavesTrafficEvent.class);
-        allLoggableEvents.add(PersonLeavesVehicleEvent.class);
-        allLoggableEvents.add(PersonArrivalEvent.class);
-        allLoggableEvents.add(ActivityStartEvent.class);
+        registryMATSimLoggableEvents();
 
-        //filter according loggerLevel
-        if (this.beamServices.beamConfig().beam().outputs().events().defaultWritingLevel().equals("")) {
-            defaultLevel = OFF;
-        } else {
-            defaultLevel = LoggerLevels.valueOf(this.beamServices.beamConfig().beam().outputs().events().defaultWritingLevel());
+        defaultLevel = getDefaultLevel();
+
+        if (defaultLevel != OFF) {
             eventsToLog.addAll(getAllLoggableEvents());
         }
+
         overrideDefaultLoggerSetup();
+
         shortLoggerSetup();
+
         verboseLoggerSetup();
 
-        //Write events for filter LoggingLevels();
         createEventsWriters();
     }
 
-    public void iterationEnds() {
-        for (BeamEventsWriterBase writer : this.writers) {
-            writer.closeFile();
-            this.eventsManager.removeHandler(writer);
-        }
-        this.writers.clear();
+    private void registryBeamLoggableEvents() {
+        allLoggableEvents.add(beam.agentsim.events.PathTraversalEvent.class);
+        allLoggableEvents.add(beam.agentsim.events.ModeChoiceEvent.class);
+        allLoggableEvents.add(beam.agentsim.events.ReplanningEvent.class);
     }
 
-    public void createEventsWriters() {
-        int iterationNumber = this.matsimServices.getIterationNumber();
-        boolean writeThisIteration = (this.beamServices.beamConfig().beam().outputs().writeEventsInterval() > 0) && (iterationNumber % this.beamServices.beamConfig().beam().outputs().writeEventsInterval() == 0);
-        if (writeThisIteration) {
-            this.matsimServices.getControlerIO().createIterationDirectory(iterationNumber);
-            String eventsFileBasePath = this.matsimServices.getControlerIO().getIterationFilename(iterationNumber, "events");
+    private void registryMATSimLoggableEvents() {
+        allLoggableEvents.add(org.matsim.api.core.v01.events.ActivityEndEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.PersonDepartureEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.PersonEntersVehicleEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.VehicleEntersTrafficEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.LinkLeaveEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.LinkEnterEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.PersonLeavesVehicleEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.PersonArrivalEvent.class);
+        allLoggableEvents.add(org.matsim.api.core.v01.events.ActivityStartEvent.class);
+    }
 
-            for (BeamEventsFileFormats fmt : this.eventsFileFormatsArray) {
+    private LoggerLevels getDefaultLevel() {
+        final String defaultWritingLevel = beamOutputEvents().defaultWritingLevel();
+        return "".equals(defaultWritingLevel)
+                ? OFF
+                : LoggerLevels.valueOf(defaultWritingLevel);
+    }
+
+    private beam.sim.config.BeamConfig.Beam.Outputs.Events beamOutputEvents() {
+        return beamServices.beamConfig().beam().outputs().events();
+    }
+
+    void iterationEnds() {
+        for (BeamEventsWriterBase writer : writers) {
+            writer.closeFile();
+            eventsManager.removeHandler(writer);
+        }
+        writers.clear();
+    }
+
+    private void createEventsWriters() {
+        int iterationNumber = matsimServices.getIterationNumber();
+
+        final int writeEventsInterval = beamServices.beamConfig().beam().outputs().writeEventsInterval();
+
+        final boolean writeThisIteration = (writeEventsInterval > 0) && (iterationNumber % writeEventsInterval == 0);
+
+        if (writeThisIteration) {
+            matsimServices.getControlerIO().createIterationDirectory(iterationNumber);
+            String eventsFileBasePath = matsimServices.getControlerIO().getIterationFilename(iterationNumber, "events");
+
+            for (BeamEventsFileFormats fmt : eventsFileFormatsArray) {
                 BeamEventsWriterBase newWriter = null;
-                if (this.beamServices.beamConfig().beam().outputs().events().explodeIntoFiles()) {
+                if (beamOutputEvents().explodeIntoFiles()) {
                     for (Class<?> eventTypeToLog : getAllEventsToLog()) {
                         newWriter = createEventWriterForClassAndFormat(eventsFileBasePath, eventTypeToLog, fmt);
                         writers.add(newWriter);
@@ -106,14 +124,16 @@ public class BeamEventsLogger {
         }
     }
 
-    public BeamEventsWriterBase createEventWriterForClassAndFormat(String eventsFilePathBase, Class<?> theClass, BeamEventsFileFormats fmt) {
-        if (fmt == BeamEventsFileFormats.xml || fmt == BeamEventsFileFormats.xmlgz) {
-            String path = eventsFilePathBase + ((fmt == BeamEventsFileFormats.xml) ? ".xml" : ".xml.gz");
-            return new BeamEventsWriterXML(path, this, this.beamServices, theClass);
-        } else if (fmt == BeamEventsFileFormats.csv || fmt == BeamEventsFileFormats.csvgz) {
-            String path = eventsFilePathBase + ((fmt == BeamEventsFileFormats.csv) ? ".csv" : ".csv.gz");
-            return new BeamEventsWriterCSV(path, this, this.beamServices, theClass);
+    private BeamEventsWriterBase createEventWriterForClassAndFormat(String eventsFilePathBase,
+            Class<?> theClass, BeamEventsFileFormats fmt) {
+        final String path = eventsFilePathBase + "." + fmt.getSuffix();
+
+        if (fmt == BeamEventsFileFormats.XML || fmt == BeamEventsFileFormats.XML_GZ) {
+            return new BeamEventsWriterXML(path, this, beamServices, theClass);
+        } else if (fmt == BeamEventsFileFormats.CSV || fmt == BeamEventsFileFormats.CSV_GZ) {
+            return new BeamEventsWriterCSV(path, this, beamServices, theClass);
         }
+
         return null;
     }
 
@@ -121,76 +141,65 @@ public class BeamEventsLogger {
         levels.put(eventType, level);
     }
 
+    Multimap<Class, String> getEventFieldsToDropWhenShort() {
+        return eventFieldsToDropWhenShort;
+    }
+
     //Logging control code changed return type from int to String
-    public LoggerLevels getLoggingLevel(Event event) {
+    LoggerLevels getLoggingLevel(Event event) {
         return getLoggingLevel(event.getClass());
     }
 
-    public LoggerLevels getLoggingLevel(Class clazz) {
-        if (levels.containsKey(clazz)) {
-            return levels.get(clazz);
-        } else {
-            return defaultLevel;
-        }
+    LoggerLevels getLoggingLevel(Class clazz) {
+        return levels.getOrDefault(clazz, defaultLevel);
     }
 
-    public boolean shouldLogThisEventType(Class<? extends Event> aClass) {
+    boolean shouldLogThisEventType(Class<? extends Event> aClass) {
         //TODO in future this is where fine tuning logging based on level number could occur (e.g. info versus debug)
         return eventsToLog.contains(aClass);
     }
 
-    public HashSet<Class<?>> getAllEventsToLog() {
+    Set<Class<?>> getAllEventsToLog() {
         return eventsToLog;
     }
 
-    public HashSet<Class<?>> getAllLoggableEvents() {
+    private Set<Class<?>> getAllLoggableEvents() {
         return allLoggableEvents;
     }
 
-    public void setEventsFileFormats() {
-        String eventsFilePath = "";
-        BeamEventsFileFormats fmt = null;
-        this.eventsFileFormats = this.beamServices.beamConfig().beam().outputs().events().fileOutputFormats();
-        this.eventsFileFormatsArray.clear();
+    private void setEventsFileFormats() {
+        eventsFileFormatsArray.clear();
+        String eventsFileFormats = beamOutputEvents().fileOutputFormats();
         for (String format : eventsFileFormats.split(",")) {
-            if (format.equalsIgnoreCase("xml")) {
-                fmt = BeamEventsFileFormats.xml;
-            } else if (format.equalsIgnoreCase("xml.gz")) {
-                fmt = BeamEventsFileFormats.xmlgz;
-            } else if (format.equalsIgnoreCase("csv")) {
-                fmt = BeamEventsFileFormats.csv;
-            } else if (format.equalsIgnoreCase("csv.gz")) {
-                fmt = BeamEventsFileFormats.csvgz;
-            }
-            this.eventsFileFormatsArray.add(fmt);
+            BeamEventsFileFormats.from(format)
+                    .ifPresent(eventsFileFormatsArray::add);
         }
     }
 
-    public HashSet<String> getKeysToWrite(Event event, Map<String, String> eventAttributes) {
-        HashSet<String> keySet = new HashSet<>(eventAttributes.keySet());
-        //Remove attribute from each event class for SHORT logger level
+    Set<String> getKeysToWrite(Event event, Map<String, String> eventAttributes) {
+        Set<String> keySet = new HashSet<>(eventAttributes.keySet());
         if (getLoggingLevel(event) == LoggerLevels.SHORT && eventFieldsToDropWhenShort.containsKey(event.getClass())) {
-            eventFields = (List) eventFieldsToDropWhenShort.get(event.getClass());
-            // iterate through the key set
+            List<String> eventFields = (List<String>) eventFieldsToDropWhenShort.get(event.getClass());
             for (String key : eventFields) {
                 keySet.remove(key);
             }
         }
-        //Add attribute from each event class for VERBOSE logger level
-        else if (getLoggingLevel(event) == LoggerLevels.VERBOSE && eventFieldsToAddWhenVerbose.containsKey(event.getClass())) {
-            eventFields = (List) eventFieldsToAddWhenVerbose.get(event.getClass());
-            // iterate through the key set
+
+//        Add attribute from each event class for VERBOSE logger level
+//        else if (getLoggingLevel(event) == LoggerLevels.VERBOSE && eventFieldsToAddWhenVerbose.containsKey(event.getClass())) {
+//            eventFields = (List) eventFieldsToAddWhenVerbose.get(event.getClass());
+//            // iterate through the key set
 //            for (String key : eventFields) {
 //                attributes.putAll(event.getVer);
 //            }
-        }
+//        }
         return keySet;
     }
 
-    public void overrideDefaultLoggerSetup() {
+    private void overrideDefaultLoggerSetup() {
         Class<?> theClass = null;
 
-        for (String classAndLevel : beamServices.beamConfig().beam().outputs().events().overrideWritingLevels().split(",")) {
+        for (String classAndLevel : beamOutputEvents().overrideWritingLevels().split(",")) {
             String[] splitClassLevel = classAndLevel.split(":");
             String classString = splitClassLevel[0].trim();
             String levelString = splitClassLevel[1].trim();
@@ -199,18 +208,20 @@ public class BeamEventsLogger {
                 theClass = Class.forName(classString);
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
-                DebugLib.stopSystemAndReportInconsistency("Logging class name '" + theClass.getCanonicalName() + "' is not a valid class, use fully qualified class names (e.g. .");
+                DebugLib.stopSystemAndReportInconsistency("Logging class name '"
+                        + theClass.getCanonicalName()
+                        + "' is not a valid class, use fully qualified class names (e.g. .");
             }
             setLoggingLevel(theClass, theLevel);
-            if (theLevel != OFF) {
-                eventsToLog.add(theClass);
-            } else if (theLevel == OFF) {
+            if (theLevel == OFF) {
                 eventsToLog.remove(theClass);
+            } else {
+                eventsToLog.add(theClass);
             }
         }
     }
 
-    public void shortLoggerSetup() {
+    private void shortLoggerSetup() {
 //        eventFieldsToDropWhenShort.put(PathTraversalEvent.class, PathTraversalEvent.ATTRIBUTE_VIZ_DATA);
 //        eventFieldsToDropWhenShort.put(PathTraversalEvent.class, PathTraversalEvent.ATTRIBUTE_LINK_IDS);
 //        eventFieldsToDropWhenShort.put(PathTraversalEvent.class, PathTraversalEvent.ATTRIBUTE_DEPARTURE_TIME);
@@ -231,7 +242,7 @@ public class BeamEventsLogger {
 //        eventFieldsToDropWhenShort.put(ActivityStartEvent.class,ActivityStartEvent.ATTRIBUTE_ACTTYPE);
     }
 
-    public void verboseLoggerSetup() {
+    private void verboseLoggerSetup() {
 //        eventFieldsToAddWhenVerbose.put(ModeChoiceEvent.class,ModeChoiceEvent.VERBOSE_ATTRIBUTE_EXP_MAX_UTILITY);
 //        eventFieldsToAddWhenVerbose.put(ModeChoiceEvent.class,ModeChoiceEvent.VERBOSE_ATTRIBUTE_LOCATION);
     }

--- a/src/main/java/beam/agentsim/events/handling/BeamEventsWriterCSV.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsWriterCSV.java
@@ -8,9 +8,9 @@ import org.matsim.core.utils.io.UncheckedIOException;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static beam.agentsim.events.LoggerLevels.*;
 
@@ -71,7 +71,7 @@ public class BeamEventsWriterCSV extends BeamEventsWriterBase {
         String[] row = new String[attributeToColumnIndexMapping.keySet().size()];
 
         Map<String, String> eventAttributes = event.getAttributes();
-        HashSet<String> attributeKeys = this.beamEventLogger.getKeysToWrite(event, eventAttributes);
+        Set<String> attributeKeys = this.beamEventLogger.getKeysToWrite(event, eventAttributes);
         for (String attribute : attributeKeys) {
             if (!attributeToColumnIndexMapping.containsKey(attribute)) {
                 if (this.eventTypeToLog == null || !attribute.equals(Event.ATTRIBUTE_TYPE)) {
@@ -108,19 +108,17 @@ public class BeamEventsWriterCSV extends BeamEventsWriterBase {
 
     private void registerClass(Class cla) {
         LoggerLevels level = beamEventLogger.getLoggingLevel(cla);
-        Field[] fields = cla.getFields();
 
         if (level != OFF) {
+            Field[] fields = cla.getFields();
             for (Field field : fields) {
-                if (level != SHORT || !beamEventLogger.eventFieldsToDropWhenShort.get(cla).contains(field.getName())) {
-                    if ((field.getName().startsWith("ATTRIBUTE_") && (this.eventTypeToLog == null || !field.getName().startsWith("ATTRIBUTE_TYPE"))) ||
-                            (level == VERBOSE && field.getName().startsWith("VERBOSE_") && (this.eventTypeToLog == null || !field.getName().startsWith("VERBOSE_")))
+                if (level != SHORT || !beamEventLogger.getEventFieldsToDropWhenShort().get(cla).contains(field.getName())) {
+                    if ((field.getName().startsWith("ATTRIBUTE_") && (eventTypeToLog == null || !field.getName().startsWith("ATTRIBUTE_TYPE"))) ||
+                            (level == VERBOSE && field.getName().startsWith("VERBOSE_") && (eventTypeToLog == null || !field.getName().startsWith("VERBOSE_")))
                             ) {
                         try {
                             attributeToColumnIndexMapping.put(field.get(null).toString(), 0);
-                        } catch (IllegalArgumentException e) {
-                            e.printStackTrace();
-                        } catch (IllegalAccessException e) {
+                        } catch (IllegalArgumentException | IllegalAccessException e) {
                             e.printStackTrace();
                         }
                     }

--- a/src/main/java/beam/agentsim/events/handling/BeamEventsWriterXML.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsWriterXML.java
@@ -6,7 +6,7 @@ import org.matsim.api.core.v01.events.Event;
 import org.matsim.core.utils.io.UncheckedIOException;
 
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.Map;
 
 /**
@@ -56,7 +56,7 @@ public class BeamEventsWriterXML extends BeamEventsWriterBase {
             Map<String, String> eventAttributes = event.getAttributes();
             try {
                 this.out.append("\t<event ");
-                HashSet<String> attrKeys = beamEventLogger.getKeysToWrite(event, eventAttributes);
+                Set<String> attrKeys = beamEventLogger.getKeysToWrite(event, eventAttributes);
                 for (String attrKey : attrKeys) {
                     this.out.append(attrKey);
                     this.out.append("=\"");


### PR DESCRIPTION
What changed:
- Improved cohesion: moved the suffix files to the Enumeration `BeamEventsFileFormats`
- Extract method: large method broken down
- Extract variable: avoided multiple calls to the same method
- Demeter law adapted: `beamServices.beamConfig().beam().outputs().events()`
- SOLID Decoupling improved: concrete classes replaced by interfaces
- Readability: some simplifications
- Premature declaration removed: variables with unused value due to intermediate conditions
- Removed warnings: Unchecked type and others
- Small performance gains: usage of `Map.containsKey` followed by `Map.get` and others
- Fixed encapsulation issues: tightened visibility
- Conventions: renamed enumeration and variables to follow conventions
- Others: string first in literal comparison, limit line size, removed wildcards, etc.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/354)
<!-- Reviewable:end -->
