### PR TITLE
Cumulative fixes

### DIFF
--- a/src/main/java/beam/analysis/physsim/PhyssimNetworkComparisonEuclideanVsLengthAttribute.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimNetworkComparisonEuclideanVsLengthAttribute.java
@@ -84,7 +84,7 @@ public class PhyssimNetworkComparisonEuclideanVsLengthAttribute {
                 "EuclideanVsLengthAttributePlot.png"
         );
 
-        XYSeries series = new XYSeries("Euclidean vs Length attribute");
+        XYSeries series = new XYSeries("Euclidean vs Length attribute", false);
 
         for (Link link : network.getLinks().values()) {
             series.add(

--- a/src/main/java/beam/physsim/jdeqsim/cacc/roadCapacityAdjustmentFunctions/Hao2018CaccRoadCapacityAdjustmentFunction.java
+++ b/src/main/java/beam/physsim/jdeqsim/cacc/roadCapacityAdjustmentFunctions/Hao2018CaccRoadCapacityAdjustmentFunction.java
@@ -185,7 +185,7 @@ class CaccRoadCapacityGraphs {
         int height = 600;
 
         XYSeriesCollection dataset = new XYSeriesCollection();
-        XYSeries series = new XYSeries("cacc");
+        XYSeries series = new XYSeries("cacc", false);
         caccCapacityIncrease.entries().forEach(e -> series.add(e.getKey(),e.getValue()));
         dataset.addSeries(series);
 

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -299,7 +299,10 @@ class RideHailManager(
     .asScala
     .flatMap { hh =>
       hh.getVehicleIds.asScala.map { vehId =>
-        beamServices.privateVehicles.get(vehId).get.beamVehicleType
+        beamServices.privateVehicles
+          .get(vehId)
+          .map(_.beamVehicleType)
+          .getOrElse(throw new IllegalStateException(s"$vehId is not found in `beamServices.privateVehicles`"))
       }
     }
     .filter(beamVehicleType => beamVehicleType.vehicleCategory == VehicleCategory.Car)

--- a/src/main/scala/beam/analysis/DelayMetricAnalysis.scala
+++ b/src/main/scala/beam/analysis/DelayMetricAnalysis.scala
@@ -119,7 +119,7 @@ class DelayMetricAnalysis @Inject()(
     util.Arrays.fill(cumulativeDelay, 0.0)
     util.Arrays.fill(cumulativeLength, 0.0)
     util.Arrays.fill(linkTravelsCount, 0)
-    linkAverageDelay = Array.ofDim[DelayInLength](networkHelper.maxLinkId)
+    linkAverageDelay = Array.ofDim[DelayInLength](networkHelper.maxLinkId + 1)
     capacitiesDelay.clear
     linkUtilization.clear()
     totalTravelTime = 0

--- a/src/main/scala/beam/router/BeamSkimmer.scala
+++ b/src/main/scala/beam/router/BeamSkimmer.scala
@@ -390,7 +390,7 @@ class BeamSkimmer @Inject()(val beamConfig: BeamConfig, val beamServices: BeamSe
     }
     logger.info(s"weightedSkims size: ${weightedSkims.size}")
 
-    weightedSkims.foreach { ws: ExcerptData =>
+    weightedSkims.seq.foreach { ws: ExcerptData =>
       writer.write(
         s"${ws.timePeriodString},${ws.mode},${ws.originTazId},${ws.destinationTazId},${ws.weightedTime},${ws.weightedGeneralizedTime},${ws.weightedCost},${ws.weightedGeneralizedCost},${ws.weightedDistance},${ws.sumWeights},${ws.weightedEnergy}\n"
       )

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -436,7 +436,7 @@ trait BeamHelper extends LazyLogging {
     val result = injector.getInstance(classOf[BeamServices])
     result.setTransitFleetSizes(networkCoordinator.tripFleetSizeMap)
 
-    fillScenarioFromExternalSources(injector, matsimConfig, networkCoordinator, result)
+    fillScenarioFromExternalSources(injector, scenario, matsimConfig, networkCoordinator, result)
 
     result
   }
@@ -482,23 +482,20 @@ trait BeamHelper extends LazyLogging {
 
   private def fillScenarioFromExternalSources(
     injector: inject.Injector,
+    matsimScenario: MutableScenario,
     matsimConfig: MatsimConfig,
     networkCoordinator: NetworkCoordinator,
     beamServices: BeamServices
-  ): Scenario = {
+  ): Unit = {
     val beamConfig = beamServices.beamConfig
     val useExternalDataForScenario: Boolean =
       Option(beamConfig.beam.exchange.scenario.folder).exists(!_.isEmpty)
-    val matsimScenario = buildScenarioFromMatsimConfig(matsimConfig, networkCoordinator)
 
     if (useExternalDataForScenario) {
       val scenarioSource: ScenarioSource = getScenarioSource2(injector, beamConfig)
       ProfilingUtils.timed(s"Load scenario using ${scenarioSource.getClass}", x => logger.info(x)) {
         new ScenarioLoader(matsimScenario, beamServices, scenarioSource).loadScenario()
-        matsimScenario
       }
-    } else {
-      matsimScenario
     }
   }
 


### PR DESCRIPTION
- Added timeout for RideHailManagerInit
- Make sure there is only one matsimScenario(`fillScenarioFromExternalSources` fills passed scenario, not creating new one)
- Fix java.lang.ArrayIndexOutOfBoundsException in beam.analysis.DelayMetricAnalysis.process 
- Fixed default `autoSort=true` when create `XYSeries`
- Fix high thread contention during the writing of the skims
![image](https://user-images.githubusercontent.com/5107562/57551284-db1c5f80-7392-11e9-9b72-2188923487c2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1798)
<!-- Reviewable:end -->
