### PR TITLE
Test car sharing; add modes explicitly

### DIFF
--- a/src/main/scala/beam/router/Modes.scala
+++ b/src/main/scala/beam/router/Modes.scala
@@ -114,7 +114,7 @@ object Modes {
 
     val transitModes =
       Seq(BUS, FUNICULAR, GONDOLA, CABLE_CAR, FERRY, TRAM, TRANSIT, RAIL, SUBWAY)
-    val allBeamModes: Seq[BeamMode] = Seq(CAR, RIDE_HAIL, BIKE) ++ transitModes
+    val allBeamModes: Seq[BeamMode] = Seq(CAR, RIDE_HAIL, RIDE_HAIL_TRANSIT, BIKE, WALK, WALK_TRANSIT) ++ transitModes
 
     val massTransitModes: List[BeamMode] = List(FERRY, TRANSIT, RAIL, SUBWAY, TRAM)
 

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -6,7 +6,6 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailSurgePricingManager}
-import beam.agentsim.agents.vehicles.BeamVehicleType
 import beam.agentsim.events.handling.BeamEventsHandling
 import beam.analysis.plots.{GraphSurgePricing, RideHailRevenueAnalysis}
 import beam.replanning._
@@ -17,7 +16,7 @@ import beam.scoring.BeamScoringFunctionFactory
 import beam.sim.config.{BeamConfig, ConfigModule, MatSimBeamConfigBuilder}
 import beam.sim.metrics.Metrics._
 import beam.sim.modules.{BeamAgentModule, UtilsModule}
-import beam.sim.population.{PopulationAdjustment}
+import beam.sim.population.PopulationAdjustment
 import beam.utils._
 import beam.utils.reflection.ReflectionUtils
 import com.conveyal.r5.streets.StreetLayer
@@ -34,7 +33,6 @@ import org.matsim.core.config.Config
 import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup
 import org.matsim.core.controler._
 import org.matsim.core.controler.corelisteners.{ControlerDefaultCoreListenersModule, EventsHandling}
-import org.matsim.core.events.EventsManagerImpl
 import org.matsim.core.scenario.{MutableScenario, ScenarioByInstanceModule, ScenarioUtils}
 import org.matsim.core.trafficmonitoring.TravelTimeCalculator
 import org.matsim.households.Household
