### PR TITLE
UrbanSim: Drop corrupted planElement

### DIFF
--- a/src/main/scala/beam/utils/scenario/Models.scala
+++ b/src/main/scala/beam/utils/scenario/Models.scala
@@ -6,9 +6,10 @@ case class HouseholdId(id: String) extends AnyVal
 
 case class PersonInfo(personId: PersonId, householdId: HouseholdId, rank: Int, age: Int)
 
-case class PlanInfo(
+case class PlanElement(
   personId: PersonId,
   planElement: String,
+  planElementIndex: Int,
   activityType: Option[String],
   x: Option[Double],
   y: Option[Double],

--- a/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
@@ -18,8 +18,6 @@ import org.matsim.core.scenario.MutableScenario
 import org.matsim.households._
 import org.matsim.vehicles.{Vehicle, VehicleType, VehicleUtils}
 
-import java.util.Random
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
@@ -86,7 +84,7 @@ class ScenarioLoader(
 
   private[utils] def getPersonsWithPlan(
     persons: Iterable[PersonInfo],
-    plans: Iterable[PlanInfo]
+    plans: Iterable[PlanElement]
   ): Iterable[PersonInfo] = {
     val personIdsWithPlan = plans.map(_.personId).toSet
     persons.filter(person => personIdsWithPlan.contains(person.personId))
@@ -238,7 +236,7 @@ class ScenarioLoader(
     }
   }
 
-  private[utils] def applyPlans(plans: Iterable[PlanInfo]): Unit = {
+  private[utils] def applyPlans(plans: Iterable[PlanElement]): Unit = {
     plans.foreach { planInfo =>
       val person = population.getPersons.get(Id.createPersonId(planInfo.personId.id))
       if (person != null) {

--- a/src/main/scala/beam/utils/scenario/ScenarioSource.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioSource.scala
@@ -2,6 +2,6 @@ package beam.utils.scenario
 
 trait ScenarioSource {
   def getPersons: Iterable[PersonInfo]
-  def getPlans: Iterable[PlanInfo]
+  def getPlans: Iterable[PlanElement]
   def getHousehold: Iterable[HouseholdInfo]
 }

--- a/src/main/scala/beam/utils/scenario/matsim/MatsimScenarioReader.scala
+++ b/src/main/scala/beam/utils/scenario/matsim/MatsimScenarioReader.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 trait MatsimScenarioReader {
   def inputType: InputType
   def readPersonsFile(path: String): Array[PersonInfo]
-  def readPlansFile(path: String): Array[PlanInfo]
+  def readPlansFile(path: String): Array[PlanElement]
   def readHouseholdsFile(path: String): Array[HouseholdInfo]
 }
 
@@ -21,8 +21,8 @@ object CsvScenarioReader extends MatsimScenarioReader with LazyLogging {
   override def readPersonsFile(path: String): Array[PersonInfo] = {
     readAs[PersonInfo](path, "readPersonsFile", toPersonInfo)
   }
-  override def readPlansFile(path: String): Array[PlanInfo] = {
-    readAs[PlanInfo](path, "readPlansFile", toPlanInfo)
+  override def readPlansFile(path: String): Array[PlanElement] = {
+    readAs[PlanElement](path, "readPlansFile", toPlanInfo)
 
   }
   override def readHouseholdsFile(path: String): Array[HouseholdInfo] = {
@@ -49,18 +49,20 @@ object CsvScenarioReader extends MatsimScenarioReader with LazyLogging {
     HouseholdInfo(householdId = HouseholdId(householdId), cars = cars, income = income, x = x, y = y)
   }
 
-  private[matsim] def toPlanInfo(rec: java.util.Map[String, String]): PlanInfo = {
+  private[matsim] def toPlanInfo(rec: java.util.Map[String, String]): PlanElement = {
     // Somehow Plan file has columns in camelCase, not snake_case
     val personId = getIfNotNull(rec, "personId")
     val planElement = getIfNotNull(rec, "planElement")
+    val planElementIndex = getIfNotNull(rec, "planElementIndex").toInt
     val activityType = Option(rec.get("activityType"))
     val x = Option(rec.get("x")).map(_.toDouble)
     val y = Option(rec.get("y")).map(_.toDouble)
     val endTime = Option(rec.get("endTime")).map(_.toDouble)
     val mode = Option(rec.get("mode")).map(_.toString)
-    PlanInfo(
+    PlanElement(
       personId = PersonId(personId),
       planElement = planElement,
+      planElementIndex = planElementIndex,
       activityType = activityType,
       x = x,
       y = y,

--- a/src/main/scala/beam/utils/scenario/matsim/MatsimScenarioSource.scala
+++ b/src/main/scala/beam/utils/scenario/matsim/MatsimScenarioSource.scala
@@ -1,5 +1,5 @@
 package beam.utils.scenario.matsim
-import beam.utils.scenario.{HouseholdInfo, PersonInfo, PlanInfo, ScenarioSource}
+import beam.utils.scenario.{HouseholdInfo, PersonInfo, PlanElement, ScenarioSource}
 
 class MatsimScenarioSource(val scenarioFolder: String, val rdr: MatsimScenarioReader) extends ScenarioSource {
 
@@ -12,7 +12,7 @@ class MatsimScenarioSource(val scenarioFolder: String, val rdr: MatsimScenarioRe
   override def getPersons: Iterable[PersonInfo] = {
     rdr.readPersonsFile(personFilePath)
   }
-  override def getPlans: Iterable[PlanInfo] = {
+  override def getPlans: Iterable[PlanElement] = {
     rdr.readPlansFile(planFilePath)
   }
   override def getHousehold: Iterable[HouseholdInfo] = {

--- a/src/main/scala/beam/utils/scenario/urbansim/CsvScenarioReader.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/CsvScenarioReader.scala
@@ -51,8 +51,8 @@ object CsvScenarioReader extends UrbanSimScenarioReader with LazyLogging {
     readAs[PersonInfo](path, "readPersonsFile", toPersonInfo)
   }
 
-  def readPlansFile(path: String): Array[PlanInfo] = {
-    readAs[PlanInfo](path, "readPlansFile", toPlanInfo)
+  def readPlansFile(path: String): Array[PlanElement] = {
+    readAs[PlanElement](path, "readPlansFile", toPlanInfo)
   }
 
   def readHouseholdsFile(path: String): Array[HouseholdInfo] = {
@@ -79,18 +79,20 @@ object CsvScenarioReader extends UrbanSimScenarioReader with LazyLogging {
     HouseholdInfo(householdId = householdId, cars = cars, income = income, unitId = unitId, buildingId = buildingId)
   }
 
-  private def toPlanInfo(rec: java.util.Map[String, String]): PlanInfo = {
+  private def toPlanInfo(rec: java.util.Map[String, String]): PlanElement = {
     // Somehow Plan file has columns in camelCase, not snake_case
     val personId = getIfNotNull(rec, "personId")
     val planElement = getIfNotNull(rec, "planElement")
+    val planElementIndex = getIfNotNull(rec, "planElementIndex").toInt
     val activityType = Option(rec.get("activityType"))
     val x = Option(rec.get("x")).map(_.toDouble)
     val y = Option(rec.get("y")).map(_.toDouble)
     val endTime = Option(rec.get("endTime")).map(_.toDouble)
     val mode = Option(rec.get("mode")).map(_.toString)
-    PlanInfo(
+    PlanElement(
       personId = personId,
       planElement = planElement,
+      planElementIndex = planElementIndex,
       activityType = activityType,
       x = x,
       y = y,

--- a/src/main/scala/beam/utils/scenario/urbansim/DataExchange.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/DataExchange.scala
@@ -9,9 +9,10 @@ private[urbansim] object DataExchange {
 
   case class PersonInfo(personId: String, householdId: String, rank: Int, age: Int)
 
-  case class PlanInfo(
+  case class PlanElement(
     personId: String,
     planElement: String,
+    planElementIndex: Int,
     activityType: Option[String],
     x: Option[Double],
     y: Option[Double],

--- a/src/main/scala/beam/utils/scenario/urbansim/ParquetScenarioReader.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/ParquetScenarioReader.scala
@@ -15,8 +15,8 @@ object ParquetScenarioReader extends UrbanSimScenarioReader with LazyLogging {
     //    readParcelAttrFile("C:\\repos\\apache_arrow\\py_arrow\\data\\parcel_attr.parquet").take(3).foreach(println)
     //    readBuildingsFile("C:\\repos\\apache_arrow\\py_arrow\\data\\buildings.parquet").take(3).foreach(println)
     //    readPersonsFile("C:\\repos\\apache_arrow\\py_arrow\\data\\persons.parquet").take(3).foreach(println)
-    readPlansFile("C:\\repos\\apache_arrow\\py_arrow\\data\\plans.parquet").take(3).foreach(println)
-    readHouseholdsFile("C:\\repos\\apache_arrow\\py_arrow\\data\\households.parquet").take(3).foreach(println)
+    readPlansFile("""C:\temp\2010\plans.parquet""").take(3).foreach(println)
+    // readHouseholdsFile("C:\\repos\\apache_arrow\\py_arrow\\data\\households.parquet").take(3).foreach(println)
   }
 
   def inputType: InputType = InputType.Parquet
@@ -37,8 +37,8 @@ object ParquetScenarioReader extends UrbanSimScenarioReader with LazyLogging {
     readAs[PersonInfo](path, "readPersonsFile", toPersonInfo)
   }
 
-  def readPlansFile(path: String): Array[PlanInfo] = {
-    readAs[PlanInfo](path, "readPlansFile", toPlanInfo)
+  def readPlansFile(path: String): Array[PlanElement] = {
+    readAs[PlanElement](path, "readPlansFile", toPlanInfo)
   }
 
   def readHouseholdsFile(path: String): Array[HouseholdInfo] = {
@@ -67,19 +67,21 @@ object ParquetScenarioReader extends UrbanSimScenarioReader with LazyLogging {
     HouseholdInfo(householdId = householdId, cars = cars, income = income, unitId = unitId, buildingId = buildingId)
   }
 
-  private[scenario] def toPlanInfo(rec: GenericRecord): PlanInfo = {
+  private[scenario] def toPlanInfo(rec: GenericRecord): PlanElement = {
     // Somehow Plan file has columns in camelCase, not snake_case
     val personId = getIfNotNull(rec, "personId").toString
     val planElement = getIfNotNull(rec, "planElement").toString
+    val planElementIndex = getIfNotNull(rec, "planElementIndex").asInstanceOf[Long].toInt
     val activityType = Option(rec.get("activityType")).map(_.toString)
     val x = Option(rec.get("x")).map(_.asInstanceOf[Double])
     val y = Option(rec.get("y")).map(_.asInstanceOf[Double])
     val endTime = Option(rec.get("endTime")).map(_.asInstanceOf[Double])
     val mode = Option(rec.get("mode")).map(_.toString)
 
-    PlanInfo(
+    PlanElement(
       personId = personId,
       planElement = planElement,
+      planElementIndex = planElementIndex,
       activityType = activityType,
       x = x,
       y = y,

--- a/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioReader.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioReader.scala
@@ -9,7 +9,7 @@ trait UrbanSimScenarioReader {
   def readParcelAttrFile(path: String): Array[ParcelAttribute]
   def readBuildingsFile(path: String): Array[BuildingInfo]
   def readPersonsFile(path: String): Array[PersonInfo]
-  def readPlansFile(path: String): Array[PlanInfo]
+  def readPlansFile(path: String): Array[PlanElement]
   def readHouseholdsFile(path: String): Array[HouseholdInfo]
 }
 

--- a/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioSource.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioSource.scala
@@ -40,8 +40,14 @@ class UrbanSimScenarioSource(
       )
     }
   }
-  override def getPlans: Iterable[PlanInfo] = {
-    rdr.readPlansFile(planFilePath).map { plan =>
+  override def getPlans: Iterable[PlanElement] = {
+    val rawPlanElements = rdr.readPlansFile(planFilePath)
+    val planElements = dropCorruptedPlanElements(rawPlanElements)
+    logger.info(
+      s"$planFilePath contains ${rawPlanElements.size} planElement, after removing corrupted data: ${planElements.length}"
+    )
+
+    planElements.map { plan =>
       val coord = (plan.x, plan.y) match {
         case (Some(x), Some(y)) =>
           val c =
@@ -59,9 +65,10 @@ class UrbanSimScenarioSource(
         case _ =>
           None
       }
-      PlanInfo(
+      PlanElement(
         personId = PersonId(plan.personId),
         planElement = plan.planElement,
+        planElementIndex = plan.planElementIndex,
         activityType = plan.activityType,
         x = coord.map(_.getX),
         y = coord.map(_.getY),
@@ -139,5 +146,18 @@ class UrbanSimScenarioSource(
         }
         unitId -> coord
     }.seq
+  }
+
+  private def dropCorruptedPlanElements(rawPlans: Array[DataExchange.PlanElement]): Array[DataExchange.PlanElement] = {
+    val correctPlanElements = rawPlans
+      .groupBy(x => x.personId)
+      .filter {
+        case (k, v) =>
+          val isCorrupted = v.exists(x => x.planElementIndex == 1 && x.endTime.isEmpty)
+          !isCorrupted
+      }
+      .flatMap { case (k, v) => v.sortBy(x => x.planElementIndex) }
+      .toArray
+    correctPlanElements
   }
 }

--- a/src/test/scala/beam/utils/scenario/urbansim/ParquetScenarioReaderTest.scala
+++ b/src/test/scala/beam/utils/scenario/urbansim/ParquetScenarioReaderTest.scala
@@ -67,18 +67,20 @@ class ParquetScenarioReaderTest extends WordSpec with Matchers with MockitoSugar
     "be able to create PlanInfo from GenericRecord" in {
       val gr = new GenericRecordMock(
         Map(
-          "personId"    -> "1".asInstanceOf[AnyRef],
-          "planElement" -> "leg".asInstanceOf[AnyRef],
-          "x"           -> 2.0.asInstanceOf[AnyRef],
-          "y"           -> 3.0.asInstanceOf[AnyRef],
-          "endTime"     -> 4.0.asInstanceOf[AnyRef],
-          "mode"        -> "mode".asInstanceOf[AnyRef],
+          "personId"         -> "1".asInstanceOf[AnyRef],
+          "planElement"      -> "leg".asInstanceOf[AnyRef],
+          "planElementIndex" -> 1L.asInstanceOf[AnyRef],
+          "x"                -> 2.0.asInstanceOf[AnyRef],
+          "y"                -> 3.0.asInstanceOf[AnyRef],
+          "endTime"          -> 4.0.asInstanceOf[AnyRef],
+          "mode"             -> "mode".asInstanceOf[AnyRef],
         ).asJava
       )
       ParquetScenarioReader.toPlanInfo(gr) should be(
-        PlanInfo(
+        PlanElement(
           personId = "1",
           planElement = "leg",
+          planElementIndex = 1,
           activityType = None,
           x = Some(2.0),
           y = Some(3.0),


### PR DESCRIPTION
- Renamed `PlanInfo` to `PlanElement`
- Drop planElements which are corrupted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1608)
<!-- Reviewable:end -->
