### PR TITLE
RideHailManager: Bounding box big enough for initial location

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
@@ -23,10 +23,10 @@ class PoolingAlonsoMora(val rideHailManager: RideHailManager)
   val tempScheduleStore: mutable.Map[Int, List[MobilityRequest]] = mutable.Map()
 
   val spatialPoolCustomerReqs: QuadTree[CustomerRequest] = new QuadTree[CustomerRequest](
-    rideHailManager.quadTreeBounds.minx,
-    rideHailManager.quadTreeBounds.miny,
-    rideHailManager.quadTreeBounds.maxx,
-    rideHailManager.quadTreeBounds.maxy
+    rideHailManager.activityQuadTreeBounds.minx,
+    rideHailManager.activityQuadTreeBounds.miny,
+    rideHailManager.activityQuadTreeBounds.maxx,
+    rideHailManager.activityQuadTreeBounds.maxy
   )
 
   val defaultBeamVehilceTypeId = Id.create(

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -21,9 +21,11 @@ import beam.sim.metrics.MetricsSupport
 import beam.sim.monitoring.ErrorListener
 import beam.sim.vehiclesharing.Fleets
 import beam.utils._
+import beam.utils.matsim_conversion.ShapeUtils.QuadTreeBounds
 import com.conveyal.r5.transit.TransportNetwork
 import com.google.inject.Inject
 import com.typesafe.scalalogging.LazyLogging
+import org.matsim.api.core.v01.population.{Activity, Person, Population => MATSimPopulation}
 import org.matsim.api.core.v01.{Id, Scenario}
 import org.matsim.core.api.experimental.events.EventsManager
 import org.matsim.core.mobsim.framework.Mobsim
@@ -31,6 +33,7 @@ import org.matsim.core.utils.misc.Time
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.collection.JavaConverters._
 
 /**
   * AgentSim.
@@ -95,6 +98,13 @@ class BeamMobsim @Inject()(
           beamServices.geo.wgs2Utm(transportNetwork.streetLayer.envelope)
         envelopeInUTM.expandBy(beamServices.beamConfig.beam.spatial.boundingBoxBuffer)
 
+        val activityQuadTreeBounds: QuadTreeBounds = buildActivityQuadTreeBounds(scenario.getPopulation)
+        log.info(s"envelopeInUTM before expansion: $envelopeInUTM")
+
+        envelopeInUTM.expandToInclude(activityQuadTreeBounds.minx, activityQuadTreeBounds.miny)
+        envelopeInUTM.expandToInclude(activityQuadTreeBounds.maxx, activityQuadTreeBounds.maxy)
+        log.info(s"envelopeInUTM after expansion: $envelopeInUTM")
+
         private val parkingManager = context.actorOf(
           ZonalParkingManager
             .props(beamServices, beamServices.beamRouter),
@@ -115,6 +125,7 @@ class BeamMobsim @Inject()(
               beamServices.beamRouter,
               parkingManager,
               envelopeInUTM,
+              activityQuadTreeBounds,
               rideHailSurgePricingManager,
               rideHailIterationHistory.oscillationAdjustedTNCIterationStats,
               beamSkimmer,
@@ -259,6 +270,31 @@ class BeamMobsim @Inject()(
     endSegment("agentsim-events", "agentsim")
 
     logger.info("Processing Agentsim Events (End)")
+  }
+
+  def buildActivityQuadTreeBounds(population: MATSimPopulation): QuadTreeBounds = {
+    val persons = population.getPersons.values().asInstanceOf[java.util.Collection[Person]].asScala.view
+    val activities = persons.flatMap(p => p.getSelectedPlan.getPlanElements.asScala.view).collect {
+      case activity: Activity =>
+        activity
+    }
+    val coordinates = activities.map(_.getCoord)
+    // Force to compute xs and ys arrays
+    val xs = coordinates.map(_.getX).toArray
+    val ys = coordinates.map(_.getY).toArray
+    val xMin = xs.min
+    val xMax = xs.max
+    val yMin = ys.min
+    val yMax = ys.max
+    logger.info(
+      s"QuadTreeBounds with X: [$xMin; $xMax], Y: [$yMin, $yMax]. boundingBoxBuffer: ${beamServices.beamConfig.beam.spatial.boundingBoxBuffer}"
+    )
+    QuadTreeBounds(
+      xMin - beamServices.beamConfig.beam.spatial.boundingBoxBuffer,
+      yMin - beamServices.beamConfig.beam.spatial.boundingBoxBuffer,
+      xMax + beamServices.beamConfig.beam.spatial.boundingBoxBuffer,
+      yMax + beamServices.beamConfig.beam.spatial.boundingBoxBuffer
+    )
   }
 
 }


### PR DESCRIPTION
It should solve a problem when we try to use `UNIFORM_RANDOM` with `UrbanSim` data:
```
15:23:13.408 [ClusterSystem-akka.actor.default-dispatcher-24] ERROR b.a.agents.ridehail.RideHailManager - Could not createRideHailVehicleAndAgent: cannot add a point at x=667806.803402751, y=4109056.4709358355 with bounds topLeft: (442704.66790294164,4073548.042681266) bottomRight: (665356.5467613721,4313187.271314456)
java.lang.IllegalArgumentException: cannot add a point at x=667806.803402751, y=4109056.4709358355 with bounds topLeft: (442704.66790294164,4073548.042681266) bottomRight: (665356.5467613721,4313187.271314456)
	at org.matsim.core.utils.collections.QuadTree$Node.put(QuadTree.java:602)
	at org.matsim.core.utils.collections.QuadTree$Node.put(QuadTree.java:623)
	at org.matsim.core.utils.collections.QuadTree.put(QuadTree.java:87)
	at beam.agentsim.agents.ridehail.RideHailVehicleManager.putOutOfService(RideHailVehicleManager.scala:297)
	at beam.agentsim.agents.ridehail.RideHailManager.createRideHailVehicleAndAgent(RideHailManager.scala:1192)
	at beam.agentsim.agents.ridehail.RideHailManager.<init>(RideHailManager.scala:385)
	at beam.sim.BeamMobsim$$anon$1.$anonfun$rideHailManager$1(BeamMobsim.scala:122)
	at akka.actor.TypedCreatorFunctionConsumer.produce(IndirectActorProducer.scala:88)
	at akka.actor.Props.newActor(Props.scala:212)
	at akka.actor.ActorCell.newActor(ActorCell.scala:646)
	at akka.actor.ActorCell.create(ActorCell.scala:672)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:545)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:567)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:293)
	at akka.dispatch.Mailbox.run(Mailbox.scala:228)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:241)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```
Create `activityQuadTreeBounds` in `BeamMobsim` and use it to expand `envelopeInUTM`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1877)
<!-- Reviewable:end -->
