### PR TITLE
Bump to 2.5.16 to avoid RNG security issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ targetCompatibility = 1.8
 
 compileScala.options.encoding = 'UTF-8'
 def scalaBinaryVersion = "2.12"
-def akkaBinaryVersion = "2.5.15"
+def akkaBinaryVersion = "2.5.16"
 def circeBinaryVersion="0.7.1"
 def slf4jVersion = "1.7.25"
 def kamonVersion = "0.6.7"


### PR DESCRIPTION
This shouldn't affect us, but still better to make sure to not be on a known security risk version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/536)
<!-- Reviewable:end -->
