### PR TITLE
Change the way how we generate `RideHailRequest.requestId`

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailRequest.scala
@@ -1,10 +1,8 @@
 package beam.agentsim.agents.ridehail
 
-import java.util.UUID
-
 import beam.agentsim.agents.vehicles.VehiclePersonId
 import beam.router.BeamRouter.Location
-import org.apache.commons.lang.builder.HashCodeBuilder
+import beam.utils.RideHailRequestIdGenerator
 import org.matsim.api.core.v01.population.Person
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.vehicles.Vehicle
@@ -17,7 +15,7 @@ case class RideHailRequest(
   destinationUTM: Location,
   asPooled: Boolean = false,
   groupedWithOtherRequests: List[RideHailRequest] = List(),
-  requestId: Int = UUID.randomUUID().hashCode()
+  requestId: Int = RideHailRequestIdGenerator.nextId
 ) {
 
   def addSubRequest(subRequest: RideHailRequest): RideHailRequest =

--- a/src/main/scala/beam/router/BeamRouter.scala
+++ b/src/main/scala/beam/router/BeamRouter.scala
@@ -484,7 +484,7 @@ object BeamRouter {
   )
 
   object RoutingResponse {
-    val dummyRoutingResponse = Some(RoutingResponse(Vector(), java.util.UUID.randomUUID().hashCode()))
+    val dummyRoutingResponse = Some(RoutingResponse(Vector(), IdGeneratorImpl.nextId))
   }
 
   def props(

--- a/src/main/scala/beam/utils/IdGenerator.scala
+++ b/src/main/scala/beam/utils/IdGenerator.scala
@@ -12,3 +12,11 @@ object IdGeneratorImpl extends IdGenerator {
     id.getAndIncrement()
   }
 }
+
+object RideHailRequestIdGenerator extends IdGenerator {
+  private val id: AtomicInteger = new AtomicInteger(0)
+
+  def nextId: Int = {
+    id.getAndIncrement()
+  }
+}

--- a/src/test/scala/beam/agentsim/agents/OtherPersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/OtherPersonAgentSpec.scala
@@ -371,7 +371,7 @@ class OtherPersonAgentSpec
             )
           )
         ),
-        java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       expectMsgType[ModeChoiceEvent]
@@ -432,7 +432,7 @@ class OtherPersonAgentSpec
             )
           )
         ),
-        java.util.UUID.randomUUID().hashCode()
+        1
       )
       expectMsgType[ModeChoiceEvent]
 

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -532,7 +532,7 @@ class PersonAgentSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       events.expectMsgType[ModeChoiceEvent]

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -3,7 +3,6 @@ package beam.agentsim.agents
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.testkit.TestActor.RealMessage
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import akka.util.Timeout
 import beam.agentsim.agents.PersonTestUtil._
@@ -396,7 +395,7 @@ class PersonAndTransitDriverSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       personEvents.expectMsgType[ModeChoiceEvent]

--- a/src/test/scala/beam/agentsim/agents/PersonWithCarPlanSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithCarPlanSpec.scala
@@ -16,7 +16,7 @@ import beam.agentsim.events._
 import beam.agentsim.infrastructure.ParkingManager.ParkingStockAttributes
 import beam.agentsim.infrastructure.{TAZTreeMap, ZonalParkingManager}
 import beam.agentsim.scheduler.BeamAgentScheduler
-import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger, SchedulerProps, StartSchedule}
+import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, SchedulerProps, StartSchedule}
 import beam.router.BeamRouter._
 import beam.router.Modes.BeamMode
 import beam.router.Modes.BeamMode.CAR
@@ -203,7 +203,7 @@ class PersonWithCarPlanSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       expectMsgType[ModeChoiceEvent]
@@ -332,7 +332,7 @@ class PersonWithCarPlanSpec
             )
             lastSender ! RoutingResponse(
               Vector(EmbodiedBeamTrip(Vector(embodiedLeg))),
-              requestId = java.util.UUID.randomUUID().hashCode()
+              requestId = 1
             )
         }
       }

--- a/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
@@ -233,7 +233,7 @@ class PersonWithVehicleSharingSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       events.expectMsgType[ModeChoiceEvent]
@@ -400,7 +400,7 @@ class PersonWithVehicleSharingSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
 
       events.expectMsgType[ModeChoiceEvent]
@@ -485,7 +485,7 @@ class PersonWithVehicleSharingSpec
             )
           )
         ),
-        requestId = java.util.UUID.randomUUID().hashCode()
+        requestId = 1
       )
       val modeChoiceEvent = events.expectMsgType[ModeChoiceEvent]
       assert(modeChoiceEvent.chosenTrip.tripClassifier == CAR)
@@ -598,7 +598,7 @@ class PersonWithVehicleSharingSpec
           )
           mockRouter.lastSender ! RoutingResponse(
             Vector(EmbodiedBeamTrip(Vector(embodiedLeg))),
-            requestId = java.util.UUID.randomUUID().hashCode()
+            requestId = 1
           )
       }
 
@@ -633,7 +633,7 @@ class PersonWithVehicleSharingSpec
           )
           mockRouter.lastSender ! RoutingResponse(
             Vector(EmbodiedBeamTrip(Vector(embodiedLeg))),
-            requestId = java.util.UUID.randomUUID().hashCode()
+            requestId = 1
           )
       }
 
@@ -671,7 +671,7 @@ class PersonWithVehicleSharingSpec
           )
           mockRouter.lastSender ! RoutingResponse(
             Vector(EmbodiedBeamTrip(Vector(embodiedLeg))),
-            requestId = java.util.UUID.randomUUID().hashCode()
+            requestId = 1
           )
       }
 


### PR DESCRIPTION
- Added `RideHailRequestIdGenerator` instead of using `IdGeneratorImpl ` to avoid high thread contention. IDs for `RideHailRequest` and( `RoutingRequest`, `EmbodyWithCurrentTravelTime`) have different meanings, so they can intersect (? @colinsheppard)
- Removed `java.util.UUID.randomUUID().hashCode()` from all tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1182)
<!-- Reviewable:end -->
