### PR TITLE
Project: Explicitly set line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,31 @@
+# fallback on built-in heuristics
+# this must be first so later entries will override it
+* text=auto
+
+# check out text files with lf, not crlf, on Windows.  (especially
+# important for Scala source files, since """ preserves line endings)
+text eol=lf
+
+# These files are text and should be normalized (convert crlf => lf)
+*.c       eol=lf
+*.check   eol=lf
+*.css     eol=lf
+*.flags   eol=lf
+*.html    eol=lf
+*.java    eol=lf
+*.js      eol=lf
+*.policy  eol=lf
+*.sbt     eol=lf
+*.scala   eol=lf
+*.sh      eol=lf
+*.txt     eol=lf
+*.xml     eol=lf
+
+# Windows-specific files get windows endings
+*.bat     eol=crlf
+*.cmd     eol=crlf
+*-windows.tmpl eol=crlf
+
 *.osm filter=lfs diff=lfs merge=lfs -text
 *.pbf filter=lfs diff=lfs merge=lfs -text
 *.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Applied more rules to `.gitattributes` to be able to work without headache in mutli-OS environment.
Git parameters should be next:
- In Windows: `git config --local core.autocrlf true`
- Linux/OSX: `git config --local core.autocrlf input`

More info:
- [Dealing with line endings
](https://help.github.com/articles/dealing-with-line-endings/#platform-windows)
- [Git Replace LF with CLRF](https://stackoverflow.com/a/20653073/5794617)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/451)
<!-- Reviewable:end -->