@@ -45,7 +43,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
-import scala.util.Try
 
 trait BeamHelper extends LazyLogging {
   private val argsParser = new scopt.OptionParser[Arguments]("beam") {
@@ -230,7 +227,7 @@ trait BeamHelper extends LazyLogging {
           bind(classOf[TollCalculator]).asEagerSingleton()
 
           // Override EventsManager
-          bind(classOf[EventsManager]).to(classOf[EventsManagerImpl]).asEagerSingleton()
+          bind(classOf[EventsManager]).to(classOf[LoggingParallelEventsManager]).asEagerSingleton()
 
         }
       }

--- a/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
+++ b/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
@@ -29,15 +29,10 @@ object AvailableModeUtils {
   }
 
   def availableModesForPerson(person: Person): Seq[BeamMode] = {
-    val availModes = person.getCustomAttributes
+    person.getCustomAttributes
       .get("beam-attributes")
       .asInstanceOf[AttributesOfIndividual]
-      .availableModes :+ WALK :+ WALK_TRANSIT :+ DRIVE_TRANSIT
-    if (availModes.contains(RIDE_HAIL)) {
-      availModes :+ RIDE_HAIL_TRANSIT
-    } else {
-      availModes
-    }
+      .availableModes
   }
 
   def isModeAvailableForPerson[T <: BeamMode](

--- a/src/test/java/beam/analysis/physsim/PhyssimCalcLinkStatsTest.java
+++ b/src/test/java/beam/analysis/physsim/PhyssimCalcLinkStatsTest.java
@@ -44,7 +44,7 @@ public class PhyssimCalcLinkStatsTest {
         EventsManager eventsManager = EventsUtils.createEventsManager();
         eventsManager.addHandler(travelTimeCalculator);
 
-        BeamConfig beamConfig = BeamConfig.apply(TestConfigUtils.testConfig("test/input/equil-square/equil-0.001k.conf").withValue("beam.physsim.quick_fix_minCarSpeedInMetersPerSecond", ConfigValueFactory.fromAnyRef(0.0)));
+        BeamConfig beamConfig = BeamConfig.apply(TestConfigUtils.testConfig("test/input/equil-square/equil-0.001k.conf").resolve().withValue("beam.physsim.quick_fix_minCarSpeedInMetersPerSecond", ConfigValueFactory.fromAnyRef(0.0)));
         physsimCalcLinkStats = new PhyssimCalcLinkStats(network, null,  beamConfig, defaultTravelTimeCalculator );
 
         //physsimCalcLinkStats = new PhyssimCalcLinkStats(network, null, null);

--- a/src/test/java/beam/analysis/plots/GraphTestUtil.java
+++ b/src/test/java/beam/analysis/plots/GraphTestUtil.java
@@ -27,7 +27,7 @@ class GraphTestUtil {
     private static final String BASE_PATH = Paths.get(".").toAbsolutePath().toString();
     private static final String TRANSIT_VEHICLE_FILE_PATH = BASE_PATH + "/test/input/beamville/transitVehicles.xml";
     private static final String EVENTS_FILE_PATH = BASE_PATH + "/test/input/beamville/test-data/beamville.events.xml";
-    private static BeamConfig beamconfig = BeamConfig.apply(TestConfigUtils.testConfig("test/input/beamville/beam.conf"));
+    private static BeamConfig beamconfig = BeamConfig.apply(TestConfigUtils.testConfig("test/input/beamville/beam.conf").resolve());
     private static BeamServices services = mock(BeamServices.class);
     private static GraphsStatsAgentSimEventsListener graphsFromAgentSimEvents;
     private static EventsManager events;

--- a/src/test/java/beam/analysis/plots/ModeChosenGraphTest.java
+++ b/src/test/java/beam/analysis/plots/ModeChosenGraphTest.java
@@ -43,7 +43,7 @@ public class ModeChosenGraphTest {
             stats = stat.getFirst();
             return super.compute(stat);
         }
-    }, BeamConfig.apply(TestConfigUtils.testConfig("test/input/beamville/beam.conf")) );
+    }, BeamConfig.apply(TestConfigUtils.testConfig("test/input/beamville/beam.conf").resolve()) );
 
     @Before
     public void setUpClass() {

--- a/src/test/scala/beam/agentsim/agents/OtherPersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/OtherPersonAgentSpec.scala
@@ -64,7 +64,7 @@ class OtherPersonAgentSpec
   akka.log-dead-letters = 10
   akka.actor.debug.fsm = true
   akka.loglevel = debug
-  """).withFallback(testConfig("test/input/beamville/beam.conf"))
+  """).withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -67,7 +67,7 @@ class PersonAgentSpec
         akka.loglevel = debug
         """
           )
-          .withFallback(testConfig("test/input/beamville/beam.conf"))
+          .withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -65,7 +65,7 @@ class PersonAndTransitDriverSpec
         akka.loglevel = debug
         """
           )
-          .withFallback(testConfig("test/input/beamville/beam.conf"))
+          .withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/PersonWithCarPlanSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithCarPlanSpec.scala
@@ -63,7 +63,7 @@ class PersonWithCarPlanSpec
         akka.test.timefactor = 2
         """
           )
-          .withFallback(testConfig("test/input/beamville/beam.conf"))
+          .withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
@@ -75,7 +75,7 @@ class PersonWithVehicleSharingSpec
         akka.test.timefactor = 2
         """
           )
-          .withFallback(testConfig("test/input/beamville/beam.conf"))
+          .withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
@@ -47,7 +47,7 @@ class RideHailAgentSpec
   akka.log-dead-letters = 10
   akka.actor.debug.fsm = true
   akka.loglevel = debug
