### PR TITLE
Startup message logged twice 4ci - fixed

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -647,7 +647,7 @@ trait BeamHelper extends LazyLogging {
         scenarioFolder = beamConfig.beam.exchange.scenario.folder,
         rdr = beam.utils.scenario.matsim.CsvScenarioReader
       )
-    } else throw new NotImplementedError(s"ScenarioSource '${src}' is not yet implemented")
+    } else throw new NotImplementedError(s"ScenarioSource '$src' is not yet implemented")
   }
 }
 

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -51,7 +51,7 @@ import scala.concurrent.Await
 
 trait BeamHelper extends LazyLogging {
 
-  val beamAsciiArt: String =
+  protected val beamAsciiArt: String =
     """
     |  ________
     |  ___  __ )__________ _______ ___
@@ -482,9 +482,6 @@ trait BeamHelper extends LazyLogging {
     matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
 
     ReflectionUtils.setFinalField(classOf[StreetLayer], "LINK_RADIUS_METERS", 2000.0)
-
-    logger.info(beamAsciiArt)
-    logger.info(ConfigConsistencyComparator.logStringBuilder.toString())
 
     matsimConfig.controler.setOutputDirectory(outputDirectory)
     matsimConfig.controler().setWritePlansInterval(beamConfig.beam.outputs.writePlansInterval)

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -617,7 +617,7 @@ trait BeamHelper extends LazyLogging {
         vehicleId => beamServices.privateVehicles.get(vehicleId).map(_.beamVehicleType.id.toString).getOrElse("")
       )
       .map {
-        case (vehicleType, vehicleIds) => s"$vehicleType (${vehicleIds.size})"
+        case (vehicleType, ids) => s"$vehicleType (${ids.size})"
       }
       .mkString(" , ")
   }

--- a/src/main/scala/beam/utils/ConfigConsistencyComparator.scala
+++ b/src/main/scala/beam/utils/ConfigConsistencyComparator.scala
@@ -20,7 +20,7 @@ object ConfigConsistencyComparator extends LazyLogging {
   private val bottom = sessionSeparator + eol
   private val consistentFileMessage = buildTopicTile("All good, your config file is fully consistent!")
 
-  val logStringBuilder = new StringBuilder(top)
+  private val logStringBuilder = new StringBuilder(top)
 
   private val ignorePaths: Set[String] = Set("beam.physsim.inputNetworkFilePath")
 
@@ -97,7 +97,7 @@ object ConfigConsistencyComparator extends LazyLogging {
     buildTopicTile(title) + buildStringFromKeys(keys)
   }
 
-  def buildTopicTile(title: String): String = {
+  private def buildTopicTile(title: String): String = {
     s"""$borderLeft
        |$topicBorderLeft$title
        |""".stripMargin


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1765)
<!-- Reviewable:end -->

Both: startup message and config consistency validator are logged twice when application starts:
```
  ________
  ___  __ )__________ _______ ___
  __  __  |  _ \  __ `/_  __ `__ \
  _  /_/ //  __/ /_/ /_  / / / / /
  /_____/ \___/\__,_/ /_/ /_/ /_/

 _____________________________________
****************************************************************************************************************************  
** Config File Consistency Check
**  
** Testing your config file against what BEAM is expecting.
**  
** Found the following deprecated parameters, you can safely remove them from your config file:
...
```