### PR TITLE
R5RoutingWorker: Use `onComplete` to not to throw `NoSuchElementException`

### DIFF
--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -70,7 +70,10 @@ class R5RoutingWorker(
           calcRoute(request).copy(requestId = Some(request.requestId))
         }
       }
-      eventualResponse.failed.foreach(log.error(_, ""))
+      eventualResponse.onComplete {
+        case scala.util.Failure(ex) =>
+          log.error("calcRoute failed", ex)
+      }
       eventualResponse pipeTo sender
 
     case UpdateTravelTime(travelTime) =>


### PR DESCRIPTION
[NoSuchElementException](https://docs.oracle.com/javase/7/docs/api/java/util/NoSuchElementException.html) are thrown in https://github.com/LBNL-UCB-STI/beam/blob/master/src/main/scala/beam/router/r5/R5RoutingWorker.scala#L73

![image](https://user-images.githubusercontent.com/5107562/45238062-b440f180-b30a-11e8-8878-8ad32cdd1604.png)

![image](https://user-images.githubusercontent.com/5107562/45238078-c589fe00-b30a-11e8-8e54-326e8e6253da.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/535)
<!-- Reviewable:end -->
