### PR TITLE
dropped use of SortedSet in favor of a List in Multinomial Logit function

### DIFF
--- a/src/test/scala/beam/agentsim/agents/choice/logit/MultinomialLogitSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/choice/logit/MultinomialLogitSpec.scala
@@ -113,4 +113,84 @@ class MultinomialLogitSpec extends WordSpecLike with Matchers {
 
     }
   }
+  "an MNL sampling alternatives where at least one has utility which is positively infinite" should {
+    "select one of them" in new MultinomialLogitSpec.InfinitelyValuedAlternatives {
+      val random: Random = new Random(0)
+      val mnl: MultinomialLogit[String, String] = new MultinomialLogit[String, String](Map.empty, utilityFunctions)
+      mnl.sampleAlternative(alternatives, random) match {
+        case None => fail()
+        case Some(selected) =>
+
+          // these alternatives have a dangerous cost value
+          selected.alternativeType should (equal ("B") or equal ("D"))
+
+          // the alternatives that "blow up" to infinity have a dangerous cost
+          selected.utility should equal (dangerousCostValue)
+
+          // the dangerous cost value, when e is raised to them, should go to pos. infinity
+          math.pow(math.E, dangerousCostValue) should equal (Double.PositiveInfinity)
+      }
+    }
+  }
+
+  "an MNL with n alternatives where all have equal value" should {
+    "select one with 1/n probability" in new MultinomialLogitSpec.EquallyValuedAlternatives {
+      val random: Random = new Random(0)
+      val mnl: MultinomialLogit[String, String] = new MultinomialLogit[String, String](Map.empty, utilityFunctions)
+      mnl.sampleAlternative(alternatives, random) match {
+        case None => fail()
+        case Some(selected) =>
+          // there are four equal alternatives, so, they should each be given a 25% probability of selection
+          selected.realProbability should equal (0.25)
+
+          // the utility should be the same
+          selected.utility should equal (alternativesCost)
+      }
+    }
+  }
+}
+
+
+object MultinomialLogitSpec {
+  trait InfinitelyValuedAlternatives {
+    val dangerousCostValue = 1000.0
+    val utilityFunctions = Map(
+      "value" -> UtilityFunctionOperation.Multiplier(1.0)
+    )
+    // alternatives B and D should evaluate to e^1000 which is greater than Double.MaxValue => infinite
+    val alternatives: Map[String, Map[String, Double]] = Map(
+      "A" -> Map(
+        "value" -> -0.5
+      ),
+      "B" -> Map(
+        "value" -> dangerousCostValue
+      ),
+      "C" -> Map(
+        "value" -> 2.0
+      ),
+      "D" -> Map(
+        "value" -> dangerousCostValue
+      )
+    )
+  }
+  trait EquallyValuedAlternatives {
+    val alternativesCost = -1
+    val utilityFunctions = Map(
+      "value" -> UtilityFunctionOperation.Multiplier(1.0)
+    )
+    val alternatives: Map[String, Map[String, Double]] = Map(
+      "A" -> Map(
+        "value" -> alternativesCost
+      ),
+      "B" -> Map(
+        "value" -> alternativesCost
+      ),
+      "C" -> Map(
+        "value" -> alternativesCost
+      ),
+      "D" -> Map(
+        "value" -> alternativesCost
+      )
+    )
+  }
 }

--- a/src/test/scala/beam/agentsim/agents/choice/logit/MultinomialLogitSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/choice/logit/MultinomialLogitSpec.scala
@@ -118,17 +118,16 @@ class MultinomialLogitSpec extends WordSpecLike with Matchers {
       val random: Random = new Random(0)
       val mnl: MultinomialLogit[String, String] = new MultinomialLogit[String, String](Map.empty, utilityFunctions)
       mnl.sampleAlternative(alternatives, random) match {
-        case None => fail()
+        case None           => fail()
         case Some(selected) =>
-
           // these alternatives have a dangerous cost value
-          selected.alternativeType should (equal ("B") or equal ("D"))
+          selected.alternativeType should (equal("B") or equal("D"))
 
           // the alternatives that "blow up" to infinity have a dangerous cost
-          selected.utility should equal (dangerousCostValue)
+          selected.utility should equal(dangerousCostValue)
 
           // the dangerous cost value, when e is raised to them, should go to pos. infinity
-          math.pow(math.E, dangerousCostValue) should equal (Double.PositiveInfinity)
+          math.pow(math.E, dangerousCostValue) should equal(Double.PositiveInfinity)
       }
     }
   }
@@ -138,25 +137,27 @@ class MultinomialLogitSpec extends WordSpecLike with Matchers {
       val random: Random = new Random(0)
       val mnl: MultinomialLogit[String, String] = new MultinomialLogit[String, String](Map.empty, utilityFunctions)
       mnl.sampleAlternative(alternatives, random) match {
-        case None => fail()
+        case None           => fail()
         case Some(selected) =>
           // there are four equal alternatives, so, they should each be given a 25% probability of selection
-          selected.realProbability should equal (0.25)
+          selected.realProbability should equal(0.25)
 
           // the utility should be the same
-          selected.utility should equal (alternativesCost)
+          selected.utility should equal(alternativesCost)
       }
     }
   }
 }
 
-
 object MultinomialLogitSpec {
+
   trait InfinitelyValuedAlternatives {
     val dangerousCostValue = 1000.0
+
     val utilityFunctions = Map(
       "value" -> UtilityFunctionOperation.Multiplier(1.0)
     )
+
     // alternatives B and D should evaluate to e^1000 which is greater than Double.MaxValue => infinite
     val alternatives: Map[String, Map[String, Double]] = Map(
       "A" -> Map(
@@ -173,11 +174,14 @@ object MultinomialLogitSpec {
       )
     )
   }
+
   trait EquallyValuedAlternatives {
     val alternativesCost = -1
+
     val utilityFunctions = Map(
       "value" -> UtilityFunctionOperation.Multiplier(1.0)
     )
+
     val alternatives: Map[String, Map[String, Double]] = Map(
       "A" -> Map(
         "value" -> alternativesCost


### PR DESCRIPTION
dropped use of SortedSet in favor of a List in MultinomialLogit's sampleAlternative function, per discussions about the issues with equality testing in SortedSet (see #1884 and [this link](https://stackoverflow.com/questions/4952374/scala-sortedset-sorted-by-one-ordering-and-unique-by-something-else) for details).

tracking infinitely-valued alternatives is now done by placing infinitely-valued alternatives at the tail of the list, and afterward, checking the `lastOption` of the list for a utility which equals Double.PositiveInfinity.

this also changed the Tuple2 of (AlternativeType, Double) into it's own case class, which is clearer.

in support of this change, the following happened:

- added a test for dealing with positively infinite values
- added a test for dealing with equally-valued alternatives
- recognized that the MNL's output wasn't reporting the utility, but instead, the e^u value, which is less meaningful from a logging/event standpoint. the true utility value is now output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1885)
<!-- Reviewable:end -->
