### PR TITLE
FastHouseholdCAVSchedulingSpec: Use real BeamService instead of mock

### DIFF
--- a/src/test/scala/beam/agentsim/agents/household/FastHouseholdCAVSchedulingSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/household/FastHouseholdCAVSchedulingSpec.scala
@@ -35,7 +35,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.List
-import scala.collection.{JavaConverters, mutable}
+import scala.collection.{mutable, JavaConverters}
 import scala.concurrent.ExecutionContext
 
 class FastHouseholdCAVSchedulingSpec
@@ -72,20 +72,24 @@ class FastHouseholdCAVSchedulingSpec
     val tazTreeMap: TAZTreeMap = BeamServices.getTazTreeMap("test/input/beamville/taz-centers.csv")
     val beamConfig = beamCfg
 
-    override var matsimServices: MatsimServices =  new MatsimServicesMock(null, mock[Scenario])
+    override var matsimServices: MatsimServices = new MatsimServicesMock(null, mock[Scenario])
 
     override val modeIncentives = ModeIncentive(Map[BeamMode, List[Incentive]]())
+
     val fuelTypePrices: Map[FuelType, Double] =
       BeamVehicleUtils.readFuelTypeFile(beamConfig.beam.agentsim.agents.vehicles.fuelTypesFilePath).toMap
 
     val vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleType] =
-      BeamVehicleUtils.readBeamVehicleTypeFile(beamConfig.beam.agentsim.agents.vehicles.vehicleTypesFilePath, fuelTypePrices)
+      BeamVehicleUtils.readBeamVehicleTypeFile(
+        beamConfig.beam.agentsim.agents.vehicles.vehicleTypesFilePath,
+        fuelTypePrices
+      )
 
     override val geo: GeoUtils = new GeoUtilsImpl(beamConfig)
     override lazy val controler: ControlerI = ???
     override lazy val vehicleEnergy: VehicleEnergy = ???
     override var modeChoiceCalculatorFactory: ModeChoiceCalculatorFactory = _
-    override lazy val dates: DateUtils =  ???
+    override lazy val dates: DateUtils = ???
     override var beamRouter: ActorRef = _
     override lazy val rideHailTransitModes: Seq[BeamMode] = ???
     override lazy val agencyAndRouteByVehicleIds: TrieMap[Id[Vehicle], (String, String)] = ???
@@ -94,7 +98,7 @@ class FastHouseholdCAVSchedulingSpec
     override lazy val ptFares: PtFares = ???
     override def startNewIteration(): Unit = ???
     override def networkHelper: NetworkHelper = ???
-    override def setTransitFleetSizes(tripFleetSizeMap:  mutable.HashMap[String, Integer]): Unit = ???
+    override def setTransitFleetSizes(tripFleetSizeMap: mutable.HashMap[String, Integer]): Unit = ???
   }
 
   describe("A Household CAV Scheduler") {

--- a/src/test/scala/beam/utils/SimRunnerForTest.scala
+++ b/src/test/scala/beam/utils/SimRunnerForTest.scala
@@ -21,7 +21,7 @@ import org.matsim.core.router.util.{LeastCostPathCalculatorFactory, TravelDisuti
 import org.matsim.core.scenario.ScenarioUtils
 import org.matsim.core.scoring.ScoringFunctionFactory
 
-private class MatsimServicesMock(
+class MatsimServicesMock(
   override val getControlerIO: OutputDirectoryHierarchy,
   override val getScenario: Scenario
 ) extends MatsimServices {


### PR DESCRIPTION
After fix, when I run tests:
![image](https://user-images.githubusercontent.com/5107562/55109317-1f67df00-5108-11e9-933a-3e5257fd983f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1570)
<!-- Reviewable:end -->
