### PR TITLE
Project:  Minor memory improvements

### DIFF
--- a/src/main/scala/beam/agentsim/events/handling/BeamEventsWriterXML.scala
+++ b/src/main/scala/beam/agentsim/events/handling/BeamEventsWriterXML.scala
@@ -1,7 +1,6 @@
 package beam.agentsim.events.handling
 
 import java.io.IOException
-import java.util
 
 import beam.sim.BeamServices
 import org.matsim.api.core.v01.events.Event
@@ -23,6 +22,8 @@ class BeamEventsWriterXML(
   beamServices: BeamServices,
   eventTypeToLog: Class[_]
 ) extends BeamEventsWriterBase(outFileName, beamEventLogger, beamServices, eventTypeToLog) {
+
+  val specialChars: Array[Char] = Array('<', '>', '\"', '&')
 
   writeHeaders()
 
@@ -83,7 +84,7 @@ class BeamEventsWriterXML(
     */
   private def encodeAttributeValue(attributeValue: String): String = {
     // Replace special characters(if any) with encoded strings
-    attributeValue.find(List('<', '>', '\"', '&').contains(_)) match {
+    attributeValue.find(specialChars.contains(_)) match {
       case Some(_) =>
         attributeValue
           .replaceAll("<", "&lt;")

--- a/src/main/scala/beam/router/osm/TollCalculator.scala
+++ b/src/main/scala/beam/router/osm/TollCalculator.scala
@@ -12,6 +12,7 @@ import beam.sim.config.BeamConfig
 import com.conveyal.osmlib.OSM
 import com.google.common.collect.Maps
 import com.typesafe.scalalogging.LazyLogging
+import gnu.trove.map.hash.TIntObjectHashMap
 import javax.inject.Inject
 import org.apache.commons.collections4.MapUtils
 
@@ -23,8 +24,15 @@ import scala.util.control.NonFatal
 class TollCalculator @Inject()(val config: BeamConfig) extends LazyLogging {
   import beam.utils.FileUtils._
 
-  private val tollsByLinkId: java.util.Map[Int, Array[Toll]] =
-    readTollPrices(config.beam.agentsim.toll.filePath)
+  private val tollsByLinkId: TIntObjectHashMap[Array[Toll]] = {
+    val map: util.Map[Int, Array[Toll]] = readTollPrices(config.beam.agentsim.toll.filePath)
+    val intHashMap = new TIntObjectHashMap[Array[Toll]]()
+    map.asScala.foreach {
+      case (k, v) =>
+        intHashMap.put(k, v)
+    }
+    intHashMap
+  }
   private val tollsByWayId: java.util.Map[Long, Array[Toll]] = readFromCacheFileOrOSM()
 
   logger.info("tollsByLinkId size: {}", tollsByLinkId.size)


### PR DESCRIPTION
- Initialize special chars only once in `BeamEventsWriterXML.scala`
- Use `TIntObjectHashMap` to avoid boxing (heap allocation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1551)
<!-- Reviewable:end -->
