### PR TITLE
StuckFinder: Increased twice the thresholds. Attempt #4

### DIFF
--- a/src/main/scala/beam/utils/matsim_conversion/VehiclesDataConversion.scala
+++ b/src/main/scala/beam/utils/matsim_conversion/VehiclesDataConversion.scala
@@ -280,7 +280,8 @@ object VehiclesDataConversion extends App {
     val vehicles = (vehiclesDoc \ "vehicle").map { vehicle =>
       Seq(vehicle \@ "id", vehicle \@ "type")
     }
-    val beamVehiclesPath = new File(scenarioDirectory +
+    val beamVehiclesPath = new File(
+      scenarioDirectory +
       "/vehicles.csv"
     ).toString
     writeCsvFile(beamVehiclesPath, vehicles, beamVehicleTitles)

--- a/test/input/sf-light/sf-light-0.5k.conf
+++ b/test/input/sf-light/sf-light-0.5k.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-10k.conf
+++ b/test/input/sf-light/sf-light-10k.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-1k.conf
+++ b/test/input/sf-light/sf-light-1k.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80,
-        rideHailAgent = 52,
+        rideHailAgent = 104,
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80,
-        rideHailAgent = 52,
+        rideHailAgent = 104,
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-2.5k.conf
+++ b/test/input/sf-light/sf-light-2.5k.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-25k.conf
+++ b/test/input/sf-light/sf-light-25k.conf
@@ -222,7 +222,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -231,7 +231,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light-5k.conf
+++ b/test/input/sf-light/sf-light-5k.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000

--- a/test/input/sf-light/sf-light.conf
+++ b/test/input/sf-light/sf-light.conf
@@ -226,7 +226,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000
@@ -235,7 +235,7 @@ beam.debug.stuckAgentDetection {
     {
       actorTypeToMaxNumberOfMessages {
         population = 80
-        rideHailAgent = 52
+        rideHailAgent = 104
         transitDriverAgent = 114
       }
       markAsStuckAfterMs = 20000


### PR DESCRIPTION
Increase thresholds for `beam.agentsim.agents.modalbehaviors.DrivesVehicle$EndLegTrigger` and `beam.agentsim.agents.modalbehaviors.DrivesVehicle$StartLegTrigger`.

Have seen errors in [periodic master build logs](https://beam-ci.tk/blue/rest/organizations/jenkins/pipelines/master-periodic/runs/199/log/?start=0):
```
05:05:09.583 [ClusterSystem-akka.actor.default-dispatcher-27] WARN  beam.utils.StuckFinder - ScheduledTrigger(TriggerWithId(StartLegTrigger(82043,BeamLeg(CAR @ 82043,dur:143,path: 2821 .. 70906)),1544874),Actor[akka://ClusterSystem/user/BeamMobsim.iteration/RideHailManager/rideHailAgent-031400-2015000474543-0-6806555#-1874477004],0) is exceed max number of messages threshold. Trigger type: 'class beam.agentsim.agents.modalbehaviors.DrivesVehicle$StartLegTrigger', current count: 53, max: 52

05:05:09.839 [ClusterSystem-akka.actor.default-dispatcher-15] WARN  beam.utils.StuckFinder - ScheduledTrigger(TriggerWithId(EndLegTrigger(82186),1544875),Actor[akka://ClusterSystem/user/BeamMobsim.iteration/RideHailManager/rideHailAgent-031400-2015000474543-0-6806555#-1874477004],0) is exceed max number of messages threshold. Trigger type: 'class beam.agentsim.agents.modalbehaviors.DrivesVehicle$EndLegTrigger', current count: 53, max: 52

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1215)
<!-- Reviewable:end -->
