### PR TITLE
DebugTool: Print the agent type and the line when coordinates are in wrong format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,8 @@ dependencies {
     scoverage "org.scoverage:scalac-scoverage-plugin_${scalaBinaryVersion}:1.3.1", "org.scoverage:scalac-scoverage-runtime_${scalaBinaryVersion}:1.3.1"
 
     compile 'org.apache.commons:commons-compress:1.18'
+
+    compile group: 'com.lihaoyi', name: 'sourcecode_2.12', version: '0.1.5'
 }
 
 // Autoformatting using scalafmt

--- a/src/main/java/beam/analysis/plots/RideHailWaitingTazAnalysis.java
+++ b/src/main/java/beam/analysis/plots/RideHailWaitingTazAnalysis.java
@@ -3,6 +3,7 @@ package beam.analysis.plots;
 import beam.agentsim.events.ReserveRideHailEvent;
 import beam.agentsim.infrastructure.TAZTreeMap;
 import beam.sim.BeamServices;
+import beam.utils.CallerInfo;
 import beam.utils.MathUtils;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -12,6 +13,9 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.io.IOUtils;
+import sourcecode.Enclosing;
+import sourcecode.File;
+import sourcecode.Line;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -57,7 +61,8 @@ public class RideHailWaitingTazAnalysis implements GraphAnalysis {
             if (rideHailWaitingQueue.containsKey(personId.toString()) && personEntersVehicleEvent.getVehicleId().toString().contains("rideHailVehicle")) {
                 //process and add the waiting time to the total time spent by all the passengers on waiting for a ride hail
                 ReserveRideHailEvent reserveRideHailEvent = (ReserveRideHailEvent) rideHailWaitingQueue.get(_personId);
-                Coord pickupCoord = beamServices.geo().wgs2Utm(new Coord(reserveRideHailEvent.originX, reserveRideHailEvent.originY));
+                CallerInfo ci = new CallerInfo(this.getClass(), new File("RideHailWaitingTazAnalysis.java"), new Enclosing("java"), new Line(64));
+                Coord pickupCoord = beamServices.geo().wgs2Utm(new Coord(reserveRideHailEvent.originX, reserveRideHailEvent.originY), ci);
                 TAZTreeMap.TAZ pickUpLocationTAZ = beamServices.tazTreeMap().getTAZ(pickupCoord.getX(),pickupCoord.getY());
                 double waitingTime = personEntersVehicleEvent.getTime() - reserveRideHailEvent.getTime();
                 processRideHailWaitingTimesAndTaz(reserveRideHailEvent, waitingTime,pickUpLocationTAZ);

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
@@ -21,6 +21,7 @@ import beam.router.Modes.BeamMode.{TRANSIT, WALK}
 import beam.router.model.BeamLeg
 import beam.router.osm.TollCalculator
 import beam.sim.HasServices
+import beam.utils.DebugUtil
 import com.conveyal.r5.transit.TransportNetwork
 import org.matsim.api.core.v01.Id
 import org.matsim.api.core.v01.events.{
@@ -72,7 +73,7 @@ object DrivesVehicle {
 
 }
 
-trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with HasServices with Stash {
+trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with HasServices with Stash with DebugUtil {
 
   protected val transportNetwork: TransportNetwork
   protected val parkingManager: ActorRef

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailIterationsStatsCollector.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailIterationsStatsCollector.scala
@@ -2,7 +2,7 @@ package beam.agentsim.agents.ridehail
 
 import beam.agentsim.events.{ModeChoiceEvent, PathTraversalEvent}
 import beam.sim.BeamServices
-import beam.utils.GeoUtils
+import beam.utils.{DebugUtil, GeoUtils}
 import com.conveyal.r5.transit.TransportNetwork
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Coord
@@ -87,7 +87,8 @@ class RideHailIterationsStatsCollector(
   rideHailIterationHistoryActor: RideHailIterationHistory,
   transportNetwork: TransportNetwork
 ) extends BasicEventHandler
-    with LazyLogging {
+    with LazyLogging
+    with DebugUtil {
 
   private val beamConfig = beamServices.beamConfig
   // TAZ level -> how to get as input here?

--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -1,6 +1,5 @@
 package beam.agentsim.scheduler
 
-import java.lang.Double
 import java.util.Comparator
 import java.util.concurrent.TimeUnit
 
@@ -12,8 +11,8 @@ import beam.agentsim.agents.ridehail.RideHailManager.RideHailRepositioningTrigge
 import beam.agentsim.scheduler.BeamAgentScheduler._
 import beam.agentsim.scheduler.Trigger.TriggerWithId
 import beam.sim.config.BeamConfig
+import beam.utils.StuckFinder
 import beam.utils.logging.LogActorState
-import beam.utils.{DebugLib, StuckFinder}
 import com.google.common.collect.TreeMultimap
 
 import scala.annotation.tailrec
@@ -251,8 +250,8 @@ class BeamAgentScheduler(
         awaitingResponse.values().asScala.take(1).foreach { x =>
           if (x.agent.path.name.contains("RideHailManager")) {
             rideHailManagerStuckDetectionLog match {
-              case RideHailManagerStuckDetectionLog(Some(tick), true) if tick==nowInSeconds => // still stuck, no need to print state again
-              case RideHailManagerStuckDetectionLog(Some(tick), false) if tick==nowInSeconds =>
+              case RideHailManagerStuckDetectionLog(Some(tick), true) if tick == nowInSeconds  => // still stuck, no need to print state again
+              case RideHailManagerStuckDetectionLog(Some(tick), false) if tick == nowInSeconds =>
                 // the time has not changed sense set last monitor timeout and RidehailManager still blocking scheduler -> log state and try to remove stuckness
                 rideHailManagerStuckDetectionLog = RideHailManagerStuckDetectionLog(Some(nowInSeconds), true)
                 x.agent ! LogActorState

--- a/src/main/scala/beam/sim/common/GeoUtils.scala
+++ b/src/main/scala/beam/sim/common/GeoUtils.scala
@@ -31,12 +31,8 @@ trait GeoUtils extends ExponentialLazyLogging {
 
   def wgs2Utm(coord: Coord)(implicit callerInfo: CallerInfo): Coord = {
     if (coord.getX < -180 || coord.getX > 180 || coord.getY < -90 || coord.getY > 90) {
-      val file = callerInfo.file
-      val enclosing = callerInfo.enclosing
-      val line = callerInfo.line
-      val sourceFileName = new java.io.File(file.value).getName
-      val msg = s"${callerInfo.clazz} ${enclosing.value}($sourceFileName:${line.value}) ${file.value}:${line.value}"
-      logger.warn(s"Coordinate does not appear to be in WGS. No conversion will happen: $coord. \r\n $msg")
+      logger.warn(s"""Coordinate does not appear to be in WGS. No conversion will happen: $coord
+        |$callerInfo""".stripMargin)
       coord
     } else {
       wgs2Utm.transform(coord)

--- a/src/main/scala/beam/utils/DebugUtil.scala
+++ b/src/main/scala/beam/utils/DebugUtil.scala
@@ -1,0 +1,12 @@
+package beam.utils
+
+case class CallerInfo(clazz: Class[_], file: sourcecode.File, enclosing: sourcecode.Enclosing, line: sourcecode.Line)
+
+trait DebugUtil {
+  // Some magic with scala macros :)
+  implicit def getCallerInfo(
+    implicit file: sourcecode.File,
+    enclosing: sourcecode.Enclosing,
+    line: sourcecode.Line
+  ): CallerInfo = CallerInfo(this.getClass, file, enclosing, line)
+}

--- a/src/main/scala/beam/utils/DebugUtil.scala
+++ b/src/main/scala/beam/utils/DebugUtil.scala
@@ -1,6 +1,11 @@
 package beam.utils
 
-case class CallerInfo(clazz: Class[_], file: sourcecode.File, enclosing: sourcecode.Enclosing, line: sourcecode.Line)
+case class CallerInfo(clazz: Class[_], file: sourcecode.File, enclosing: sourcecode.Enclosing, line: sourcecode.Line) {
+  override def toString: String = {
+    val sourceFileName = new java.io.File(file.value).getName
+    s"$clazz ${enclosing.value}($sourceFileName:${line.value}) ${file.value}:${line.value}"
+  }
+}
 
 trait DebugUtil {
   // Some magic with scala macros :)

--- a/src/main/scala/beam/utils/ScenarioReaderCsv.scala
+++ b/src/main/scala/beam/utils/ScenarioReaderCsv.scala
@@ -123,7 +123,8 @@ class ScenarioReaderCsv(var scenario: MutableScenario, var beamServices: BeamSer
   }
 }
 
-object ScenarioReaderCsv {
+object ScenarioReaderCsv extends DebugUtil {
+
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   var vehicleCounter = 1

--- a/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
@@ -29,7 +29,7 @@ import beam.sim.config.{BeamConfig, MatSimBeamConfigBuilder}
 import beam.sim.population.AttributesOfIndividual
 import beam.utils.BeamVehicleUtils.{readBeamVehicleTypeFile, readFuelTypeFile}
 import beam.utils.TestConfigUtils.testConfig
-import beam.utils.{BeamVehicleUtils, NetworkHelperImpl, StuckFinder}
+import beam.utils.{DebugUtil, NetworkHelperImpl, StuckFinder}
 import com.typesafe.config.ConfigFactory
 import org.matsim.api.core.v01.events._
 import org.matsim.api.core.v01.population.Person
@@ -72,7 +72,8 @@ class PersonWithPersonalVehiclePlanSpec
     with FunSpecLike
     with BeforeAndAfterAll
     with MockitoSugar
-    with ImplicitSender {
+    with ImplicitSender
+    with DebugUtil {
 
   private implicit val timeout: Timeout = Timeout(60, TimeUnit.SECONDS)
   private lazy val beamConfig = BeamConfig(system.settings.config)

--- a/src/test/scala/beam/sflight/AbstractSfLightSpec.scala
+++ b/src/test/scala/beam/sflight/AbstractSfLightSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorIdentity, ActorRef, ActorSystem, Identify, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKitBase}
 import beam.router.BeamRouter
 import beam.sim.{BeamServices, BeamServicesImpl}
-import beam.utils.SimRunnerForTest
+import beam.utils.{DebugUtil, SimRunnerForTest}
 import beam.utils.TestConfigUtils.testConfig
 import com.typesafe.config.{Config, ConfigFactory}
 import org.matsim.api.core.v01.population.{Activity, Plan}
@@ -23,7 +23,8 @@ class AbstractSfLightSpec(val name: String)
     with Matchers
     with ImplicitSender
     with MockitoSugar
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with DebugUtil {
   lazy implicit val system = ActorSystem(name, ConfigFactory.parseString("""akka.loglevel="OFF"
       |akka.test.timefactor=10""".stripMargin))
 


### PR DESCRIPTION
It uses [sourcecode](https://github.com/lihaoyi/sourcecode) to get source file, line and enclosing name on compile-time using scala macros. Magic happens due to https://github.com/LBNL-UCB-STI/beam/compare/art/print-stacktrace-when-coordinates-are-wrong-4ci?expand=1#diff-a9cc8fe78944a2aa3bbe386d2d2c9629R10 trait `DebugUtil` with `implicit def getCallerInfo` and this implicit comes to the scope because of https://github.com/LBNL-UCB-STI/beam/compare/art/print-stacktrace-when-coordinates-are-wrong-4ci?expand=1#diff-526ef9e78edd0f381ba50a20bdc1e8c1R28. It was (IMHO) the easiest way with making less code changes.
An example of output:
```
03:30:09.778 WARN  beam.sim.common.GeoUtilsImpl - [4] Coordinate does not appear to be in WGS. No conversion will happen: [x=552954.6304091329][y=4176210.316522328]. 
 class beam.agentsim.agents.PersonAgent beam.agentsim.agents.modalbehaviors.DrivesVehicle#$anonfun#applyOrElse(DrivesVehicle.scala:222) C:\repos\beam\src\main\scala\beam\agentsim\agents\modalbehaviors\DrivesVehicle.scala:222
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1359)
<!-- Reviewable:end -->
