### PR TITLE
zn/#1539 rh start at activity locations

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -1386,12 +1386,9 @@ class RideHailManager(
           val radius =
             beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.procedural.initialLocation.home.radiusInMeters
           val activityLocations: List[Location] =
-            person.getSelectedPlan.getPlanElements
-              .asScala
-              .collect {
-                case activity: Activity => activity.getCoord()
-              }
-              .toList
+            person.getSelectedPlan.getPlanElements.asScala.collect {
+              case activity: Activity => activity.getCoord()
+            }.toList
           val randomActivityLocation: Location = activityLocations(rand.nextInt(activityLocations.length))
           new Coord(
             randomActivityLocation.getX + radius * (rand.nextDouble() - 0.5),

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -77,6 +77,7 @@ object RideHailAgentLocationWithRadiusOrdering extends Ordering[(RideHailAgentLo
 object RideHailManager {
 
   val INITIAL_RIDE_HAIL_LOCATION_HOME = "HOME"
+  val INITIAL_RIDE_HAIL_LOCATION_RANDOM_ACTIVITY = "RANDOM_ACTIVITY"
   val INITIAL_RIDE_HAIL_LOCATION_UNIFORM_RANDOM = "UNIFORM_RANDOM"
   val INITIAL_RIDE_HAIL_LOCATION_ALL_AT_CENTER = "ALL_AT_CENTER"
   val INITIAL_RIDE_HAIL_LOCATION_ALL_IN_CORNER = "ALL_IN_CORNER"
@@ -1379,15 +1380,30 @@ class RideHailManager(
   }
 
   def getRideInitLocation(person: Person): Location = {
-    val personInitialLocation: Location =
-      person.getSelectedPlan.getPlanElements
-        .iterator()
-        .next()
-        .asInstanceOf[Activity]
-        .getCoord
     val rideInitialLocation: Location =
       beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.procedural.initialLocation.name match {
+        case RideHailManager.INITIAL_RIDE_HAIL_LOCATION_RANDOM_ACTIVITY =>
+          val radius =
+            beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.procedural.initialLocation.home.radiusInMeters
+          val activityLocations: List[Location] =
+            person.getSelectedPlan.getPlanElements
+              .asScala
+              .collect {
+                case activity: Activity => activity.getCoord()
+              }
+              .toList
+          val randomActivityLocation: Location = activityLocations(rand.nextInt(activityLocations.length))
+          new Coord(
+            randomActivityLocation.getX + radius * (rand.nextDouble() - 0.5),
+            randomActivityLocation.getY + radius * (rand.nextDouble() - 0.5)
+          )
         case RideHailManager.INITIAL_RIDE_HAIL_LOCATION_HOME =>
+          val personInitialLocation: Location =
+            person.getSelectedPlan.getPlanElements
+              .iterator()
+              .next()
+              .asInstanceOf[Activity]
+              .getCoord
           val radius =
             beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.procedural.initialLocation.home.radiusInMeters
           new Coord(
@@ -1410,6 +1426,12 @@ class RideHailManager(
           new Coord(x, y)
         case unknown =>
           log.error(s"unknown rideHail.initialLocation $unknown, assuming HOME")
+          val personInitialLocation: Location =
+            person.getSelectedPlan.getPlanElements
+              .iterator()
+              .next()
+              .asInstanceOf[Activity]
+              .getCoord
           val radius =
             beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.procedural.initialLocation.home.radiusInMeters
           new Coord(


### PR DESCRIPTION
Give option for ride hail agents to be generated at random activity locations, not just random homes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1541)
<!-- Reviewable:end -->