-  """).withFallback(testConfig("test/input/beamville/beam.conf"))
+  """).withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/agentsim/agents/ridehail/RideHailSurgePricingManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/RideHailSurgePricingManagerSpec.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 class RideHailSurgePricingManagerSpec extends WordSpecLike with Matchers with MockitoSugar {
 
   val testConfigFileName = "test/input/beamville/beam.conf"
-  val config: Config = testConfig(testConfigFileName)
+  val config: Config = testConfig(testConfigFileName).resolve()
   val vehicles: TrieMap[Id[BeamVehicle], BeamVehicle] = TrieMap()
   val personRefs: TrieMap[Id[Person], ActorRef] = TrieMap()
   lazy val beamConfig: BeamConfig = BeamConfig(config)

--- a/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
@@ -30,7 +30,7 @@ class ZonalParkingManagerSpec
   akka.log-dead-letters = 10
   akka.actor.debug.fsm = true
   akka.loglevel = debug
-  """).withFallback(testConfig("test/input/beamville/beam.conf"))
+  """).withFallback(testConfig("test/input/beamville/beam.conf").resolve())
       )
     )
     with FunSpecLike

--- a/src/test/scala/beam/integration/CarSharingSpec.scala
+++ b/src/test/scala/beam/integration/CarSharingSpec.scala
@@ -1,0 +1,82 @@
+package beam.integration
+import beam.agentsim.events.ModeChoiceEvent
+import beam.router.r5.DefaultNetworkCoordinator
+import beam.sim.config.{BeamConfig, MatSimBeamConfigBuilder}
+import beam.sim.population.DefaultPopulationAdjustment
+import beam.sim.population.PopulationAdjustment.AVAILABLE_MODES
+import beam.sim.{BeamHelper, BeamServices}
+import beam.utils.FileUtils
+import beam.utils.TestConfigUtils.testConfig
+import com.typesafe.config.ConfigFactory
+import org.matsim.api.core.v01.events.Event
+import org.matsim.core.controler.AbstractModule
+import org.matsim.core.events.handler.BasicEventHandler
+import org.matsim.core.scenario.{MutableScenario, ScenarioUtils}
+import org.scalatest.{FlatSpec, Matchers}
+
+class CarSharingSpec extends FlatSpec with Matchers with BeamHelper {
+
+  "Running a car-sharing-only scenario with abundant cars" must "result in everybody driving" in {
+    val config = ConfigFactory
+      .parseString("""
+        |beam.outputs.events.fileOutputFormats = xml
+        |beam.physsim.skipPhysSim = true
+        |beam.agentsim.lastIteration = 0
+        |beam.agentsim.agents.vehicles.sharedFleets = [inexhaustible-reserving]
+      """.stripMargin)
+      .withFallback(testConfig("test/input/beamville/beam.conf"))
+      .resolve()
+    val configBuilder = new MatSimBeamConfigBuilder(config)
+    val matsimConfig = configBuilder.buildMatSamConf()
+    val beamConfig = BeamConfig(config)
+    FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+    val scenario = ScenarioUtils.loadScenario(matsimConfig).asInstanceOf[MutableScenario]
+    val networkCoordinator = DefaultNetworkCoordinator(beamConfig)
+    networkCoordinator.loadNetwork()
+    networkCoordinator.convertFrequenciesToTrips()
+    scenario.setNetwork(networkCoordinator.network)
+    var nonCarTrips = 0
+    var trips = 0
+    val injector = org.matsim.core.controler.Injector.createInjector(
+      scenario.getConfig,
+      new AbstractModule() {
+        override def install(): Unit = {
+          install(module(config, scenario, networkCoordinator))
+          addEventHandlerBinding().toInstance(new BasicEventHandler {
+            override def handleEvent(event: Event): Unit = {
+              event match {
+                case modeChoiceEvent: ModeChoiceEvent =>
+                  trips = trips + 1
+                  if (modeChoiceEvent.getAttributes.get("mode") != "car") {
+                    nonCarTrips = nonCarTrips + 1
+                  }
+                case _ =>
+              }
+            }
+          })
+        }
+      }
+    )
+    val services = injector.getInstance(classOf[BeamServices])
+
+    // Only driving allowed
+    val population = scenario.getPopulation
+    population.getPersons.keySet.forEach { personId =>
+      population.getPersonAttributes.putAttribute(personId.toString, AVAILABLE_MODES, "car")
+    }
+
+    // No private vehicles (but we have a car sharing operator)
+    val households = scenario.getHouseholds
+    households.getHouseholds.values.forEach { household =>
+      household.getVehicleIds.clear()
+    }
+    services.privateVehicles.clear()
+
+    DefaultPopulationAdjustment(services).update(scenario)
+    val controler = services.controler
+    controler.run()
+
+    assume(trips != 0, "Something's wildly broken, I am not seeing any trips.")
+    assert(nonCarTrips == 0, "Someone wasn't driving even though everybody wants to and cars abound.")
+  }
+}

