### PR TITLE
RideHailManager: Use getClosestIdleRideHailAgent

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
@@ -5,16 +5,13 @@ import beam.agentsim.agents.rideHail.allocation.{
   EVFleetAllocationManager,
   ImmediateDispatchWithOverwrite
 }
-import beam.agentsim.agents.ridehail.{BufferedRideHailRequests, RideHailManager, RideHailRequest}
 import beam.agentsim.agents.ridehail.RideHailManager.{
   BufferedRideHailRequestsTimeout,
-  RideHailAgentLocation,
-  RoutingResponses
+  RideHailAgentLocation
 }
-import beam.agentsim.events.SpaceTime
+import beam.agentsim.agents.ridehail.{BufferedRideHailRequests, RideHailManager, RideHailRequest}
 import beam.agentsim.scheduler.BeamAgentScheduler.ScheduleTrigger
 import beam.router.BeamRouter.{Location, RoutingRequest, RoutingResponse}
-import beam.router.RoutingModel.BeamTime
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
@@ -31,11 +28,10 @@ abstract class RideHailResourceAllocationManager(private val rideHailManager: Ri
   ): VehicleAllocationResponse = {
     // closest request
     rideHailManager
-      .getClosestIdleVehiclesWithinRadius(
+      .getClosestIdleRideHailAgent(
         vehicleAllocationRequest.request.pickUpLocation,
         rideHailManager.radiusInMeters
-      )
-      .headOption match {
+      ) match {
       case Some(agentLocation) =>
         VehicleAllocation(agentLocation, None)
       case None =>


### PR DESCRIPTION
 Use `getClosestIdleRideHailAgent` instead of `getClosestIdleVehiclesWithinRadius` because we need only head:

![image](https://user-images.githubusercontent.com/5107562/44868589-795d0f00-acb5-11e8-8496-d6585c562cf5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/472)
<!-- Reviewable:end -->
