### PR TITLE
ma/#482-1-sigopt-continue-experiment-4ci Has done a couple of refacto…

### DIFF
--- a/src/main/scala/beam/calibration/BeamSigoptTuner.scala
+++ b/src/main/scala/beam/calibration/BeamSigoptTuner.scala
@@ -2,6 +2,7 @@ package beam.calibration
 
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+
 import Bounded._
 import beam.utils.OptionalUtils.JavaOptionals._
 import beam.experiment._
@@ -10,10 +11,11 @@ import com.sigopt.Sigopt
 import com.sigopt.exception.SigoptException
 import com.sigopt.model._
 import com.typesafe.config.{Config, ConfigFactory}
+
 import scala.collection.JavaConverters
 import scala.util.Try
-
 import beam.calibration.BeamSigoptTuner._
+import com.typesafe.scalalogging.LazyLogging
 
 case class SigoptExperimentData(
   experimentDef: ExperimentDef,
@@ -21,7 +23,7 @@ case class SigoptExperimentData(
   benchmarkFileLoc: String,
   experimentId: String,
   development: Boolean = false
-) {
+) extends LazyLogging{
 
   lazy val projectRoot: Path = {
     if (System.getenv("BEAM_ROOT") != null) {
@@ -42,7 +44,18 @@ case class SigoptExperimentData(
   val isMaster: Boolean = experimentId == "None"
 
   val experiment: Experiment =
-    fetchExperiment(experimentId).getOrElse(createExperiment(experimentDef))
+    fetchExperiment(experimentId) match {
+      case Some(e) => {
+        logger.info(s"Retrieved the existing experiment with experiement id $experimentId")
+        e
+      }
+      case None => {
+        val e: Experiment = createExperiment(experimentDef)
+        logger.info("New Experiment created with experimentId [" + e.getId + "]")
+        System.exit(0)
+        e
+      }
+    }
 
 }
 

--- a/src/main/scala/beam/calibration/RunCalibration.scala
+++ b/src/main/scala/beam/calibration/RunCalibration.scala
@@ -78,7 +78,7 @@ object RunCalibration extends App with BeamHelper {
           (NUM_ITERATIONS_TAG, numIters)
         case Array("--experiment_id", experimentId: String) =>
           val trimmedExpId = experimentId.trim
-          if (trimmedExpId == "None") { (EXPERIMENT_ID_TAG, trimmedExpId) } else {
+          if (trimmedExpId != "None") { (EXPERIMENT_ID_TAG, trimmedExpId) } else {
             (EXPERIMENT_ID_TAG, NEW_EXPERIMENT_FLAG)
           }
         case arg @ _ =>


### PR DESCRIPTION
…rings in order to accommodate the case to exit in case of new experiement creation after printing its id and correctly reading the existing experiment id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/490)
<!-- Reviewable:end -->
