### PR TITLE
Refactor `ridehail` package - iteration 01

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -19,11 +19,7 @@ import beam.agentsim.agents.modalbehaviors.DrivesVehicle.{
 }
 import beam.agentsim.agents.modalbehaviors.{ChoosesMode, DrivesVehicle, ModeChoiceCalculator}
 import beam.agentsim.agents.planning.{BeamPlan, Tour}
-import beam.agentsim.agents.ridehail.RideHailManager.{
-  ReserveRide,
-  RideHailRequest,
-  RideHailResponse
-}
+import beam.agentsim.agents.ridehail.{ReserveRide, RideHailRequest, RideHailResponse}
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events.{ReplanningEvent, ReserveRideHailEvent}
 import beam.agentsim.scheduler.BeamAgentScheduler.{
@@ -34,7 +30,7 @@ import beam.agentsim.scheduler.BeamAgentScheduler.{
 import beam.agentsim.scheduler.Trigger
 import beam.agentsim.scheduler.Trigger.TriggerWithId
 import beam.router.Modes.BeamMode
-import beam.router.Modes.BeamMode.{DRIVE_TRANSIT, WALK, WALK_TRANSIT}
+import beam.router.Modes.BeamMode.WALK_TRANSIT
 import beam.router.RoutingModel._
 import beam.sim.BeamServices
 import com.conveyal.r5.transit.TransportNetwork

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -6,16 +6,9 @@ import beam.agentsim.agents.BeamAgent._
 import beam.agentsim.agents.PersonAgent._
 import beam.agentsim.agents._
 import beam.agentsim.agents.household.HouseholdActor.MobilityStatusInquiry.mobilityStatusInquiry
-import beam.agentsim.agents.household.HouseholdActor.{
-  MobilityStatusReponse,
-  ReleaseVehicleReservation
-}
+import beam.agentsim.agents.household.HouseholdActor.{MobilityStatusReponse,  ReleaseVehicleReservation}
 import beam.agentsim.agents.modalbehaviors.ChoosesMode._
-import beam.agentsim.agents.ridehail.RideHailManager.{
-  RideHailInquiry,
-  RideHailRequest,
-  RideHailResponse
-}
+import beam.agentsim.agents.ridehail.{RideHailInquiry,  RideHailRequest,  RideHailResponse}
 import beam.agentsim.agents.vehicles.AccessErrorCodes.RideHailNotRequestedError
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles.{VehiclePersonId, _}
@@ -336,7 +329,7 @@ trait ChoosesMode {
   ): Boolean = {
     driveTransitTrip.isDefined && driveTransitTrip.get.legs
       .exists(_.beamLeg.mode.isMassTransit) &&
-    rideHail2TransitResult.getOrElse(RideHailResponse.dummy).error.isEmpty
+    rideHail2TransitResult.getOrElse(RideHailResponse.DUMMY).error.isEmpty
   }
 
   def makeRideHailRequestFromBeamLeg(legs: Vector[BeamLeg]): Option[Int] = {

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -8,7 +8,11 @@ import beam.agentsim.agents._
 import beam.agentsim.agents.household.HouseholdActor.MobilityStatusInquiry.mobilityStatusInquiry
 import beam.agentsim.agents.household.HouseholdActor.{MobilityStatusReponse,  ReleaseVehicleReservation}
 import beam.agentsim.agents.modalbehaviors.ChoosesMode._
-import beam.agentsim.agents.ridehail.{RideHailInquiry,  RideHailRequest,  RideHailResponse}
+import beam.agentsim.agents.ridehail.{
+  RideHailInquiry,
+  RideHailRequest,
+  RideHailResponse
+}
 import beam.agentsim.agents.vehicles.AccessErrorCodes.RideHailNotRequestedError
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles.{VehiclePersonId, _}

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
@@ -3,6 +3,7 @@ package beam.agentsim.agents.ridehail
 import beam.agentsim.agents.vehicles.VehiclePersonId
 import beam.router.BeamRouter.Location
 import beam.router.RoutingModel.{BeamTime, DiscreteTime}
+import org.apache.commons.lang.builder.HashCodeBuilder
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.api.core.v01.population.Person
 import org.matsim.vehicles.Vehicle
@@ -14,10 +15,18 @@ case class RideHailRequest(
   departAt: BeamTime,
   destination: Location
 ) {
-  // We make requestId be independent of request type, all that matters is details of the customer
-  // TODO: is this an attempt to create an unique value?
-  lazy val requestId: Int =
-    this.copy(requestType = RideHailInquiry).hashCode()
+  /**
+   * Returns a unique identifiable value based on the fields. Field requestType should not be part of the hash.
+   * @return hashCode(customer, pickUpLocation, departAt, destination)
+   */
+  lazy val requestId: Int = {
+    new HashCodeBuilder()
+      .append(customer)
+      .append(pickUpLocation)
+      .append(departAt)
+      .append(destination)
+      .toHashCode
+  }
 }
 
 object RideHailRequest {

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
@@ -1,0 +1,32 @@
+package beam.agentsim.agents.ridehail
+
+import beam.agentsim.agents.vehicles.VehiclePersonId
+import beam.router.BeamRouter.Location
+import beam.router.RoutingModel.{BeamTime, DiscreteTime}
+import org.matsim.api.core.v01.{Coord, Id}
+import org.matsim.api.core.v01.population.Person
+import org.matsim.vehicles.Vehicle
+
+case class RideHailRequest(
+  requestType: RideHailRequestType,
+  customer: VehiclePersonId,
+  pickUpLocation: Location,
+  departAt: BeamTime,
+  destination: Location
+) {
+  // We make requestId be independent of request type, all that matters is details of the customer
+  // TODO: is this an attempt to create an unique value?
+  lazy val requestId: Int =
+    this.copy(requestType = RideHailInquiry).hashCode()
+}
+
+object RideHailRequest {
+
+  val DUMMY = RideHailRequest(
+    RideHailInquiry,
+    VehiclePersonId(Id.create("dummy", classOf[Vehicle]), Id.create("dummy", classOf[Person])),
+    new Coord(Double.NaN, Double.NaN),
+    DiscreteTime(Int.MaxValue),
+    new Coord(Double.NaN, Double.NaN)
+  )
+}

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequestType.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequestType.scala
@@ -1,0 +1,7 @@
+package beam.agentsim.agents.ridehail
+
+sealed trait RideHailRequestType
+
+case object RideHailInquiry extends RideHailRequestType
+
+case object ReserveRide extends RideHailRequestType

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailResponse.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailResponse.scala
@@ -1,0 +1,19 @@
+package beam.agentsim.agents.ridehail
+
+import beam.agentsim.agents.ridehail.RideHailManager.TravelProposal
+import beam.agentsim.events.resources.ReservationError
+import beam.agentsim.scheduler.BeamAgentScheduler.ScheduleTrigger
+
+case class RideHailResponse(
+  request: RideHailRequest,
+  travelProposal: Option[TravelProposal],
+  error: Option[ReservationError] = None,
+  triggersToSchedule: Vector[ScheduleTrigger] = Vector()
+)
+
+object RideHailResponse {
+  val DUMMY = RideHailResponse(RideHailRequest.DUMMY, None, None)
+
+  def dummyWithError(error: ReservationError) =
+    RideHailResponse(RideHailRequest.DUMMY, None, Some(error))
+}

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/DefaultRideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/DefaultRideHailResourceAllocationManager.scala
@@ -6,21 +6,18 @@ import org.matsim.vehicles.Vehicle
 
 class DefaultRideHailResourceAllocationManager extends RideHailResourceAllocationManager {
 
-  val isBufferedRideHailAllocationMode = false
+  override val isBufferedRideHailAllocationMode = false
 
-  def proposeVehicleAllocation(
+  override def proposeVehicleAllocation(
     vehicleAllocationRequest: VehicleAllocationRequest
   ): Option[VehicleAllocation] = {
     None
   }
 
-// TODO RW/Asif: how to make sure no one ever can call this?
-  def allocateVehicles(
+  override def allocateVehicles(
     allocationsDuringReservation: Vector[(VehicleAllocationRequest, Option[VehicleAllocation])]
   ): IndexedSeq[(VehicleAllocationRequest, Option[VehicleAllocation])] = {
-    log.error("batch processing is not implemented for DefaultRideHailResourceAllocationManager")
-    //???
-    allocationsDuringReservation
+    throw new NotImplementedError("DefaultRideHailResourceAllocationManager.allocateVehicles not implemented.")
   }
 
   override def repositionVehicles(tick: Double): Vector[(Id[Vehicle], Location)] = {

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RandomRepositioning.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RandomRepositioning.scala
@@ -2,24 +2,25 @@ package beam.agentsim.agents.ridehail.allocation
 
 import beam.agentsim.agents.ridehail.RideHailManager
 import beam.router.BeamRouter.Location
+import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
 
 class RandomRepositioning(val rideHailManager: RideHailManager)
-    extends RideHailResourceAllocationManager {
+    extends RideHailResourceAllocationManager with LazyLogging {
 
-  val isBufferedRideHailAllocationMode = false
+  override val isBufferedRideHailAllocationMode = false
 
-  def proposeVehicleAllocation(
+  override def proposeVehicleAllocation(
     vehicleAllocationRequest: VehicleAllocationRequest
   ): Option[VehicleAllocation] = {
     None
   }
 
-  def allocateVehicles(
+  override def allocateVehicles(
     allocationsDuringReservation: Vector[(VehicleAllocationRequest, Option[VehicleAllocation])]
   ): IndexedSeq[(VehicleAllocationRequest, Option[VehicleAllocation])] = {
-    log.error("batch processing is not implemented for DefaultRideHailResourceAllocationManager")
+    logger.error("batch processing is not implemented for DefaultRideHailResourceAllocationManager")
     allocationsDuringReservation
   }
 
@@ -28,12 +29,12 @@ class RandomRepositioning(val rideHailManager: RideHailManager)
     val repositioningShare =
       rideHailManager.beamServices.beamConfig.beam.agentsim.agents.rideHail.allocationManager.randomRepositioning.repositioningShare
     val fleetSize = rideHailManager.resources.size
-    val numVechilesToReposition = (repositioningShare * fleetSize).toInt
+    val numVehiclesToReposition = (repositioningShare * fleetSize).toInt
     if (rideHailManager.getIdleVehicles.size >= 2) {
       val origin = rideHailManager.getIdleVehicles.values.toVector
       val destination = scala.util.Random.shuffle(origin)
       (for ((o, d) <- origin zip destination)
-        yield (o.vehicleId, d.currentLocation.loc)).splitAt(numVechilesToReposition)._1
+        yield (o.vehicleId, d.currentLocation.loc)).splitAt(numVehiclesToReposition)._1
     } else {
       Vector()
     }

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RepositioningLowWaitingTimes.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RepositioningLowWaitingTimes.scala
@@ -8,26 +8,27 @@ import beam.router.BeamRouter.Location
 import beam.utils._
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.vehicles.Vehicle
-
 import scala.collection.concurrent.TrieMap
+
+import com.typesafe.scalalogging.LazyLogging
 
 class RepositioningLowWaitingTimes(
   val rideHailManager: RideHailManager,
   tncIterationStats: Option[TNCIterationStats]
-) extends RideHailResourceAllocationManager {
+) extends RideHailResourceAllocationManager with LazyLogging {
 
-  val isBufferedRideHailAllocationMode = false
+  override val isBufferedRideHailAllocationMode = false
 
-  def proposeVehicleAllocation(
+  override def proposeVehicleAllocation(
     vehicleAllocationRequest: VehicleAllocationRequest
   ): Option[VehicleAllocation] = {
     None
   }
 
-  def allocateVehicles(
+  override def allocateVehicles(
     allocationsDuringReservation: Vector[(VehicleAllocationRequest, Option[VehicleAllocation])]
   ): Vector[(VehicleAllocationRequest, Option[VehicleAllocation])] = {
-    log.error("batch procesbsing is not implemented for DefaultRideHailResourceAllocationManager")
+    logger.error("batch processing is not implemented for DefaultRideHailResourceAllocationManager")
     allocationsDuringReservation
   }
 
@@ -47,8 +48,9 @@ class RepositioningLowWaitingTimes(
     }
 
     if (result.size < idleVehicles.values.size) {
-      log.debug(
-        s"filterOutAlreadyRepositioningVehiclesIfEnoughAlternativeIdleVehiclesAvailable: reduced set by ${idleVehicles.values.size - result.size}"
+      logger.debug(
+        s"filterOutAlreadyRepositioningVehiclesIfEnoughAlternativeIdleVehiclesAvailable: " +
+          s"reduced set by ${idleVehicles.values.size - result.size}"
       )
     }
 
@@ -174,7 +176,7 @@ class RepositioningLowWaitingTimes(
             val tazEntries = tncIterStats getCoordinatesWithRideHailStatsEntry (tick, tick + 3600)
 
             for (tazEntry <- tazEntries.filter(x => x._2.getDemandEstimate > 0)) {
-              if (!firstRepositionCoordsOfDay.isDefined || (firstRepositionCoordsOfDay.isDefined && rideHailManager.beamServices.geo
+              if (firstRepositionCoordsOfDay.isEmpty || (firstRepositionCoordsOfDay.isDefined && rideHailManager.beamServices.geo
                     .distInMeters(firstRepositionCoordsOfDay.get._1, tazEntry._1) < 10000)) {
                 spatialPlot.addPoint(PointToPlot(tazEntry._1, Color.RED, 10))
                 spatialPlot.addString(
@@ -209,7 +211,7 @@ class RepositioningLowWaitingTimes(
               spatialPlot.addString(StringToPlot("A", firstRepositionCoordOfDay.get, Color.BLACK, 50))
             }*/
 
-            if (!firstRepositionCoordsOfDay.isDefined) {
+            if (firstRepositionCoordsOfDay.isEmpty) {
               firstRepositionCoordsOfDay = Some(
                 rideHailManager
                   .getRideHailAgentLocation(whichTAZToRepositionTo.head._1)
@@ -243,7 +245,7 @@ class RepositioningLowWaitingTimes(
         }
 
         if (whichTAZToRepositionTo.nonEmpty) {
-          log.debug(s"whichTAZToRepositionTo.size:${whichTAZToRepositionTo.size}")
+          logger.debug(s"whichTAZToRepositionTo.size:${whichTAZToRepositionTo.size}")
         }
 
         val result = if (firstRepositioningOfDay) {

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
@@ -5,23 +5,12 @@ import beam.router.BeamRouter.Location
 import beam.router.RoutingModel.BeamTime
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
-import org.slf4j.{Logger, LoggerFactory}
 
 trait RideHailResourceAllocationManager {
-
-  lazy val log: Logger = LoggerFactory.getLogger(getClass)
 
   // TODO RW make two traits, one for rideHail manager and one for buffered RideHail Manager?
 
   val isBufferedRideHailAllocationMode: Boolean
-
-  // def respondToCustomerInquiry()
-
-  // def allocateSingleCustomer()
-  // NON batch: None means: go to default behaviour
-  // batch none means: allocate dummy vehicle (person should send confirmation to scheduler, don't move any vehicle).
-
-  // def allocateBatchCustomers()
 
   // TODO: add distinguish param inquiry vs. reservation
   def proposeVehicleAllocation(

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/StanfordRideHailAllocationManagerV1.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/StanfordRideHailAllocationManagerV1.scala
@@ -5,10 +5,8 @@ import beam.router.BeamRouter.Location
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
 
-import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks._
-import StanfordRideHailAllocationManagerV1.LINK_ID
 /*
 TODO: check all network api, if they can use them properly
 
@@ -106,30 +104,5 @@ class StanfordRideHailAllocationManagerV1(
   // TODO: allow specifying route not only dest coord
   // need capacity and number of vehicles on road to implement it
 
-  /*
-  API available to implement allocation manager
-   */
-  def apiExamples(
-    vehicleAllocationRequest: VehicleAllocationRequest
-  ): TrieMap[Id[Vehicle], RideHailManager.RideHailAgentLocation] = {
-
-    // RHM
-    val rideHailAgentLocation = rideHailManager
-      .getClosestIdleRideHailAgent(
-        vehicleAllocationRequest.pickUpLocation,
-        rideHailManager.radiusInMeters
-      )
-      .get
-    rideHailManager.getVehicleFuelLevel(rideHailAgentLocation.vehicleId)
-    rideHailManager.getClosestIdleVehiclesWithinRadius(
-      vehicleAllocationRequest.pickUpLocation,
-      rideHailManager.radiusInMeters
-    )
-    rideHailManager.getIdleVehicles
-  }
 }
 
-object StanfordRideHailAllocationManagerV1 {
-  // TODO: Should be described. Where this number come from?
-  val LINK_ID = 5
-}

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/StanfordRideHailAllocationManagerV1.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/StanfordRideHailAllocationManagerV1.scala
@@ -23,7 +23,7 @@ class StanfordRideHailAllocationManagerV1(
   val rideHailManager: RideHailManager,
   val rideHailNetworkApi: RideHailNetworkAPI
 ) extends RideHailResourceAllocationManager {
-  val isBufferedRideHailAllocationMode = false
+  override val isBufferedRideHailAllocationMode = false
 
   /*
   This method is used to provide an initial vehicle allocation proposal (vehicleAllocationRequest.isInquiry==true).
@@ -58,7 +58,7 @@ class StanfordRideHailAllocationManagerV1(
     This method is called periodically, e.g. every 60 seconds.
    */
 
-  def allocateVehicles(
+  override def allocateVehicles(
     allocationsDuringReservation: Vector[(VehicleAllocationRequest, Option[VehicleAllocation])]
   ): IndexedSeq[(VehicleAllocationRequest, Option[VehicleAllocation])] = {
     val result = ArrayBuffer[(VehicleAllocationRequest, Option[VehicleAllocation])]()

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -12,7 +12,7 @@ import beam.agentsim.agents.modalbehaviors.DrivesVehicle.{
   NotifyLegStartTrigger
 }
 import beam.agentsim.agents.modalbehaviors.ModeChoiceCalculator
-import beam.agentsim.agents.ridehail.RideHailManager.{RideHailRequest, RideHailResponse}
+import beam.agentsim.agents.ridehail.{RideHailRequest, RideHailResponse}
 import beam.agentsim.agents.vehicles.BeamVehicleType.Car
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.{
@@ -79,7 +79,7 @@ class PersonAgentSpec
     with MockitoSugar
     with ImplicitSender {
 
-  private implicit val timeout = Timeout(60, TimeUnit.SECONDS)
+  private implicit val timeout: Timeout = Timeout(60, TimeUnit.SECONDS)
   val config = BeamConfig(system.settings.config)
 
   val dummyAgentId = Id.createPersonId("dummyAgent")

--- a/src/test/scala/beam/agentsim/agents/ridehail/RideHailManagerTest.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/RideHailManagerTest.scala
@@ -1,0 +1,29 @@
+package beam.agentsim.agents.ridehail
+
+class RideHailManagerTest {
+
+  // TODO: code extracted from StanfordRideHailAllocationManagerV1. Should create a test for it
+
+  //  val rideHailManager: RideHailManager = ???
+  //
+  //  def apiExamples(
+  //    vehicleAllocationRequest: VehicleAllocationRequest
+  //  ): TrieMap[Id[Vehicle], RideHailManager.RideHailAgentLocation] = {
+  //
+  //
+  //    // RHM
+  //    val rideHailAgentLocation = rideHailManager
+  //      .getClosestIdleRideHailAgent(
+  //        vehicleAllocationRequest.pickUpLocation,
+  //        rideHailManager.radiusInMeters
+  //      )
+  //      .get
+  //    rideHailManager.getVehicleFuelLevel(rideHailAgentLocation.vehicleId)
+  //    rideHailManager.getClosestIdleVehiclesWithinRadius(
+  //      vehicleAllocationRequest.pickUpLocation,
+  //      rideHailManager.radiusInMeters
+  //    )
+  //    rideHailManager.getIdleVehicles
+  //  }
+
+}

--- a/src/test/scala/beam/agentsim/agents/ridehail/RideHailNetworkAPITest.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/RideHailNetworkAPITest.scala
@@ -1,0 +1,18 @@
+package beam.agentsim.agents.ridehail
+
+class RideHailNetworkAPITest  {
+
+  // TODO: code extracted from StanfordRideHailAllocationManagerV1. Should create a test for it
+  // network operations
+  //  val linkId = 5
+  //  rideHailNetworkApi.getClosestLink(vehicleAllocationRequest.pickUpLocation)
+  //  val links = rideHailNetworkApi.getLinks
+  //  rideHailNetworkApi.getTravelTimeEstimate(vehicleAllocationRequest.departAt.atTime, linkId)
+  //  rideHailNetworkApi.getFreeFlowTravelTime(linkId)
+  //  val fromLinkIds = rideHailNetworkApi.getFromLinkIds(linkId)
+  //  val toLinkIds = rideHailNetworkApi.getToLinkIds(linkId)
+  //  val coord = rideHailNetworkApi.getLinkCoord(linkId)
+  //  val fromCoord = rideHailNetworkApi.getFromNodeCoordinate(linkId)
+  //  val toCoord = rideHailNetworkApi.getToNodeCoordinate(linkId)
+
+}


### PR DESCRIPTION
# Changes

- Added `override` when it fits

- At `DefaultRideHailResourceAllocationManager`, replaced comment "make sure this should not be called"
  with Exception

- Extracted RideHailRequest, RideHailResponse to its own file

- Changed the method `StanfordRideHailAllocationManagerV1.apiExamples`
The code below looked like unused and it was removed:
```Scala
    // network operations
    rideHailNetworkApi.getClosestLink(vehicleAllocationRequest.pickUpLocation)
    val links = rideHailNetworkApi.getLinks
    rideHailNetworkApi.getTravelTimeEstimate(vehicleAllocationRequest.departAt.atTime, LINK_ID)
    rideHailNetworkApi.getFreeFlowTravelTime(LINK_ID)
    val fromLinkIds = rideHailNetworkApi.getFromLinkIds(LINK_ID)
    val toLinkIds = rideHailNetworkApi.getToLinkIds(LINK_ID)
    val coord = rideHailNetworkApi.getLinkCoord(LINK_ID)
    val fromCoord = rideHailNetworkApi.getFromNodeCoordinate(LINK_ID)
    val toCoord = rideHailNetworkApi.getToNodeCoordinate(LINK_ID)
```

- Fixed typos: `numVechilesToReposition`, `procesbsing`, `unknonwn`

- Removed log from `RideHailResourceAllocationManager`: _Interface Segregation Principle_

- Replaced negative test condition with Positive test condition

- Removed dead code and small formmating and removed some warnings

# Possible bug identified
Is the following snippet of code an attempt to create an unique value?
```Scala
  lazy val requestId: Int =
    this.copy(requestType = RideHailInquiry).hashCode()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/364)
<!-- Reviewable:end -->
