### PR TITLE
Memory optimizations for events writers (CSV, XML)

### DIFF
--- a/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
+++ b/src/main/java/beam/agentsim/events/handling/BeamEventsLogger.java
@@ -87,7 +87,7 @@ class BeamEventsLogger {
     }
 
     Set<String> getKeysToWrite(Event event, Map<String, String> eventAttributes) {
-        return new HashSet<>(eventAttributes.keySet());
+        return eventAttributes.keySet();
     }
 
     /**

--- a/src/main/scala/beam/agentsim/events/PathTraversalEvent.scala
+++ b/src/main/scala/beam/agentsim/events/PathTraversalEvent.scala
@@ -1,6 +1,7 @@
 package beam.agentsim.events
 
 import java.util
+import java.util.concurrent.atomic.AtomicReference
 
 import beam.agentsim.agents.vehicles.BeamVehicleType
 import beam.router.Modes.BeamMode
@@ -54,34 +55,39 @@ case class PathTraversalEvent(
 
   override def getEventType: String = "PathTraversal"
 
+  private val filledAttrs: AtomicReference[util.Map[String, String]] =
+    new AtomicReference[util.Map[String, String]](null)
+
   override def getAttributes: util.Map[String, String] = {
-    val attr = super.getAttributes()
-    attr.put(ATTRIBUTE_VEHICLE_ID, vehicleId.toString)
-    attr.put(ATTRIBUTE_DRIVER_ID, driverId)
-    attr.put(ATTRIBUTE_VEHICLE_TYPE, vehicleType)
-    attr.put(ATTRIBUTE_LENGTH, legLength.toString)
-    attr.put(ATTRIBUTE_NUM_PASS, numberOfPassengers.toString)
+    if (filledAttrs.get() != null) filledAttrs.get()
+    else {
+      val attr = super.getAttributes()
+      attr.put(ATTRIBUTE_VEHICLE_ID, vehicleId.toString)
+      attr.put(ATTRIBUTE_DRIVER_ID, driverId)
+      attr.put(ATTRIBUTE_VEHICLE_TYPE, vehicleType)
+      attr.put(ATTRIBUTE_LENGTH, legLength.toString)
+      attr.put(ATTRIBUTE_NUM_PASS, numberOfPassengers.toString)
 
-    attr.put(ATTRIBUTE_DEPARTURE_TIME, departureTime.toString)
-    attr.put(ATTRIBUTE_ARRIVAL_TIME, arrivalTime.toString)
-    attr.put(ATTRIBUTE_MODE, mode.value)
-    attr.put(ATTRIBUTE_LINK_IDS, linkIds.mkString(","))
-    attr.put(ATTRIBUTE_LINK_TRAVEL_TIME, linkTravelTime.mkString(","))
-    attr.put(ATTRIBUTE_PRIMARY_FUEL_TYPE, primaryFuelType)
-    attr.put(ATTRIBUTE_SECONDARY_FUEL_TYPE, secondaryFuelType)
-    attr.put(ATTRIBUTE_PRIMARY_FUEL, primaryFuelConsumed.toString)
-    attr.put(ATTRIBUTE_SECONDARY_FUEL, secondaryFuelConsumed.toString)
-    attr.put(ATTRIBUTE_VEHICLE_CAPACITY, capacity.toString)
+      attr.put(ATTRIBUTE_DEPARTURE_TIME, departureTime.toString)
+      attr.put(ATTRIBUTE_ARRIVAL_TIME, arrivalTime.toString)
+      attr.put(ATTRIBUTE_MODE, mode.value)
+      attr.put(ATTRIBUTE_LINK_IDS, linkIds.mkString(","))
+      attr.put(ATTRIBUTE_LINK_TRAVEL_TIME, linkTravelTime.mkString(","))
+      attr.put(ATTRIBUTE_PRIMARY_FUEL_TYPE, primaryFuelType)
+      attr.put(ATTRIBUTE_SECONDARY_FUEL_TYPE, secondaryFuelType)
+      attr.put(ATTRIBUTE_PRIMARY_FUEL, primaryFuelConsumed.toString)
+      attr.put(ATTRIBUTE_SECONDARY_FUEL, secondaryFuelConsumed.toString)
+      attr.put(ATTRIBUTE_VEHICLE_CAPACITY, capacity.toString)
 
-    attr.put(ATTRIBUTE_START_COORDINATE_X, startX.toString)
-    attr.put(ATTRIBUTE_START_COORDINATE_Y, startY.toString)
-    attr.put(ATTRIBUTE_END_COORDINATE_X, endX.toString)
-    attr.put(ATTRIBUTE_END_COORDINATE_Y, endY.toString)
-    attr.put(ATTRIBUTE_END_LEG_PRIMARY_FUEL_LEVEL, endLegPrimaryFuelLevel.toString)
-    attr.put(ATTRIBUTE_END_LEG_SECONDARY_FUEL_LEVEL, endLegSecondaryFuelLevel.toString)
-    attr.put(ATTRIBUTE_SEATING_CAPACITY, seatingCapacity.toString)
-    attr.put(ATTRIBUTE_TOLL_PAID, amountPaid.toString)
-    /*
+      attr.put(ATTRIBUTE_START_COORDINATE_X, startX.toString)
+      attr.put(ATTRIBUTE_START_COORDINATE_Y, startY.toString)
+      attr.put(ATTRIBUTE_END_COORDINATE_X, endX.toString)
+      attr.put(ATTRIBUTE_END_COORDINATE_Y, endY.toString)
+      attr.put(ATTRIBUTE_END_LEG_PRIMARY_FUEL_LEVEL, endLegPrimaryFuelLevel.toString)
+      attr.put(ATTRIBUTE_END_LEG_SECONDARY_FUEL_LEVEL, endLegSecondaryFuelLevel.toString)
+      attr.put(ATTRIBUTE_SEATING_CAPACITY, seatingCapacity.toString)
+      attr.put(ATTRIBUTE_TOLL_PAID, amountPaid.toString)
+      /*
     attr.put(ATTRIBUTE_LINKID_WITH_LANE_MAP, linkIdsToLaneOptions.map{case ((linkId, laneOption)) => s"$linkId:${laneOption.getOrElse(0)}"}.mkString(","))
     attr.put(ATTRIBUTE_LINKID_WITH_SPEED_MAP, linkIdsToSpeedOptions.map{case ((linkId, speedOption)) => s"$linkId:${speedOption.getOrElse(0)}"}.mkString(","))
     attr.put(ATTRIBUTE_LINKID_WITH_SELECTED_GRADIENT_MAP, linkIdsToGradientOptions.map{case ((linkId, gradientOption)) => s"$linkId:${gradientOption.getOrElse(0)}"}.mkString(","))
@@ -90,9 +96,10 @@ case class PathTraversalEvent(
     attr.put(ATTRIBUTE_LINKID_WITH_FINAL_CONSUMPTION_MAP, linkIdsToConsumptionOptions.map{case ((linkId, consumptionOption)) => s"$linkId:${consumptionOption.getOrElse(0)}"}.mkString(","))
     attr.put(ATTRIBUTE_SECONDARY_LINKID_WITH_SELECTED_RATE_MAP, secondaryLinkIdsToSelectedRateOptions.map{case ((linkId, rateOption)) => s"$linkId:${rateOption.getOrElse(0)}"}.mkString(","))
     attr.put(ATTRIBUTE_SECONDARY_LINKID_WITH_FINAL_CONSUMPTION_MAP, secondaryLinkIdsToConsumptionOptions.map{case ((linkId, consumptionOption)) => s"$linkId:${consumptionOption.getOrElse(0)}"}.mkString(","))
-     */
-
-    attr
+       */
+      filledAttrs.set(attr)
+      attr
+    }
   }
 }
 

