### PR TITLE
BugFix: LoggingParallelEventsManager process all events before calling finishProcessing on underlying eventManager

### DIFF
--- a/src/main/scala/beam/sim/LoggingParallelEventsManager.scala
+++ b/src/main/scala/beam/sim/LoggingParallelEventsManager.scala
@@ -52,7 +52,7 @@ class LoggingParallelEventsManager @Inject()(config: Config) extends EventsManag
     tryLog("afterSimStep", eventManager.afterSimStep(time))
   }
   override def finishProcessing(): Unit = {
-    tryLog("finishProcessing", eventManager.finishProcessing())
+    val s = System.currentTimeMillis()
     isFinished.set(true)
     logger.info("Set `isFinished` to true")
     dedicatedHandler.foreach { f =>
@@ -60,6 +60,9 @@ class LoggingParallelEventsManager @Inject()(config: Config) extends EventsManag
       Await.result(f, 1000.seconds)
       logger.info("dedicatedHandler future finished.")
     }
+    tryLog("finishProcessing", eventManager.finishProcessing())
+    val e = System.currentTimeMillis()
+    logger.info(s"finishProcessing executed in ${e - s} ms")
     logger.debug(s"Overall processed events: ${numOfEvents.get()}")
   }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1181)
<!-- Reviewable:end -->
