### PR TITLE
Write csv and plot to compare euclidean vs. length attribute plot #1697

### DIFF
--- a/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
+++ b/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
@@ -257,11 +257,12 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
 
         BufferedWriter writerObservedVsSimulated = IOUtils.getBufferedWriter(pathToCsv);
 
-        writerObservedVsSimulated.write("euclidean,length\n");
+        writerObservedVsSimulated.write("linkid,euclidean,length\n");
 
         for (Link link : jdeqSimScenario.getNetwork().getLinks().values()) {
             writerObservedVsSimulated.write(
-                    String.format("%f,%f\n",
+                    String.format("%s,%f,%f\n",
+                            link.getId().toString(),
                             CoordUtils.calcEuclideanDistance(
                                     link.getFromNode().getCoord(),
                                     link.getToNode().getCoord()


### PR DESCRIPTION
Write csv and plot to compare euclidean vs. length attribute plot for
matsim network #1697

![0 EuclideanVsLengthAttributePlot](https://user-images.githubusercontent.com/48454797/56828691-26e2eb00-6862-11e9-92c8-d7ddc5dcbda5.png)

csv example:
```
euclidean,length
75.251034,75.065000
75.251034,75.065000
146.482438,146.110000
25.642816,26.915000
12.238537,12.260000
3.537632,3.542000
3.537632,3.542000
3.511446,3.516000
3.511446,3.516000
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1754)
<!-- Reviewable:end -->
