### PR TITLE
StuckFinder: Increased twice the thresholds

### DIFF
--- a/test/input/sf-light/sf-light-0.5k.conf
+++ b/test/input/sf-light/sf-light-0.5k.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-10k.conf
+++ b/test/input/sf-light/sf-light-10k.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-1k.conf
+++ b/test/input/sf-light/sf-light-1k.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40,
-        rideHailAgent = 26,
+        rideHailAgent = 52,
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40,
-        rideHailAgent = 26,
+        rideHailAgent = 52,
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-2.5k.conf
+++ b/test/input/sf-light/sf-light-2.5k.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-25k.conf
+++ b/test/input/sf-light/sf-light-25k.conf
@@ -207,14 +207,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -222,7 +222,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -231,7 +231,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-5k.conf
+++ b/test/input/sf-light/sf-light-5k.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light.conf
+++ b/test/input/sf-light/sf-light.conf
@@ -211,14 +211,14 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger"
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger"
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 40
-        rideHailAgent = 26
+        rideHailAgent = 52
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000


### PR DESCRIPTION
Increased twice the thresholds for next trigger types:
- beam.agentsim.agents.modalbehaviors.DrivesVehicle$AlightVehicleTrigger
- beam.agentsim.agents.modalbehaviors.DrivesVehicle$BoardVehicleTrigger
- beam.agentsim.agents.modalbehaviors.DrivesVehicle$EndLegTrigger
- beam.agentsim.agents.modalbehaviors.DrivesVehicle$StartLegTrigger

Build failed with error that max number of messages to actor type is exceed (https://beam-ci.tk/blue/rest/organizations/jenkins/pipelines/master/runs/501/log/?start=0).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1202)
<!-- Reviewable:end -->
