### PR TITLE
BeamVehicle.collectFuelConsumptionData is slow due to the usage of List type

### DIFF
--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
@@ -3,7 +3,7 @@ package beam.agentsim.agents.vehicles
 import akka.actor.ActorRef
 import beam.agentsim.Resource
 import beam.agentsim.agents.PersonAgent
-import beam.agentsim.agents.vehicles.BeamVehicle.{BeamVehicleState, FuelConsumptionData}
+import beam.agentsim.agents.vehicles.BeamVehicle.BeamVehicleState
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.VehicleProtocol._
 import beam.agentsim.infrastructure.ParkingStall
@@ -14,13 +14,11 @@ import beam.sim.BeamServices
 import beam.sim.common.GeoUtils
 import beam.sim.common.GeoUtils.{Straight, TurningDirection}
 import com.typesafe.scalalogging.StrictLogging
+import org.matsim.api.core.v01.Id
 import org.matsim.api.core.v01.network.{Link, Network}
-import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.households.Household
 import org.matsim.utils.objectattributes.ObjectAttributes
 import org.matsim.vehicles.Vehicle
-
-import scala.collection.JavaConverters._
 
 /**
   * A [[BeamVehicle]] is a state container __administered__ by a driver ([[PersonAgent]]
@@ -107,7 +105,7 @@ class BeamVehicle(
     val distanceInMeters = beamLeg.travelPath.distanceInM
     val network =
       if (beamServices.matsimServices != null) Some(beamServices.matsimServices.getScenario.getNetwork) else None
-    val fuelConsumption: Option[List[FuelConsumptionData]] = network map (
+    val fuelConsumption = network map (
       n => BeamVehicle.collectFuelConsumptionData(beamLeg, beamVehicleType, n)
     )
     fuelLevelInJoules match {
@@ -204,10 +202,11 @@ object BeamVehicle {
     beamLeg: BeamLeg,
     vehicleType: BeamVehicleType,
     network: Network
-  ): List[FuelConsumptionData] = {
+  ): IndexedSeq[FuelConsumptionData] = {
     if (beamLeg.mode.isTransit & !Modes.isOnStreetTransit(beamLeg.mode)) {
-      List()
+      Vector.empty
     } else {
+      val networkLinks = network.getLinks
       val linkIds = beamLeg.travelPath.linkIds
       val linkTravelTimes: IndexedSeq[Int] = beamLeg.travelPath.linkTravelTime
       // generate the link arrival times for each link ,by adding cumulative travel times of previous links
@@ -222,13 +221,13 @@ object BeamVehicle {
             })
         }
       }
-      val nextLinkIds = linkIds.toList.takeRight(linkIds.size - 1)
+      val nextLinkIds = linkIds.takeRight(linkIds.size - 1)
       linkIds.zipWithIndex.map { idAndIdx =>
         val id = idAndIdx._1
         val idx = idAndIdx._2
         val travelTime = linkTravelTimes(idx)
         val arrivalTime = linkArrivalTimes(idx)
-        val currentLink: Option[Link] = Option(network.getLinks.get(Id.createLinkId(id)))
+        val currentLink: Option[Link] = Option(networkLinks.get(Id.createLinkId(id)))
         val averageSpeed = try {
           if (travelTime > 0) currentLink.map(_.getLength).getOrElse(0.0) / travelTime else 0
         } catch {
@@ -236,7 +235,7 @@ object BeamVehicle {
         }
         // get the next link , and calculate the direction to be taken based on the angle between the two links
         val nextLink = if (idx < nextLinkIds.length) {
-          Some(network.getLinks.get(Id.createLinkId(nextLinkIds(idx))))
+          Some(networkLinks.get(Id.createLinkId(nextLinkIds(idx))))
         } else {
           currentLink
         }
@@ -262,8 +261,7 @@ object BeamVehicle {
           turnAtLinkEnd = turnAtLinkEnd,
           numberOfStops = numStops
         )
-      }.toList
+      }
     }
   }
-
 }

--- a/src/main/scala/beam/agentsim/agents/vehicles/EnergyEconomyAttributes.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/EnergyEconomyAttributes.scala
@@ -41,7 +41,7 @@ case object EnergyEconomyAttributes extends Enum[EnergyEconomyAttributes] {
       joulesPerMeter * distanceInMeters
     }
 
-    def estimateConsumptionInJoules(fuelConsumption: List[FuelConsumptionData]): Double = {
+    def estimateConsumptionInJoules(fuelConsumption: IndexedSeq[FuelConsumptionData]): Double = {
       joulesPerMeter * fuelConsumption.map(_.linkLength).sum
     }
 


### PR DESCRIPTION
- Removed `linkIds.toList` because it's redundant and makes `nextLinkIds.length` linear operation ([List documentation](https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/List.html))
- Extracted `networkLinks` as local value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1142)
<!-- Reviewable:end -->
