### PR TITLE
Project: Use getClosestIdleRideHailAgent instead of getClosestIdleVehiclesWithinRadius

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
@@ -253,7 +253,12 @@ class RideHailModifyPassengerScheduleManager(
         log.debug("vehicleIdModify: {} -> {}", x._1, x._2)
       }
       resourcesNotCheckedIn_onlyForDebugging.foreach { x =>
-        log.debug("resource not checked in: {}-> getWithVehicleIds({}): {}",  x.toString, getWithVehicleIds(x).size, getWithVehicleIds(x))
+        log.debug(
+          "resource not checked in: {}-> getWithVehicleIds({}): {}",
+          x.toString,
+          getWithVehicleIds(x).size,
+          getWithVehicleIds(x)
+        )
       }
       interruptIdToModifyPassengerScheduleStatus.foreach { x =>
         log.debug("interruptId: {} -> {}", x._1, x._2)
@@ -263,7 +268,11 @@ class RideHailModifyPassengerScheduleManager(
   }
 
   def startWaiveOfRepositioningRequests(tick: Double, triggerId: Long): Unit = {
-    log.debug("RepositioningTimeout({}) - START repositioning waive - triggerId({})", tick, triggerId)
+    log.debug(
+      "RepositioningTimeout({}) - START repositioning waive - triggerId({})",
+      tick,
+      triggerId
+    )
     printState()
     assert(
       (vehicleIdToModifyPassengerScheduleStatus.toVector.unzip._2
@@ -281,8 +290,10 @@ class RideHailModifyPassengerScheduleManager(
   }
 
   def sendoutAckMessageToSchedulerForRideHailAllocationmanagerTimeout(): Unit = {
-    log.debug("sending ACK to scheduler for next repositionTimeout ({})",
-      nextCompleteNoticeRideHailAllocationTimeout.id)
+    log.debug(
+      "sending ACK to scheduler for next repositionTimeout ({})",
+      nextCompleteNoticeRideHailAllocationTimeout.id
+    )
 
     val rideHailAllocationManagerTimeout = nextCompleteNoticeRideHailAllocationTimeout.newTriggers
       .filter(x => x.trigger.isInstanceOf[RideHailAllocationManagerTimeout])

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
@@ -247,28 +247,23 @@ class RideHailModifyPassengerScheduleManager(
   }
 
   def printState(): Unit = {
-    log.debug("printState START")
-    vehicleIdToModifyPassengerScheduleStatus.foreach(
-      x => log.debug("vehicleIdModify:" + x._1 + " -> " + x._2)
-    )
-    resourcesNotCheckedIn_onlyForDebugging.foreach(
-      x =>
-        log.debug(
-          "resource not checked in:" + x.toString + "-> getWithVehicleIds(" + getWithVehicleIds(x).size + "):" + getWithVehicleIds(
-            x
-          )
-      )
-    )
-    interruptIdToModifyPassengerScheduleStatus.foreach(
-      x => log.debug("interruptId:" + x._1 + " -> " + x._2)
-    )
-    log.debug("printState END")
+    if (log.isDebugEnabled) {
+      log.debug("printState START")
+      vehicleIdToModifyPassengerScheduleStatus.foreach { x =>
+        log.debug("vehicleIdModify: {} -> {}", x._1, x._2)
+      }
+      resourcesNotCheckedIn_onlyForDebugging.foreach { x =>
+        log.debug("resource not checked in: {}-> getWithVehicleIds({}): {}",  x.toString, getWithVehicleIds(x).size, getWithVehicleIds(x))
+      }
+      interruptIdToModifyPassengerScheduleStatus.foreach { x =>
+        log.debug("interruptId: {} -> {}", x._1, x._2)
+      }
+      log.debug("printState END")
+    }
   }
 
   def startWaiveOfRepositioningRequests(tick: Double, triggerId: Long): Unit = {
-    log.debug(
-      "RepositioningTimeout(" + tick + ") - START repositioning waive - triggerId(" + triggerId + ")"
-    )
+    log.debug("RepositioningTimeout({}) - START repositioning waive - triggerId({})", tick, triggerId)
     printState()
     assert(
       (vehicleIdToModifyPassengerScheduleStatus.toVector.unzip._2
@@ -286,9 +281,8 @@ class RideHailModifyPassengerScheduleManager(
   }
 
   def sendoutAckMessageToSchedulerForRideHailAllocationmanagerTimeout(): Unit = {
-    log.debug(
-      "sending ACK to scheduler for next repositionTimeout (" + nextCompleteNoticeRideHailAllocationTimeout.id + ")"
-    )
+    log.debug("sending ACK to scheduler for next repositionTimeout ({})",
+      nextCompleteNoticeRideHailAllocationTimeout.id)
 
     val rideHailAllocationManagerTimeout = nextCompleteNoticeRideHailAllocationTimeout.newTriggers
       .filter(x => x.trigger.isInstanceOf[RideHailAllocationManagerTimeout])

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/EVFleetAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/EVFleetAllocationManager.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.agents.rideHail.allocation
 
+import beam.agentsim.agents.ridehail.RideHailManager
 import beam.agentsim.agents.ridehail.allocation._
-import beam.agentsim.agents.ridehail.{ReserveRide, RideHailManager}
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
 
@@ -34,11 +34,10 @@ class EVFleetAllocationManager(val rideHailManager: RideHailManager)
       case None =>
         // go with closest
         rideHailManager
-          .getClosestIdleVehiclesWithinRadius(
+          .getClosestIdleRideHailAgent(
             vehicleAllocationRequest.request.pickUpLocation,
             rideHailManager.radiusInMeters
           )
-          .headOption
       case _ =>
         agentLocationOpt
     }

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/ImmediateDispatchWithOverwrite.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/ImmediateDispatchWithOverwrite.scala
@@ -26,11 +26,10 @@ class ImmediateDispatchWithOverwrite(val rideHailManager: RideHailManager)
 
     // just go with closest request
     rideHailManager
-      .getClosestIdleVehiclesWithinRadius(
+      .getClosestIdleRideHailAgent(
         vehicleAllocationRequest.request.pickUpLocation,
         rideHailManager.radiusInMeters
-      )
-      .headOption match {
+      ) match {
       case Some(agentLocation) =>
         VehicleAllocation(agentLocation, None)
       case None =>

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
@@ -1,8 +1,14 @@
 package beam.agentsim.agents.ridehail.allocation
 
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle.StopDrivingIfNoPassengerOnBoardReply
-import beam.agentsim.agents.rideHail.allocation.{EVFleetAllocationManager, ImmediateDispatchWithOverwrite}
-import beam.agentsim.agents.ridehail.RideHailManager.{BufferedRideHailRequestsTimeout, RideHailAgentLocation}
+import beam.agentsim.agents.rideHail.allocation.{
+  EVFleetAllocationManager,
+  ImmediateDispatchWithOverwrite
+}
+import beam.agentsim.agents.ridehail.RideHailManager.{
+  BufferedRideHailRequestsTimeout,
+  RideHailAgentLocation
+}
 import beam.agentsim.agents.ridehail.{BufferedRideHailRequests, RideHailManager, RideHailRequest}
 import beam.agentsim.scheduler.BeamAgentScheduler.ScheduleTrigger
 import beam.router.BeamRouter.{Location, RoutingRequest, RoutingResponse}

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
@@ -1,20 +1,11 @@
 package beam.agentsim.agents.ridehail.allocation
 
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle.StopDrivingIfNoPassengerOnBoardReply
-import beam.agentsim.agents.rideHail.allocation.{
-  EVFleetAllocationManager,
-  ImmediateDispatchWithOverwrite
-}
+import beam.agentsim.agents.rideHail.allocation.{EVFleetAllocationManager, ImmediateDispatchWithOverwrite}
+import beam.agentsim.agents.ridehail.RideHailManager.{BufferedRideHailRequestsTimeout, RideHailAgentLocation}
 import beam.agentsim.agents.ridehail.{BufferedRideHailRequests, RideHailManager, RideHailRequest}
-import beam.agentsim.agents.ridehail.RideHailManager.{
-  BufferedRideHailRequestsTimeout,
-  RideHailAgentLocation,
-  RoutingResponses
-}
-import beam.agentsim.events.SpaceTime
 import beam.agentsim.scheduler.BeamAgentScheduler.ScheduleTrigger
 import beam.router.BeamRouter.{Location, RoutingRequest, RoutingResponse}
-import beam.router.RoutingModel.BeamTime
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
@@ -31,11 +22,10 @@ abstract class RideHailResourceAllocationManager(private val rideHailManager: Ri
   ): VehicleAllocationResponse = {
     // closest request
     rideHailManager
-      .getClosestIdleVehiclesWithinRadius(
+      .getClosestIdleRideHailAgent(
         vehicleAllocationRequest.request.pickUpLocation,
         rideHailManager.radiusInMeters
-      )
-      .headOption match {
+      ) match {
       case Some(agentLocation) =>
         VehicleAllocation(agentLocation, None)
       case None =>


### PR DESCRIPTION
 Use `getClosestIdleRideHailAgent` instead of `getClosestIdleVehiclesWithinRadius` because **only head element** is consumed
![image](https://user-images.githubusercontent.com/5107562/44995284-97d04c80-afcc-11e8-9274-edba2e127415.png)

Use lazy logging instead of strict one:
![image](https://user-images.githubusercontent.com/5107562/44995782-e848a980-afce-11e8-8dc1-56a0755ca72c.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/497)
<!-- Reviewable:end -->