--- a/src/main/scala/beam/agentsim/events/handling/BeamEventsWriterXML.scala
+++ b/src/main/scala/beam/agentsim/events/handling/BeamEventsWriterXML.scala
@@ -1,12 +1,7 @@
 package beam.agentsim.events.handling
 
-import java.io.IOException
-
 import beam.sim.BeamServices
 import org.matsim.api.core.v01.events.Event
-import org.matsim.core.utils.io.UncheckedIOException
-
-import scala.collection.JavaConverters._
 
 /**
   * @author Bhavya Latha Bandaru.
@@ -23,75 +18,64 @@ class BeamEventsWriterXML(
   eventTypeToLog: Class[_]
 ) extends BeamEventsWriterBase(outFileName, beamEventLogger, beamServices, eventTypeToLog) {
 
-  val specialChars: Array[Char] = Array('<', '>', '\"', '&')
+  val specialCharToEscape: Map[Char, String] = Map('<' -> "&lt;", '>' -> "&gt;", '"' -> "&quot;", '&' -> "&amp;")
+  val specialChars: Array[Char] = specialCharToEscape.keys.toArray
+
+  val header: String =
+    """<?xml version="1.0" encoding="utf-8"?>
+<events version="1.0">""".stripMargin
 
   writeHeaders()
 
   /**
     * Writes the events to the xml file.
+    *
     * @param event event to written
     */
   override protected def writeEvent(event: Event): Unit = {
     //get all the event attributes
-    try {
-      val keyValues = event.getAttributes.asScala map { keyValue =>
-        //for each attribute, encode the values for special characters (if any) and append them to the event xml tag.
-        val encodedString = encodeAttributeValue(keyValue._2)
-        keyValue._1 + "=\"" + encodedString + "\" "
-      }
-      //write the event tag to the xml file
-      val eventElem = s"\t<event ${keyValues.mkString(" ")}/>\n"
-      this.outWriter.append(eventElem)
-    } catch {
-      case e: Exception =>
-        throw e
-    }
+    outWriter.append("\t<event ")
+    event.getAttributes.forEach((name, value) => {
+      outWriter.append(name)
+      outWriter.append("=\"")
+      outWriter.append(encodeAttributeValue(value))
+      outWriter.append("\" ")
+    })
+    outWriter.append("/>")
+    outWriter.newLine()
   }
 
   /**
     * Adds the xml header to the file.
     */
   override protected def writeHeaders(): Unit = {
-    val header =
-      """<?xml version="1.0" encoding="utf-8"?>
-<events version="1.0">""".stripMargin
-    try {
-      this.outWriter.write(header)
-      this.outWriter.write("\n")
-    } catch {
-      case e: IOException =>
-        throw new UncheckedIOException(e)
-    }
+    outWriter.write(header)
+    outWriter.newLine()
   }
 
   /**
     * Appends the footer and closes the file stream.
     */
   override def closeFile(): Unit = {
-    try {
-      this.outWriter.write("</events>")
-      this.outWriter.close()
-    } catch {
-      case e: IOException =>
-        throw new UncheckedIOException(e)
-    }
+    outWriter.write("</events>")
+    outWriter.close()
   }
 
   /**
     * Encodes any special character encountered in the xml attribute value.
+    *
     * @param attributeValue xml attribute value
     * @return encoded attribute value
     */
   private def encodeAttributeValue(attributeValue: String): String = {
-    // Replace special characters(if any) with encoded strings
-    attributeValue.find(specialChars.contains(_)) match {
-      case Some(_) =>
-        attributeValue
-          .replaceAll("<", "&lt;")
-          .replaceAll(">", "&gt;")
-          .replaceAll("\"", "&quot;")
-          .replaceAll("&", "&amp;")
-      case None => attributeValue
+    var i: Int = 0
+    var result = attributeValue
+    while (i < specialChars.length) {
+      val char = specialChars(i)
+      if (result.indexOf(char) >= 0)
+        result = result.replace(char.toString, specialCharToEscape(char))
+      i += 1
     }
+    result
   }
 }


### PR DESCRIPTION
- Safe previously created attributes in `PathTraversalEvent`
- Memory optimization for XML event writer
- Do not allocate extra HashSet, map already contains keys as Set `keySet`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1755)
<!-- Reviewable:end -->
