### PR TITLE
Let emergency parking be expensive, but in the desired place

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -13,11 +13,9 @@ import beam.agentsim.agents.vehicles.AccessErrorCodes.RideHailNotRequestedError
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles.{VehiclePersonId, _}
 import beam.agentsim.events.{ModeChoiceEvent, SpaceTime}
-import beam.agentsim.infrastructure.{ParkingInquiry, ParkingInquiryResponse}
-import beam.agentsim.infrastructure.ParkingStall
+import beam.agentsim.infrastructure.{ParkingInquiry, ParkingInquiryResponse, ParkingStall}
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger}
 import beam.router.BeamRouter._
-import beam.router.Modes
 import beam.router.Modes.BeamMode
 import beam.router.Modes.BeamMode._
 import beam.router.model.{BeamLeg, EmbodiedBeamLeg, EmbodiedBeamTrip}
@@ -1146,9 +1144,9 @@ object ChoosesMode {
       parkingResponse = if (withParking) {
         None
       } else {
-        Some(ParkingInquiryResponse(ParkingStall.lastResortStall(), 0))
+        Some(ParkingInquiryResponse(ParkingStall.defaultStall(new Coord(0.0, 0.0)), 0))
       },
-      driveTransitParkingResponse = Some(ParkingInquiryResponse(ParkingStall.lastResortStall(), 0)),
+      driveTransitParkingResponse = Some(ParkingInquiryResponse(ParkingStall.defaultStall(new Coord(0.0, 0.0)), 0)),
       rideHailResult = if (withRideHail) {
         None
       } else {

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
@@ -1,9 +1,7 @@
 package beam.agentsim.infrastructure
 
-import scala.util.Random
-
-import beam.agentsim.infrastructure.parking.{ParkingType, ParkingZone, PricingModel}
 import beam.agentsim.infrastructure.charging.ChargingPointType
+import beam.agentsim.infrastructure.parking.{ParkingType, ParkingZone, PricingModel}
 import beam.agentsim.infrastructure.taz.TAZ
 import beam.router.BeamRouter.Location
 import org.matsim.api.core.v01.{Coord, Id}
@@ -36,34 +34,4 @@ object ParkingStall {
     pricingModel = None,
     parkingType = ParkingType.Public
   )
-
-  /**
-    * take a stall from the infinite parking zone, with a random location by default from planet-wide UTM values
-    * @param random random number generator
-    * @param minCoord coordinate representing the lower bounds on x,y values for this coordinate system
-    * @param maxCoord coordinate representing the upper bounds on x,y values for this coordinate system
-    * @param cost the cost of this stall
-    *
-    * @return a stall that costs a lot but at least it exists. it's coordinate can be anywhere on the planet. for routing, the nearest link should be found using Beam Geotools.
-    */
-  def lastResortStall(
-    random: Random = Random,
-    minCoord: Coord = new Coord(167000, 0),
-    maxCoord: Coord = new Coord(833000, 10000000),
-    cost: Double = CostOfEmergencyStall
-  ): ParkingStall = {
-
-    val x = (random.nextDouble() * (maxCoord.getX - minCoord.getX)) + minCoord.getX
-    val y = (random.nextDouble() * (maxCoord.getY - minCoord.getY)) + minCoord.getY
-
-    ParkingStall(
-      tazId = TAZ.EmergencyTAZId,
-      parkingZoneId = ParkingZone.DefaultParkingZoneId,
-      locationUTM = new Coord(x, y),
-      cost = cost,
-      chargingPointType = None,
-      pricingModel = Some { PricingModel.FlatFee(cost.toInt) },
-      parkingType = ParkingType.Public
-    )
-  }
 }

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -3,9 +3,9 @@ package beam.agentsim.infrastructure
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Random, Success, Try}
-
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import beam.agentsim.Resource.ReleaseParkingStall
+import beam.agentsim.infrastructure.ParkingStall.CostOfEmergencyStall
 import beam.agentsim.infrastructure.charging.ChargingInquiryData
 import beam.agentsim.infrastructure.parking._
 import beam.agentsim.infrastructure.taz.TAZ
@@ -107,6 +107,7 @@ object ZonalParkingManager extends LazyLogging {
 
   /**
     * constructs a ZonalParkingManager from file
+    *
     * @param beamServices central repository for simulation data
     * @param random random number generator used to sample parking stall locations
     * @return an instance of the ZonalParkingManager class
@@ -137,6 +138,7 @@ object ZonalParkingManager extends LazyLogging {
 
   /**
     * constructs a ZonalParkingManager from a string iterator
+    *
     * @param parkingDescription line-by-line string representation of parking including header
     * @param beamServices central repository for simulation data
     * @param random random generator used for sampling parking locations
@@ -155,6 +157,7 @@ object ZonalParkingManager extends LazyLogging {
 
   /**
     * builds a ZonalParkingManager Actor
+    *
     * @param beamServices core services related to this simulation
     * @param beamRouter Actor responsible for routing decisions (deprecated/previously unused)
     * @return
@@ -169,6 +172,7 @@ object ZonalParkingManager extends LazyLogging {
 
   /**
     * looks for the nearest ParkingZone that meets the agent's needs
+    *
     * @param searchStartRadius small radius describing a ring shape
     * @param searchMaxRadius larger radius describing a ring shape
     * @param destinationUTM coordinates of this request
@@ -258,7 +262,14 @@ object ZonalParkingManager extends LazyLogging {
       case Some(result) =>
         result
       case None =>
-        val newStall = ParkingStall.lastResortStall(random)
+        val newStall =
+          ParkingStall
+            .defaultStall(destinationUTM)
+            .copy(
+              cost = CostOfEmergencyStall,
+              pricingModel = Some(PricingModel.FlatFee(CostOfEmergencyStall.toInt)),
+              tazId = TAZ.EmergencyTAZId
+            )
         (ParkingZone.DefaultParkingZone, newStall)
     }
   }

--- a/test/input/beamville/parking/taz-parking-empty.csv
+++ b/test/input/beamville/parking/taz-parking-empty.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f436133927ab5fc9776ff10fef347f787241a50bfa62b5559a712fce00fee613
-size 5074
+oid sha256:6cbc3569589642c684e581d0249bbee771694720f1bbdd5eb1a2078e020798a9
+size 4380


### PR DESCRIPTION
This changes the emergency parking stall that is returned when there is no parking available.

Previously, this would be a parking stall that is expensive and somewhere far away in the world, at a random coordinate. This would put stress on the router by having it go through its quadtree a lot and give error messages.

Now, it is only expensive, and otherwise like the parking stall in the "abundant" parking lot, i.e. directly at the desired destination, so no routing is done.

This also fixes a test which was supposed to test for "no parking available", but the data file was bad, so there _was_ parking available. Possibly this was the only reason why for this case, the "far out" parking location would actually be necessary sometimes.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1883)
<!-- Reviewable:end -->
