### PR TITLE
StuckFinder: Increased twice the thresholds. Attempt #3

### DIFF
--- a/test/input/sf-light/sf-light-0.5k.conf
+++ b/test/input/sf-light/sf-light-0.5k.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light-10k.conf
+++ b/test/input/sf-light/sf-light-10k.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light-1k.conf
+++ b/test/input/sf-light/sf-light-1k.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light-2.5k.conf
+++ b/test/input/sf-light/sf-light-2.5k.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light-25k.conf
+++ b/test/input/sf-light/sf-light-25k.conf
@@ -200,7 +200,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light-5k.conf
+++ b/test/input/sf-light/sf-light-5k.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"

--- a/test/input/sf-light/sf-light.conf
+++ b/test/input/sf-light/sf-light.conf
@@ -204,7 +204,7 @@ beam.debug.stuckAgentDetection {
     },
     {
       actorTypeToMaxNumberOfMessages {
-        population = 10
+        population = 20
       }
       markAsStuckAfterMs = 20000
       triggerType = "beam.agentsim.agents.PersonAgent$PersonDepartureTrigger"


### PR DESCRIPTION
Increased twice the thresholds for `beam.agentsim.agents.PersonAgent$PersonDepartureTrigger` because I saw error:
```
06:33:37.348 [single-mode-test-akka.actor.default-dispatcher-13] WARN  beam.utils.StuckFinder - ScheduledTrigger(TriggerWithId(PersonDepartureTrigger(84955),916549),Actor[akka://single-mode-test/user/BeamMobsim.iteration/population/033000-2015000413884-0/033000-2015000413884-0-5912962#1643075731],0) is exceed max number of messages threshold. Trigger type: 'class beam.agentsim.agents.PersonAgent$PersonDepartureTrigger', current count: 11, max: 10
```
https://beam-ci.tk/blue/rest/organizations/jenkins/pipelines/beam-4ci/runs/3394/log/?start=0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1205)
<!-- Reviewable:end -->
