### PR TITLE
remove non rideHail vehicle ids from rideHailIndividualWaiting file

### DIFF
--- a/src/main/java/beam/analysis/plots/RideHailWaitingStats.java
+++ b/src/main/java/beam/analysis/plots/RideHailWaitingStats.java
@@ -171,7 +171,9 @@ public class RideHailWaitingStats implements IGraphStats {
             Id<Person> personId = personEntersVehicleEvent.getPersonId();
             String _personId = personId.toString();
 
-            if (rideHailWaiting.containsKey(personId.toString())) {
+            // This rideHailVehicle check is put here again to remove the non rideHail vehicleId which were coming due the
+            // another occurrence of modeChoice event because of replanning event.
+            if (rideHailWaiting.containsKey(personId.toString()) && eventAttributes.get("vehicle").contains("rideHailVehicle")) {
 
                 ModeChoiceEvent modeChoiceEvent = (ModeChoiceEvent) rideHailWaiting.get(_personId);
                 double difference = personEntersVehicleEvent.getTime() - modeChoiceEvent.getTime();


### PR DESCRIPTION
non rideHail vehicle ids were coming due do introducing of another modechoice event because of replanning event

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/578)
<!-- Reviewable:end -->
