### PR TITLE
Include all modes in excerpt skims

### DIFF
--- a/src/main/scala/beam/router/BeamSkimmer.scala
+++ b/src/main/scala/beam/router/BeamSkimmer.scala
@@ -258,8 +258,11 @@ class BeamSkimmer @Inject()(val beamConfig: BeamConfig, val beamServices: BeamSe
     ProfilingUtils.timed(s"writeObservedSkims on iteration ${event.getIteration}", x => logger.info(x)) {
       writeObservedSkims(event)
     }
-    ProfilingUtils.timed(s"writeCarSkimsForPeakNonPeakPeriods on iteration ${event.getIteration}", x => logger.info(x)) {
-      writeCarSkimsForPeakNonPeakPeriods(event)
+    ProfilingUtils.timed(
+      s"writeAllModeSkimsForPeakNonPeakPeriods on iteration ${event.getIteration}",
+      x => logger.info(x)
+    ) {
+      writeAllModeSkimsForPeakNonPeakPeriods(event)
     }
     // Writing full skims are very large, but code is preserved here in case we want to enable it.
     // TODO make this a configurable output "writeFullSkimsInterval" with default of 0
@@ -274,7 +277,7 @@ class BeamSkimmer @Inject()(val beamConfig: BeamConfig, val beamServices: BeamSe
     hoursIncluded: List[Int],
     origin: TAZ,
     destination: TAZ,
-    mode: BeamMode.CAR.type,
+    mode: BeamMode,
     get: BeamServices,
     dummyId: Id[BeamVehicleType],
     writer: BufferedWriter
@@ -323,11 +326,11 @@ class BeamSkimmer @Inject()(val beamConfig: BeamConfig, val beamServices: BeamSe
     )
   }
 
-  def writeCarSkimsForPeakNonPeakPeriods(event: IterationEndsEvent): Unit = {
+  def writeAllModeSkimsForPeakNonPeakPeriods(event: IterationEndsEvent): Unit = {
     val morningPeakHours = (7 to 8).toList
     val afternoonPeakHours = (15 to 16).toList
     val nonPeakHours = (0 to 6).toList ++ (9 to 14).toList ++ (17 to 23).toList
-    val modes = List(CAR)
+    val modes = BeamMode.allModes
     val fileHeader =
       "period,mode,origTaz,destTaz,travelTimeInS,generalizedTimeInS,cost,generalizedCost,distanceInM,numObservations,energy"
     val filePath = event.getServices.getControlerIO.getIterationFilename(


### PR DESCRIPTION
AllModes (Prepare data in parallel):
01:39:50.021 INFO  beam.router.BeamSkimmer - Get weightedSkims for modes executed in 35092 ms
01:39:50.021 INFO  beam.router.BeamSkimmer - weightedSkims size: 22394880
01:41:21.614 INFO  beam.router.BeamSkimmer - writeAllModeSkimsForPeakNonPeakPeriods on iteration 0 executed in 126686 ms

AllModes (Single thread):
00:28:58.692 INFO  beam.router.BeamSkimmer - writeAllModeSkimsForPeakNonPeakPeriods on iteration 0 executed in 243807 ms, compressed size: 188 MBytes 

Only CAR mode:
00:33:56.431 INFO  beam.router.BeamSkimmer - writeCarSkimsForPeakNonPeakPeriods on iteration 0 executed in 26972 ms, complressed size: 26.0 MB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1725)
<!-- Reviewable:end -->
