### PR TITLE
RideHailManager: Replace TrieMap by HashMap

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -45,7 +45,7 @@ import org.matsim.core.utils.geometry.CoordUtils
 import org.matsim.vehicles.Vehicle
 
 import scala.collection.JavaConverters._
-import scala.collection.{concurrent, mutable}
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{Await, Future}
@@ -273,15 +273,11 @@ class RideHailManager(
       boundingBox.getMaxY
     )
   }
-  private val availableRideHailVehicles =
-    concurrent.TrieMap[Id[Vehicle], RideHailAgentLocation]()
-  private val outOfServiceRideHailVehicles =
-    concurrent.TrieMap[Id[Vehicle], RideHailAgentLocation]()
-  private val inServiceRideHailVehicles =
-    concurrent.TrieMap[Id[Vehicle], RideHailAgentLocation]()
-  private val pendingModifyPassengerScheduleAcks =
-    collection.concurrent.TrieMap[String, RideHailResponse]()
-  private val parkingInquiryCache = collection.concurrent.TrieMap[Int, RideHailAgentLocation]()
+  private val availableRideHailVehicles = mutable.HashMap[Id[Vehicle], RideHailAgentLocation]()
+  private val outOfServiceRideHailVehicles = mutable.HashMap[Id[Vehicle], RideHailAgentLocation]()
+  private val inServiceRideHailVehicles = mutable.HashMap[Id[Vehicle], RideHailAgentLocation]()
+  private val pendingModifyPassengerScheduleAcks = mutable.HashMap[String, RideHailResponse]()
+  private val parkingInquiryCache = collection.mutable.HashMap[Int, RideHailAgentLocation]()
   private val pendingAgentsSentToPark = collection.mutable.Map[Id[Vehicle], ParkingStall]()
   var nextCompleteNoticeRideHailAllocationTimeout: CompletionNotice = _
   private var lockedVehicles = Set[Id[Vehicle]]()
@@ -1111,7 +1107,7 @@ class RideHailManager(
     DebugLib.emptyFunctionForSettingBreakPoint()
   }
 
-  def getIdleVehicles: collection.concurrent.TrieMap[Id[Vehicle], RideHailAgentLocation] = {
+  def getIdleVehicles: mutable.HashMap[Id[Vehicle], RideHailAgentLocation] = {
     availableRideHailVehicles
   }
 

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RepositioningLowWaitingTimes.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RepositioningLowWaitingTimes.scala
@@ -13,7 +13,6 @@ import beam.utils._
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.vehicles.Vehicle
 
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.Await
 
 class RepositioningLowWaitingTimes(
@@ -275,7 +274,7 @@ class RepositioningLowWaitingTimes(
   }
 
   def filterOutAlreadyRepositioningVehiclesIfEnoughAlternativeIdleVehiclesAvailable(
-    idleVehicles: TrieMap[Id[Vehicle], RideHailManager.RideHailAgentLocation],
+    idleVehicles: collection.mutable.Map[Id[Vehicle], RideHailManager.RideHailAgentLocation],
     maxNumberOfVehiclesToReposition: Int
   ): Vector[RideHailAgentLocation] = {
     val (idle, repositioning) = idleVehicles.values.toVector.partition(


### PR DESCRIPTION
`TrieMap` is used mostly for `concurrent` read/write. But in our case we have a guarantee that two threads reads/writes map simultaneously

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/823)
<!-- Reviewable:end -->
