### PR TITLE
Avoid scenario loaded twice 4ci

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -72,7 +72,7 @@ trait BeamHelper extends LazyLogging {
           args.copy(
             config = Some(BeamConfigUtils.parseFileSubstitutingInputDirectory(value)),
             configLocation = Option(value)
-          )
+        )
       )
       .validate(
         value =>
@@ -86,7 +86,7 @@ trait BeamHelper extends LazyLogging {
           args.copy(clusterType = value.trim.toLowerCase match {
             case "master" => Some(Master)
             case "worker" => Some(Worker)
-            case _ => None
+            case _        => None
           })
       )
       .text("If running as a cluster, specify master or worker")
@@ -133,15 +133,15 @@ trait BeamHelper extends LazyLogging {
   ): TypesafeConfig = {
     (for {
       seedAddress <- parsedArgs.seedAddress
-      nodeHost <- parsedArgs.nodeHost
-      nodePort <- parsedArgs.nodePort
+      nodeHost    <- parsedArgs.nodeHost
+      nodePort    <- parsedArgs.nodePort
     } yield {
       config.withFallback(
         ConfigFactory.parseMap(
           Map(
             "seed.address" -> seedAddress,
-            "node.host" -> nodeHost,
-            "node.port" -> nodePort
+            "node.host"    -> nodeHost,
+            "node.port"    -> nodePort
           ).asJava
         )
       )
@@ -163,16 +163,16 @@ trait BeamHelper extends LazyLogging {
           ) ++ {
             if (parsedArgs.useCluster)
               Map(
-                "beam.cluster.clusterType" -> parsedArgs.clusterType.get.toString,
-                "akka.actor.provider" -> "akka.cluster.ClusterActorRefProvider",
+                "beam.cluster.clusterType"              -> parsedArgs.clusterType.get.toString,
+                "akka.actor.provider"                   -> "akka.cluster.ClusterActorRefProvider",
                 "akka.remote.artery.canonical.hostname" -> parsedArgs.nodeHost.get,
-                "akka.remote.artery.canonical.port" -> parsedArgs.nodePort.get,
+                "akka.remote.artery.canonical.port"     -> parsedArgs.nodePort.get,
                 "akka.cluster.seed-nodes" -> java.util.Arrays
                   .asList(s"akka://ClusterSystem@${parsedArgs.seedAddress.get}")
               )
             else Map.empty[String, Any]
           }
-          ).asJava
+        ).asJava
       )
     )
   }