--- a/src/test/scala/beam/integration/DriveTransitSpec.scala
+++ b/src/test/scala/beam/integration/DriveTransitSpec.scala
@@ -26,6 +26,7 @@ class DriveTransitSpec extends WordSpecLike with Matchers with BeamHelper {
   "DriveTransit trips" must {
     "run to completion" taggedAs (Periodic, ExcludeRegular) ignore { //TODO need vehicle input dta
       val config = testConfig("test/input/sf-light/sf-light-1k.conf")
+        .resolve()
         .withValue(
           TestConstants.KEY_AGENT_MODAL_BEHAVIORS_MODE_CHOICE_CLASS,
           ConfigValueFactory.fromAnyRef(TestConstants.MODE_CHOICE_MULTINOMIAL_LOGIT)

--- a/src/test/scala/beam/integration/IntegrationSpecCommon.scala
+++ b/src/test/scala/beam/integration/IntegrationSpecCommon.scala
@@ -11,6 +11,7 @@ trait IntegrationSpecCommon {
   val configFileName = "test/input/beamville/beam.conf"
 
   lazy val baseConfig: Config = testConfig(configFileName)
+    .resolve()
     .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml"))
     .withValue(LAST_ITER_CONF_PATH, ConfigValueFactory.fromAnyRef(totalIterations - 1))
     .resolve

--- a/src/test/scala/beam/integration/LCCMSpec.scala
+++ b/src/test/scala/beam/integration/LCCMSpec.scala
@@ -18,6 +18,7 @@ class LCCMSpec extends FlatSpec with BeamHelper with MockitoSugar {
 
   it should "be able to run for three iterations with LCCM without exceptions" in {
     val config = testConfig("test/input/beamville/beam.conf")
+      .resolve()
       .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml,csv"))
       .withValue(
         TestConstants.KEY_AGENT_MODAL_BEHAVIORS_MODE_CHOICE_CLASS,

--- a/src/test/scala/beam/integration/SingleModeSpec.scala
+++ b/src/test/scala/beam/integration/SingleModeSpec.scala
@@ -49,7 +49,7 @@ class SingleModeSpec
           .parseString("""
               akka.test.timefactor = 10
             """)
-          .withFallback(testConfig("test/input/sf-light/sf-light.conf"))
+          .withFallback(testConfig("test/input/sf-light/sf-light.conf").resolve())
       )
     )
     with WordSpecLike

--- a/src/test/scala/beam/integration/ThreeIterationsSpec.scala
+++ b/src/test/scala/beam/integration/ThreeIterationsSpec.scala
@@ -19,6 +19,7 @@ class ThreeIterationsSpec extends FlatSpec with BeamHelper with MockitoSugar {
 
   it should "be able to run for three iterations without exceptions" in {
     val config = testConfig("test/input/beamville/beam.conf")
+      .resolve()
       .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml,csv"))
       .resolve()
     val configBuilder = new MatSimBeamConfigBuilder(config)

--- a/src/test/scala/beam/integration/ridehail/RideHailBufferedRidesSpec.scala
+++ b/src/test/scala/beam/integration/ridehail/RideHailBufferedRidesSpec.scala
@@ -34,6 +34,7 @@ class RideHailBufferedRidesSpec extends FlatSpec with BeamHelper with MockitoSug
 
   it should "have same actstart as endstart events for persons when using ridehail replacement in DummyRideHailDispatchWithBufferingRequests" ignore {
     val config = testConfig("test/input/beamville/beam.conf")
+      .resolve()
       .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml,csv"))
       .withValue(
         "beam.agentsim.agents.rideHail.allocationManager.name",
@@ -63,6 +64,7 @@ class RideHailBufferedRidesSpec extends FlatSpec with BeamHelper with MockitoSug
 
   it should "have different actstart and endstart events for persons when NOT using ridehail replacement in DummyRideHailDispatchWithBufferingRequestsWithoutReplacement" ignore {
     val config = testConfig("test/input/beamville/beam.conf")
+      .resolve()
       .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml,csv"))
       .withValue(
         "beam.agentsim.agents.rideHail.allocationManager.name",

--- a/src/test/scala/beam/integration/ridehail/RideHailTestHelper.scala
+++ b/src/test/scala/beam/integration/ridehail/RideHailTestHelper.scala
@@ -10,6 +10,7 @@ object RideHailTestHelper {
 
   def buildConfig(allocationManagerName: String): Config = {
     val config = testConfig("test/input/beamville/beam.conf")
+      .resolve()
       .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml,csv"))
       .withValue(
         "beam.agentsim.agents.rideHail.allocationManager.name",

--- a/src/test/scala/beam/performance/RouterPerformanceSpec.scala
+++ b/src/test/scala/beam/performance/RouterPerformanceSpec.scala
@@ -90,7 +90,7 @@ class RouterPerformanceSpec
   override def beforeAll(configMap: ConfigMap): Unit = {
     val confPath =
       configMap.getWithDefault("config", "test/input/sf-light/sf-light.conf")
-    config = testConfig(confPath)
+    config = testConfig(confPath).resolve()
     val beamConfig = BeamConfig(config)
 
     val services: BeamServices = mock[BeamServices](withSettings().stubOnly())

--- a/src/test/scala/beam/router/R5MnetBuilderSpec.scala
+++ b/src/test/scala/beam/router/R5MnetBuilderSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.FlatSpec
 class R5MnetBuilderSpec extends FlatSpec {
 
   it should "do something" in {
-    val config = testConfig("test/input/beamville/beam.conf")
+    val config = testConfig("test/input/beamville/beam.conf").resolve()
     var transportNetwork =
       TransportNetwork.fromDirectory(new File("test/input/beamville/r5"))
     val cursor = transportNetwork.streetLayer.edgeStore.getCursor

--- a/src/test/scala/beam/router/TimeDependentRoutingSpec.scala
+++ b/src/test/scala/beam/router/TimeDependentRoutingSpec.scala
@@ -44,7 +44,7 @@ import scala.language.postfixOps
 
 class TimeDependentRoutingSpec
     extends TestKit(
-      ActorSystem("TimeDependentRoutingSpec", testConfig("test/input/beamville/beam.conf"))
+      ActorSystem("TimeDependentRoutingSpec", testConfig("test/input/beamville/beam.conf").resolve())
     )
     with WordSpecLike
     with Matchers

--- a/src/test/scala/beam/router/TollRoutingSpec.scala
+++ b/src/test/scala/beam/router/TollRoutingSpec.scala
@@ -40,7 +40,7 @@ import scala.language.postfixOps
 
 class TollRoutingSpec
     extends TestKit(
-      ActorSystem("TollRoutingSpec", testConfig("test/input/beamville/beam.conf"))
+      ActorSystem("TollRoutingSpec", testConfig("test/input/beamville/beam.conf").resolve())
     )
     with WordSpecLike
     with Matchers

--- a/src/test/scala/beam/router/WarmStartRoutingSpec.scala
+++ b/src/test/scala/beam/router/WarmStartRoutingSpec.scala
@@ -50,6 +50,7 @@ class WarmStartRoutingSpec
       ActorSystem(
         "WarmStartRoutingSpec",
         testConfig("test/input/beamville/beam.conf")
+          .resolve()
           .withValue("beam.warmStart.enabled", ConfigValueFactory.fromAnyRef(true))
           .withValue(
             "beam.warmStart.path",

--- a/src/test/scala/beam/router/osm/TollCalculatorSpec.scala
+++ b/src/test/scala/beam/router/osm/TollCalculatorSpec.scala
@@ -13,7 +13,7 @@ class TollCalculatorSpec extends WordSpecLike {
   "Using beamville as input" when {
     val beamvillePath: Path = Paths.get("test", "input", "beamville", "r5")
     val beamvilleTollCalc =
-      new TollCalculator(BeamConfig(testConfig("test/input/beamville/beam.conf")))
+      new TollCalculator(BeamConfig(testConfig("test/input/beamville/beam.conf").resolve()))
     "calculate toll for a single trunk road, it" should {
       "return value $1." in {
         assert(beamvilleTollCalc.calcTollByOsmIds(Vector(109)) == 1.0)

--- a/src/test/scala/beam/sflight/AbstractSfLightSpec.scala
+++ b/src/test/scala/beam/sflight/AbstractSfLightSpec.scala
@@ -52,7 +52,7 @@ class AbstractSfLightSpec
   var scenario: Scenario = _
 
   val confPath = "test/input/sf-light/sf-light.conf"
-  lazy val config = testConfig(confPath)
+  lazy val config = testConfig(confPath).resolve()
   lazy val beamConfig = BeamConfig(config)
   // Have to mock some things to get the router going
   lazy val services: BeamServices = mock[BeamServices](withSettings().stubOnly())

--- a/src/test/scala/beam/sflight/SfLightRunSpec.scala
+++ b/src/test/scala/beam/sflight/SfLightRunSpec.scala
@@ -10,7 +10,7 @@ import beam.sim.{BeamHelper, BeamServices}
 import beam.tags.{ExcludeRegular, Periodic}
 import beam.utils.FileUtils
 import beam.utils.TestConfigUtils.testConfig
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.matsim.api.core.v01.events.Event
 import org.matsim.core.controler.AbstractModule
 import org.matsim.core.events.handler.BasicEventHandler
@@ -41,9 +41,7 @@ class SfLightRunSpec extends WordSpecLike with Matchers with BeamHelper with Bef
           |beam.outputs.events.fileOutputFormats = xml
           |beam.agentsim.lastIteration = 0
         """.stripMargin)
-        .withFallback(testConfig("test/input/sf-light/sf-light-1k.conf").resolve())
-        .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml"))
-        .withValue("beam.agentsim.lastIteration", ConfigValueFactory.fromAnyRef(0))
+        .withFallback(testConfig("test/input/sf-light/sf-light-0.5k.conf"))
         .resolve()
       val configBuilder = new MatSimBeamConfigBuilder(config)
       val matsimConfig = configBuilder.buildMatSamConf()
@@ -52,7 +50,7 @@ class SfLightRunSpec extends WordSpecLike with Matchers with BeamHelper with Bef
 
       FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
       val scenario = ScenarioUtils.loadScenario(matsimConfig).asInstanceOf[MutableScenario]
-      val networkCoordinator = new DefaultNetworkCoordinator(beamConfig)
+      val networkCoordinator = DefaultNetworkCoordinator(beamConfig)
       networkCoordinator.loadNetwork()
       networkCoordinator.convertFrequenciesToTrips()
       scenario.setNetwork(networkCoordinator.network)

--- a/src/test/scala/beam/sflight/SfLightRunSpec.scala
+++ b/src/test/scala/beam/sflight/SfLightRunSpec.scala
@@ -10,7 +10,7 @@ import beam.sim.{BeamHelper, BeamServices}
 import beam.tags.{ExcludeRegular, Periodic}
 import beam.utils.FileUtils
 import beam.utils.TestConfigUtils.testConfig
-import com.typesafe.config.{Config, ConfigValueFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.matsim.api.core.v01.events.Event
 import org.matsim.core.controler.AbstractModule
 import org.matsim.core.events.handler.BasicEventHandler
@@ -36,7 +36,12 @@ class SfLightRunSpec extends WordSpecLike with Matchers with BeamHelper with Bef
 
   "SF Light" must {
     "run 1k scenario for one iteration and at least one person chooses car mode" in {
-      val config = testConfig("test/input/sf-light/sf-light-1k.conf")
+      val config = ConfigFactory
+        .parseString("""
+          |beam.outputs.events.fileOutputFormats = xml
+          |beam.agentsim.lastIteration = 0
+        """.stripMargin)
+        .withFallback(testConfig("test/input/sf-light/sf-light-1k.conf").resolve())
         .withValue("beam.outputs.events.fileOutputFormats", ConfigValueFactory.fromAnyRef("xml"))
         .withValue("beam.agentsim.lastIteration", ConfigValueFactory.fromAnyRef(0))
         .resolve()
@@ -83,6 +88,7 @@ class SfLightRunSpec extends WordSpecLike with Matchers with BeamHelper with Bef
       val totalIterations = configMap.getWithDefault("iterations", "1").toInt
       logger.info(s"Starting test with config [$confPath] and iterations [$totalIterations]")
       val baseConf = testConfig(confPath)
+        .resolve()
         .withValue(LAST_ITER_CONF_PATH, ConfigValueFactory.fromAnyRef(totalIterations - 1))
       baseConf.getInt(LAST_ITER_CONF_PATH) should be(totalIterations - 1)
       val conf = baseConf

--- a/src/test/scala/beam/sim/BeamAgentSchedulerSpec.scala
+++ b/src/test/scala/beam/sim/BeamAgentSchedulerSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpecLike, MustMatchers}
 
 class BeamAgentSchedulerSpec
     extends TestKit(
-      ActorSystem("BeamAgentSchedulerSpec", testConfig("test/input/beamville/beam.conf"))
+      ActorSystem("BeamAgentSchedulerSpec", testConfig("test/input/beamville/beam.conf").resolve())
     )
     with FunSpecLike
     with BeforeAndAfterAll

--- a/src/test/scala/beam/utils/PlansSamplerAppSpec.scala
+++ b/src/test/scala/beam/utils/PlansSamplerAppSpec.scala
@@ -41,7 +41,7 @@ class PlansSamplerAppSpec extends WordSpecLike with Matchers {
         attributes.toString.split(";")(0).stripPrefix("key="),
         "available-modes"
       ) should equal(
-        "car,ride_hail,bike,bus,funicular,gondola,cable_car,ferry,tram,transit,rail,subway"
+        "car,ride_hail,ride_hail_transit,bike,walk,walk_transit,bus,funicular,gondola,cable_car,ferry,tram,transit,rail,subway"
       )
     }
 

--- a/src/test/scala/beam/utils/TestConfigUtils.scala
+++ b/src/test/scala/beam/utils/TestConfigUtils.scala
@@ -9,5 +9,4 @@ object TestConfigUtils {
     BeamConfigUtils
       .parseFileSubstitutingInputDirectory(conf)
       .withValue("beam.outputs.baseOutputDirectory", ConfigValueFactory.fromAnyRef(testOutputDir))
-      .resolve()
 }


### PR DESCRIPTION
Moved some modes added ad-hoc in a getter function out of there.
Added them to the initialization of the agent.

(Found this when I was giving people "car" as only available mode, and they would walk anyway.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1169)
<!-- Reviewable:end -->
