### PR TITLE
Added SimpleRideHailUtilization

### DIFF
--- a/src/main/java/beam/analysis/StatsFactory.java
+++ b/src/main/java/beam/analysis/StatsFactory.java
@@ -29,7 +29,8 @@ public class StatsFactory {
         AboveCapacityPtUsageDuration,
         TollRevenue,
         AgencyRevenue,
-        ParkingDelay
+        ParkingDelay,
+        RideHailUtilization
     }
 
     private final BeamConfig beamConfig;
@@ -103,6 +104,8 @@ public class StatsFactory {
                 return new AgencyRevenueAnalysis();
             case ParkingDelay:
                 return new ParkingStatsCollector(beamServices);
+            case RideHailUtilization:
+                return new SimpleRideHailUtilization();
             default:
                 return null;
         }

--- a/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
+++ b/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
@@ -1,0 +1,59 @@
+package beam.analysis
+
+import java.util
+
+import beam.agentsim.events.PathTraversalEvent
+import org.matsim.api.core.v01.events.Event
+
+import scala.collection.JavaConverters._
+
+class SimpleRideHailUtilization extends IterationSummaryAnalysis {
+  // Offset is number of passengers, value is number of rides with that amount of passengers
+  private var overallRideStat: Array[Int] = Array.fill[Int](0)(0)
+
+  override def processStats(event: Event): Unit = {
+    event match {
+      case pte: PathTraversalEvent if pte.vehicleId.toString.contains("rideHailVehicle-") =>
+        handle(pte.numberOfPassengers)
+      case _ =>
+    }
+  }
+
+  override def resetStats(): Unit = {
+    overallRideStat = Array.fill[Int](0)(0)
+  }
+
+  override def getSummaryStats: util.Map[String, java.lang.Double] = {
+    val summaryMap = overallRideStat.zipWithIndex
+      .map {
+        case (rides, numOfPassenger) =>
+          val value: java.lang.Double = java.lang.Double.valueOf(rides.toString)
+          s"RideTripsWith${numOfPassenger}Passengers" -> value
+      }
+      .toMap
+      .asJava
+    summaryMap
+  }
+
+  def getStat(numOfPassengers: Int): Option[Int] = {
+    overallRideStat.lift(numOfPassengers)
+  }
+
+  def handle(numOfPassengers: Int): Int = {
+    val arrToUpdate = if (numOfPassengers >= overallRideStat.length) {
+      val newArr = Array.fill[Int](numOfPassengers + 1)(0)
+      Array.copy(overallRideStat, 0, newArr, 0, overallRideStat.length)
+      overallRideStat = newArr
+      newArr
+    } else {
+      overallRideStat
+    }
+    incrementCounter(arrToUpdate, numOfPassengers)
+  }
+
+  private def incrementCounter(arrToUpdate: Array[Int], offset: Int): Int = {
+    val updatedCounter = arrToUpdate(offset) + 1
+    arrToUpdate.update(offset, updatedCounter)
+    updatedCounter
+  }
+}

--- a/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
+++ b/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
@@ -5,8 +5,10 @@ import java.util
 import beam.agentsim.events.PathTraversalEvent
 import beam.analysis.plots.{GraphAnalysis, GraphUtils, GraphsStatsAgentSimEventsListener}
 import org.jfree.chart.JFreeChart
+import org.jfree.chart.labels.{ItemLabelAnchor, ItemLabelPosition, StandardCategoryItemLabelGenerator}
 import org.jfree.chart.plot.CategoryPlot
 import org.jfree.data.category.{CategoryDataset, DefaultCategoryDataset}
+import org.jfree.ui.TextAnchor
 import org.matsim.api.core.v01.events.Event
 import org.matsim.core.controler.events.IterationEndsEvent
 