@@ -309,7 +309,7 @@ trait BeamHelper extends LazyLogging {
     props.store(out, "Simulation out put props.")
     val beamConfig = BeamConfig(config)
     if (beamConfig.beam.agentsim.agents.modalBehaviors.modeChoiceClass
-      .equalsIgnoreCase("ModeChoiceLCCM")) {
+          .equalsIgnoreCase("ModeChoiceLCCM")) {
       Files.copy(
         Paths.get(beamConfig.beam.agentsim.agents.modalBehaviors.lccm.filePath),
         Paths.get(
@@ -416,13 +416,21 @@ trait BeamHelper extends LazyLogging {
     (scenario.getConfig, outputDir)
   }
 
-  protected def buildScenarioFromMatsimConfig(matsimConfig: Config, networkCoordinator: NetworkCoordinator): MutableScenario = {
+  protected def buildScenarioFromMatsimConfig(
+    matsimConfig: Config,
+    networkCoordinator: NetworkCoordinator
+  ): MutableScenario = {
     val result = ScenarioUtils.loadScenario(matsimConfig).asInstanceOf[MutableScenario]
     result.setNetwork(networkCoordinator.network)
     result
   }
 
-  def buildBeamServices(injector: inject.Injector, scenario: MutableScenario, matsimConfig: Config, networkCoordinator: NetworkCoordinator): BeamServices = {
+  def buildBeamServices(
+    injector: inject.Injector,
+    scenario: MutableScenario,
+    matsimConfig: Config,
+    networkCoordinator: NetworkCoordinator
+  ): BeamServices = {
     val result = injector.getInstance(classOf[BeamServices])
     result.setTransitFleetSizes(networkCoordinator.tripFleetSizeMap)
 
@@ -431,7 +439,11 @@ trait BeamHelper extends LazyLogging {
     result
   }
 
-  protected def buildInjector(config: TypesafeConfig, scenario: MutableScenario, networkCoordinator: NetworkCoordinator): inject.Injector = {
+  protected def buildInjector(
+    config: TypesafeConfig,
+    scenario: MutableScenario,
+    networkCoordinator: NetworkCoordinator
+  ): inject.Injector = {
     val networkHelper: NetworkHelper = new NetworkHelperImpl(networkCoordinator.network)
     org.matsim.core.controler.Injector.createInjector(
       scenario.getConfig,
@@ -440,11 +452,11 @@ trait BeamHelper extends LazyLogging {
   }
 
   def runBeam(
-      beamServices: BeamServices,
-      scenario: MutableScenario,
-      networkCoordinator: NetworkCoordinator,
-      outputDir: String
-    ): Unit = {
+    beamServices: BeamServices,
+    scenario: MutableScenario,
+    networkCoordinator: NetworkCoordinator,
+    outputDir: String
+  ): Unit = {
     networkCoordinator.convertFrequenciesToTrips()
 
     samplePopulation(scenario, beamServices.beamConfig, scenario.getConfig, beamServices, outputDir)
@@ -466,7 +478,12 @@ trait BeamHelper extends LazyLogging {
     run(beamServices)
   }
 
-  private def fillScenarioFromExternalSources2(injector: inject.Injector, matsimConfig: Config, networkCoordinator: NetworkCoordinator, beamServices: BeamServices): Scenario = {
+  private def fillScenarioFromExternalSources2(
+    injector: inject.Injector,
+    matsimConfig: Config,
+    networkCoordinator: NetworkCoordinator,
+    beamServices: BeamServices
+  ): Scenario = {
     val beamConfig = beamServices.beamConfig
     val useExternalDataForScenario: Boolean =
       Option(beamConfig.beam.exchange.scenario.folder).exists(!_.isEmpty)
@@ -483,8 +500,9 @@ trait BeamHelper extends LazyLogging {
     }
   }
 
-
-  def setupBeamWithConfig(config: TypesafeConfig): (BeamConfig, org.matsim.core.config.Config, String, NetworkCoordinator) = {
+  def setupBeamWithConfig(
+    config: TypesafeConfig
+  ): (BeamConfig, org.matsim.core.config.Config, String, NetworkCoordinator) = {
     val beamConfig = BeamConfig(config)
     val outputDirectory = FileUtils.getConfigOutputFile(
       beamConfig.beam.outputs.baseOutputDirectory,
@@ -558,12 +576,12 @@ trait BeamHelper extends LazyLogging {
 
   // sample population (beamConfig.beam.agentsim.numAgents - round to nearest full household)
   def samplePopulation(
-                        scenario: MutableScenario,
-                        beamConfig: BeamConfig,
-                        matsimConfig: Config,
-                        beamServices: BeamServices,
-                        outputDir: String
-                      ): Unit = {
+    scenario: MutableScenario,
+    beamConfig: BeamConfig,
+    matsimConfig: Config,
+    beamServices: BeamServices,
+    outputDir: String
+  ): Unit = {
     if (beamConfig.beam.agentsim.agentSampleSizeAsFractionOfPopulation < 1) {
       val numAgents = math.round(
         beamConfig.beam.agentsim.agentSampleSizeAsFractionOfPopulation * scenario.getPopulation.getPersons.size()
@@ -673,7 +691,7 @@ trait BeamHelper extends LazyLogging {
           )
         )
       val scenarioReader = fileFormat match {
-        case InputType.CSV => CsvScenarioReader
+        case InputType.CSV     => CsvScenarioReader
         case InputType.Parquet => ParquetScenarioReader
       }
 

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -434,7 +434,7 @@ trait BeamHelper extends LazyLogging {
     val result = injector.getInstance(classOf[BeamServices])
     result.setTransitFleetSizes(networkCoordinator.tripFleetSizeMap)
 
-    fillScenarioFromExternalSources2(injector, matsimConfig, networkCoordinator, result)
+    fillScenarioFromExternalSources(injector, matsimConfig, networkCoordinator, result)
 
     result
   }
@@ -478,7 +478,7 @@ trait BeamHelper extends LazyLogging {
     run(beamServices)
   }
 
-  private def fillScenarioFromExternalSources2(
+  private def fillScenarioFromExternalSources(
     injector: inject.Injector,
     matsimConfig: Config,
     networkCoordinator: NetworkCoordinator,
@@ -516,9 +516,6 @@ trait BeamHelper extends LazyLogging {
     if (isMetricsEnable) Kamon.start(config.withFallback(ConfigFactory.defaultReference()))
 
     ReflectionUtils.setFinalField(classOf[StreetLayer], "LINK_RADIUS_METERS", 2000.0)
-
-//    matsimConfig.controler.setOutputDirectory(outputDirectory)
-//    matsimConfig.controler().setWritePlansInterval(beamConfig.beam.outputs.writePlansInterval)
 
     logger.info("Starting beam on branch {} at commit {}.", BashUtils.getBranch, BashUtils.getCommitHash)
 

--- a/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
@@ -152,7 +152,7 @@ class ScenarioLoader(
             .find(_.vehicleCategory == VehicleCategory.Bike)
             .getOrElse(BeamVehicleType.defaultBikeBeamVehicleType)
         )
-        initialVehicleCounter += householdInfo.cars.toInt
+        initialVehicleCounter += householdInfo.cars
         totalCarCount += vehicleTypes.count(_.vehicleCategory.toString == "Car")
         val vehicleIds = new java.util.ArrayList[Id[Vehicle]]
         vehicleTypes.foreach { beamVehicleType =>
@@ -182,8 +182,8 @@ class ScenarioLoader(
     beamServices.beamConfig.beam.agentsim.agents.vehicles.downsamplingMethod match {
       case "SECONDARY_VEHICLES_FIRST" =>
         val rand = new Random(beamServices.beamConfig.matsim.modules.global.randomSeed)
-        val hh_car_count = collection.mutable.Map(households.groupBy(_.cars.toInt).toSeq: _*)
-        val totalCars = households.foldLeft(0)(_ + _.cars.toInt)
+        val hh_car_count = collection.mutable.Map(households.groupBy(_.cars).toSeq: _*)
+        val totalCars = households.foldLeft(0)(_ + _.cars)
         val goalCarTotal = math
           .round(beamServices.beamConfig.beam.agentsim.agents.vehicles.fractionOfInitialVehicleFleet * totalCars)
           .toInt
@@ -217,7 +217,7 @@ class ScenarioLoader(
         households.foreach { household =>
           nVehiclesOut += drawFromBinomial(
             rand,
-            household.cars.toInt,
+            household.cars,
             beamServices.beamConfig.beam.agentsim.agents.vehicles.fractionOfInitialVehicleFleet
           )
         }

--- a/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoader.scala
@@ -57,12 +57,8 @@ class ScenarioLoader(
     applyHousehold(householdsWithMembers, householdIdToPersons)
     // beamServices.privateVehicles is properly populated here, after `applyHousehold` call
 
-    // We have to override personHouseholds because we just loaded new households
-    beamServices.personHouseholds = scenario.getHouseholds.getHouseholds
-      .values()
-      .asScala
-      .flatMap(h => h.getMemberIds.asScala.map(_ -> h))
-      .toMap
+    replacePersonHouseholdFromService()
+
     // beamServices.personHouseholds is used later on in PopulationAdjustment.createAttributesOfIndividual when we
     logger.info("Applying persons...")
     applyPersons(personsWithPlans)
@@ -71,6 +67,14 @@ class ScenarioLoader(
     applyPlans(plans)
 
     logger.info("The scenario loading is completed..")
+  }
+
+  private def replacePersonHouseholdFromService(): Unit = {
+    beamServices.personHouseholds = scenario.getHouseholds.getHouseholds
+      .values()
+      .asScala
+      .flatMap(h => h.getMemberIds.asScala.map(_ -> h))
+      .toMap
   }
 
   private def clear(): Unit = {

--- a/src/test/scala/beam/integration/EventsFileSpec.scala
+++ b/src/test/scala/beam/integration/EventsFileSpec.scala
@@ -29,18 +29,16 @@ class EventsFileSpec extends FlatSpec with BeforeAndAfterAll with Matchers with 
     .withValue("beam.routing.transitOnStreetNetwork", ConfigValueFactory.fromAnyRef("true"))
     .resolve()
 
-  private var matsimConfig: org.matsim.core.config.Config = _
   private var scenario: MutableScenario = _
-  private var networkCoordinator: NetworkCoordinator = _
   private var personHouseholds: Map[Id[Person], Household] = _
 
   override protected def beforeAll(): Unit = {
-    val stuff = setupBeamWithConfig(config)
-    matsimConfig = stuff._2
-    networkCoordinator = stuff._4
-    scenario = buildScenarioFromMatsimConfig(matsimConfig, networkCoordinator)
+    val beamExecConfig = setupBeamWithConfig(config)
+
+    val networkCoordinator = buildNetworkCoordinator(beamExecConfig.beamConfig)
+    scenario = buildScenarioFromMatsimConfig(beamExecConfig.matsimConfig, networkCoordinator)
     val injector = buildInjector(config, scenario, networkCoordinator)
-    val services = buildBeamServices(injector, scenario, matsimConfig, networkCoordinator)
+    val services = buildBeamServices(injector, scenario, beamExecConfig.matsimConfig, networkCoordinator)
     runBeam(services, scenario, networkCoordinator, scenario.getConfig.controler().getOutputDirectory)
     personHouseholds = scenario.getHouseholds.getHouseholds
       .values()

--- a/src/test/scala/beam/integration/EventsFileSpec.scala
+++ b/src/test/scala/beam/integration/EventsFileSpec.scala
@@ -29,15 +29,19 @@ class EventsFileSpec extends FlatSpec with BeforeAndAfterAll with Matchers with 
     .withValue("beam.routing.transitOnStreetNetwork", ConfigValueFactory.fromAnyRef("true"))
     .resolve()
 
+  private var matsimConfig: org.matsim.core.config.Config = _
   private var scenario: MutableScenario = _
   private var networkCoordinator: NetworkCoordinator = _
   private var personHouseholds: Map[Id[Person], Household] = _
 
   override protected def beforeAll(): Unit = {
     val stuff = setupBeamWithConfig(config)
-    scenario = stuff._1
-    networkCoordinator = stuff._3
-    runBeam(config, scenario, networkCoordinator, scenario.getConfig.controler().getOutputDirectory)
+    matsimConfig = stuff._2
+    networkCoordinator = stuff._4
+    scenario = buildScenarioFromMatsimConfig(matsimConfig, networkCoordinator)
+    val injector = buildInjector(config, scenario, networkCoordinator)
+    val services = buildBeamServices(injector, scenario, matsimConfig, networkCoordinator)
+    runBeam(services, scenario, networkCoordinator, scenario.getConfig.controler().getOutputDirectory)
     personHouseholds = scenario.getHouseholds.getHouseholds
       .values()
       .asScala


### PR DESCRIPTION
Ccaldas/#1753 a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1766)
<!-- Reviewable:end -->

Main changes:
- Warmstart was executed before loading specific configuration. 
- General refactoring: extracted methods and made things clear
- Script loaded twice: first Matsim config xml files are loaded and then the values are replaced by specific parameters (like Urbasim). This was not completely solved due to highly coupling but at least not is clear this behavior and some redundant steps were removed