### PR TITLE
Pin BeamAgentScheduler, ZonalParkingManager and RideHailManager to dedicated threads

### DIFF
--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -115,7 +115,7 @@ class BeamMobsimIteration(
       Time.parseTime(beamConfig.matsim.modules.qsim.endTime).toInt,
       config.schedulerParallelismWindow,
       new StuckFinder(beamConfig.beam.debug.stuckAgentDetection)
-    ),
+    ).withDispatcher("beam-agent-scheduler-pinned-dispatcher"),
     "scheduler"
   )
   context.system.eventStream.subscribe(errorListener, classOf[DeadLetter])
@@ -133,7 +133,8 @@ class BeamMobsimIteration(
 
   private val parkingManager = context.actorOf(
     ZonalParkingManager
-      .props(beamScenario.beamConfig, beamScenario.tazTreeMap, geo, beamRouter, envelopeInUTM),
+      .props(beamScenario.beamConfig, beamScenario.tazTreeMap, geo, beamRouter, envelopeInUTM)
+      .withDispatcher("zonal-parking-manager-pinned-dispatcher"),
     "ParkingManager"
   )
   context.watch(parkingManager)
@@ -158,7 +159,7 @@ class BeamMobsimIteration(
         beamSkimmer,
         routeHistory
       )
-    ),
+    ).withDispatcher("ride-hail-manager-pinned-dispatcher"),
     "RideHailManager"
   )
   context.watch(rideHailManager)

--- a/test/input/common/akka.conf
+++ b/test/input/common/akka.conf
@@ -5,6 +5,24 @@ my-custom-mailbox {
   mailbox-type = "akka.dispatch.UnboundedDequeBasedMailbox"
 }
 
+beam-agent-scheduler-pinned-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
+  thread-pool-executor.allow-core-timeout=off
+}
+
+zonal-parking-manager-pinned-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
+  thread-pool-executor.allow-core-timeout=off
+}
+
+ride-hail-manager-pinned-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
+  thread-pool-executor.allow-core-timeout=off
+}
+
 akka {
   extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
 


### PR DESCRIPTION
This gives two things:
- Slightly improves performance because of decreasing context switching
- More important one is ability to see what's going on with those actors in Java Mission Control:
![image](https://user-images.githubusercontent.com/5107562/59621856-57f0e500-915a-11e9-88b1-fcb2d042f728.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1907)
<!-- Reviewable:end -->