@@ -93,7 +95,7 @@ class SimpleRideHailUtilization extends IterationSummaryAnalysis with GraphAnaly
   ): Unit = {
     val graphTitleName = "Ride Hail Utilisation"
     val xAxisTitle = "Iteration"
-    val yAxisTitle = "# Ride Trip Passengers"
+    val yAxisTitle = "# Ride Trip"
     val legend = true
     val chart: JFreeChart = GraphUtils.createStackedBarChartWithDefaultSettings(
       dataset,
@@ -104,6 +106,12 @@ class SimpleRideHailUtilization extends IterationSummaryAnalysis with GraphAnaly
       legend
     )
     val plot: CategoryPlot = chart.getCategoryPlot
+    val renderer = chart.getPlot.asInstanceOf[CategoryPlot].getRenderer
+
+    renderer.setBaseItemLabelGenerator(new StandardCategoryItemLabelGenerator())
+    renderer.setBaseItemLabelsVisible(true)
+    val position = new ItemLabelPosition(ItemLabelAnchor.CENTER, TextAnchor.HALF_ASCENT_CENTER)
+    renderer.setBasePositiveItemLabelPosition(position)
     GraphUtils.plotLegendItems(plot, rideTrips, dataset.getRowCount)
     GraphUtils.saveJFreeChartAsPNG(
       chart,

--- a/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
+++ b/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
@@ -3,13 +3,42 @@ package beam.analysis
 import java.util
 
 import beam.agentsim.events.PathTraversalEvent
+import beam.analysis.plots.{GraphAnalysis, GraphUtils, GraphsStatsAgentSimEventsListener}
+import org.jfree.chart.JFreeChart
+import org.jfree.chart.plot.CategoryPlot
+import org.jfree.data.category.{CategoryDataset, DefaultCategoryDataset}
 import org.matsim.api.core.v01.events.Event
+import org.matsim.core.controler.events.IterationEndsEvent
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
-class SimpleRideHailUtilization extends IterationSummaryAnalysis {
+class SimpleRideHailUtilization extends IterationSummaryAnalysis with GraphAnalysis {
   // Offset is number of passengers, value is number of rides with that amount of passengers
   private var overallRideStat: Array[Int] = Array.fill[Int](0)(0)
+  private var iterOverallRideStat = mutable.Map[Int, Array[Int]]()
+
+  override def createGraph(event: IterationEndsEvent): Unit = {
+    iterOverallRideStat += event.getIteration -> overallRideStat.clone()
+    val dataset = new DefaultCategoryDataset
+    val revIteration = iterOverallRideStat.keys.toSeq.reverseIterator
+    revIteration.foreach { iteration =>
+      iterOverallRideStat(iteration).zipWithIndex.foreach {
+        case (rides, numOfPassenger) =>
+          dataset.addValue(
+            java.lang.Double.valueOf(rides.toString),
+            s"RideTripsWith${numOfPassenger}Passengers",
+            s"it.$iteration"
+          )
+      }
+    }
+    val fileName = event.getServices.getControlerIO.getOutputFilename("rideHailUtilisation.png")
+    createGraphInRootDirectory(
+      dataset,
+      fileName,
+      (0 until iterOverallRideStat.values.flatten.size).map(numOfPass => s"RideTripsWith${numOfPass}Passengers").asJava
+    )
+  }
 
   override def processStats(event: Event): Unit = {
     event match {
@@ -55,5 +84,32 @@ class SimpleRideHailUtilization extends IterationSummaryAnalysis {
     val updatedCounter = arrToUpdate(offset) + 1
     arrToUpdate.update(offset, updatedCounter)
     updatedCounter
+  }
+
+  protected def createGraphInRootDirectory(
+    dataset: CategoryDataset,
+    fileName: String,
+    rideTrips: util.List[String]
+  ): Unit = {
+    val graphTitleName = "Ride Hail Utilisation"
+    val xAxisTitle = "Iteration"
+    val yAxisTitle = "# Ride Trip Passengers"
+    val legend = true
+    val chart: JFreeChart = GraphUtils.createStackedBarChartWithDefaultSettings(
+      dataset,
+      graphTitleName,
+      xAxisTitle,
+      yAxisTitle,
+      fileName,
+      legend
+    )
+    val plot: CategoryPlot = chart.getCategoryPlot
+    GraphUtils.plotLegendItems(plot, rideTrips, dataset.getRowCount)
+    GraphUtils.saveJFreeChartAsPNG(
+      chart,
+      fileName,
+      GraphsStatsAgentSimEventsListener.GRAPH_WIDTH,
+      GraphsStatsAgentSimEventsListener.GRAPH_HEIGHT
+    )
   }
 }

--- a/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
+++ b/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
@@ -5,10 +5,8 @@ import java.util
 import beam.agentsim.events.PathTraversalEvent
 import beam.analysis.plots.{GraphAnalysis, GraphUtils, GraphsStatsAgentSimEventsListener}
 import org.jfree.chart.JFreeChart
-import org.jfree.chart.labels.{ItemLabelAnchor, ItemLabelPosition, StandardCategoryItemLabelGenerator}
 import org.jfree.chart.plot.CategoryPlot
 import org.jfree.data.category.{CategoryDataset, DefaultCategoryDataset}
-import org.jfree.ui.TextAnchor
 import org.matsim.api.core.v01.events.Event
 import org.matsim.core.controler.events.IterationEndsEvent
 
@@ -106,12 +104,6 @@ class SimpleRideHailUtilization extends IterationSummaryAnalysis with GraphAnaly
       legend
     )
     val plot: CategoryPlot = chart.getCategoryPlot
-    val renderer = chart.getPlot.asInstanceOf[CategoryPlot].getRenderer
-
-    renderer.setBaseItemLabelGenerator(new StandardCategoryItemLabelGenerator())
-    renderer.setBaseItemLabelsVisible(true)
-    val position = new ItemLabelPosition(ItemLabelAnchor.CENTER, TextAnchor.HALF_ASCENT_CENTER)
-    renderer.setBasePositiveItemLabelPosition(position)
     GraphUtils.plotLegendItems(plot, rideTrips, dataset.getRowCount)
     GraphUtils.saveJFreeChartAsPNG(
       chart,

--- a/src/test/scala/beam/analysis/SimpleRideHailUtilizationTest.scala
+++ b/src/test/scala/beam/analysis/SimpleRideHailUtilizationTest.scala
@@ -1,0 +1,81 @@
+package beam.analysis
+
+import beam.agentsim.events.PathTraversalEvent
+import beam.router.Modes.BeamMode
+import org.matsim.api.core.v01.Id
+import org.scalatest.{FunSuite, Matchers}
+
+class SimpleRideHailUtilizationTest extends FunSuite with Matchers {
+
+  val pathTraversalEvent: PathTraversalEvent = PathTraversalEvent(
+    time = 1,
+    vehicleId = Id.createVehicleId("rideHailVehicle-1"),
+    driverId = "driver-id",
+    vehicleType = "CAR",
+    seatingCapacity = 0,
+    standingRoomCapacity = 0,
+    primaryFuelType = "",
+    secondaryFuelType = "",
+    numberOfPassengers = 0,
+    departureTime = 0,
+    arrivalTime = 1,
+    mode = BeamMode.CAR,
+    legLength = 1,
+    linkIds = IndexedSeq.empty,
+    linkTravelTime = IndexedSeq.empty,
+    startX = 0,
+    startY = 0,
+    endX = 1,
+    endY = 1,
+    primaryFuelConsumed = 2,
+    secondaryFuelConsumed = 2,
+    endLegPrimaryFuelLevel = 3,
+    endLegSecondaryFuelLevel = 4,
+    amountPaid = 1
+  )
+
+  test("Should ignore non-ridehail vehicles") {
+    val rhu = new SimpleRideHailUtilization
+    rhu.processStats(pathTraversalEvent.copy(vehicleId = Id.createVehicleId(1)))
+    rhu.getStat(0) shouldBe None
+  }
+
+  test("Should process ridehail vehicles") {
+    val rhu = new SimpleRideHailUtilization
+    rhu.getStat(0) shouldBe None
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 0)
+    )
+    rhu.getStat(0) shouldBe Some(1)
+
+    rhu.getStat(1) shouldBe None
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 1)
+    )
+    rhu.getStat(1) shouldBe Some(1)
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 1)
+    )
+    rhu.getStat(1) shouldBe Some(2)
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 1)
+    )
+    rhu.getStat(1) shouldBe Some(3)
+
+    rhu.getStat(2) shouldBe None
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 2)
+    )
+    rhu.getStat(2) shouldBe Some(1)
+
+    rhu.processStats(
+      pathTraversalEvent.copy(numberOfPassengers = 2)
+    )
+    rhu.getStat(2) shouldBe Some(2)
+  }
+}


### PR DESCRIPTION
Simple ridehail utilization which creates the stats from number of passengers to amount of trips. It is implemented as one more `IterationSummaryAnalysis `, so the stats are automatically added to `summaryStats.csv` file. Stats column name are `RideTripsWith0Passengers`, `RideTripsWith1Passengers` and so on. PNGs files are automatically created with name `RideTripsWith0Passengers.png`, `RideTripsWith1Passengers.png` and so on. Example:
![image](https://user-images.githubusercontent.com/5107562/59555832-53ee8700-8fe3-11e9-9cae-fb4f26cc092c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1901)
<!-- Reviewable:end -->
