### PR TITLE
Issue 849: RunCalibration execution exception with NullpointerException after refactoring

### DIFF
--- a/src/main/scala/beam/calibration/CalibrationArguments.scala
+++ b/src/main/scala/beam/calibration/CalibrationArguments.scala
@@ -1,0 +1,13 @@
+package beam.calibration
+
+object CalibrationArguments {
+    val BENCHMARK_EXPERIMENTS_TAG: String = "benchmark"
+    val NUM_ITERATIONS_TAG: String = "num_iters"
+    val EXPERIMENT_ID_TAG: String = "experiment_id"
+    val NEW_EXPERIMENT_FLAG: String = "00000"
+    val RUN_TYPE: String = "run_type"
+    val SIGOPT_API_TOKEN_TAG: String = "sigopt_api_token"
+
+    val RUN_TYPE_LOCAL: String = "local"
+    val RUN_TYPE_REMOTE: String = "remote"
+}

--- a/src/main/scala/beam/calibration/RunCalibration.scala
+++ b/src/main/scala/beam/calibration/RunCalibration.scala
@@ -1,10 +1,8 @@
 package beam.calibration
 
-import java.nio.file.{Files, Paths}
-
 import beam.calibration.utils.SigOptApiToken
-import beam.experiment.{ExperimentApp, ExperimentDef}
-import beam.sim.BeamHelper
+import beam.calibration.CalibrationArguments._
+import beam.experiment.ExperimentApp
 import com.sigopt.Sigopt
 import com.sigopt.exception.APIConnectionError
 import com.typesafe.scalalogging.LazyLogging
@@ -24,6 +22,7 @@ import org.apache.commons.lang.SystemUtils
   */
 object RunCalibration extends ExperimentApp with LazyLogging {
 
+
   // requirement:
   /*
     --runType local|remote
@@ -34,18 +33,6 @@ object RunCalibration extends ExperimentApp with LazyLogging {
   // - we need to pass existing experiment id to local and remote runs we start - [DONE]
   // - the for sigopt should be able to run locally (avoid each dev to have sigopt dev api token) - [LATER]
   // - provide a objective function with is a combination of modes and counts
-
-  // Private Constants //
-  private val BENCHMARK_EXPERIMENTS_TAG = "benchmark"
-  private val NUM_ITERATIONS_TAG = "num_iters"
-  private val EXPERIMENT_ID_TAG = "experiment_id"
-  private val NEW_EXPERIMENT_FLAG = "00000"
-  private val RUN_TYPE = "run_type"
-  private val SIGOPT_API_TOKEN_TAG = "sigopt_api_token"
-
-  private val RUN_TYPE_LOCAL = "local"
-  private val RUN_TYPE_REMOTE = "remote"
-
 
   // Store CLI inputs as private members
   private val experimentLoc: String = argsMap(EXPERIMENTS_TAG)

--- a/src/main/scala/beam/experiment/ExperimentApp.scala
+++ b/src/main/scala/beam/experiment/ExperimentApp.scala
@@ -9,7 +9,7 @@ import org.yaml.snakeyaml.constructor.Constructor
 /**
   * Prov
   */
-trait ExperimentApp extends App {
+class ExperimentApp extends App {
 
   val EXPERIMENTS_TAG = "experiments"
 


### PR DESCRIPTION
**Problem 1**: The trait `ExperimentApp` was not able to read `args` from `App`. Probably is related to stackable trait behaviour, but I did not have enough time to test and really understand the reason. After transforming it in a `class` the problem was solved. 

**Problem 2**: Due to polymorphism and Java/Scala behaviour `ExperimentApp` was executed first and than called the inherited method `parseArgs` from `RunCalibration`. However the constants were not initialized since the class `RunCalibration` is initialized only after `ExperimentApp` constructor finishes. Therefore the constant defined in the object constructor returned `null`; Extracting it to an external object solved this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/850)
<!-- Reviewable:end -->
