### PR TITLE
Put the logging for the link speed quick fix back in, but at the source

### DIFF
--- a/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
+++ b/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
@@ -12,6 +12,7 @@ import beam.physsim.jdeqsim.cacc.roadCapacityAdjustmentFunctions.Hao2018CaccRoad
 import beam.physsim.jdeqsim.cacc.roadCapacityAdjustmentFunctions.RoadCapacityAdjustmentFunction;
 import beam.physsim.jdeqsim.cacc.sim.JDEQSimulation;
 import beam.router.BeamRouter;
+import beam.router.FreeFlowTravelTime;
 import beam.sim.BeamConfigChangesObservable;
 import beam.sim.BeamServices;
 import beam.sim.config.BeamConfig;
@@ -187,11 +188,35 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
         Map<String, double[]> map = TravelTimeCalculatorHelper.GetLinkIdToTravelTimeArray(links,
                 travelTimes, maxHour);
 
+        TravelTime freeFlow = new FreeFlowTravelTime();
+        int nBins = 0;
+        int nBinsWithUnexpectedlyLowSpeed = 0;
+        for (Map.Entry<String, double[]> entry : map.entrySet()) {
+            int hour = 0;
+            Link link = agentSimScenario.getNetwork().getLinks().get(Id.createLinkId(entry.getKey()));
+            for (double linkTravelTime : entry.getValue()) {
+                double speed = link.getLength() / linkTravelTime;
+                if (speed < beamConfig.beam().physsim().quick_fix_minCarSpeedInMetersPerSecond()) {
+                    double linkTravelTime1 = travelTimes.getLinkTravelTime(link, hour * 60.0 * 60.0, null, null);
+                    double freeFlowTravelTime = freeFlow.getLinkTravelTime(link, hour * 60.0 * 60.0, null, null);
+                    log.debug("{} {} {}", linkTravelTime, linkTravelTime1, freeFlowTravelTime);
+                    nBinsWithUnexpectedlyLowSpeed++;
+                }
+                hour++;
+                nBins++;
+            }
+        }
+        if (nBinsWithUnexpectedlyLowSpeed > 0) {
+            log.error("Iteration {} had {} link speed bins (of {}) with speed smaller than {}.", iterationNumber, nBinsWithUnexpectedlyLowSpeed, nBins, beamConfig.beam().physsim().quick_fix_minCarSpeedInMetersPerSecond());
+        }
+
+
         Integer startingIterationForTravelTimesMSA = beamConfig.beam().routing().startingIterationForTravelTimesMSA();
         if (startingIterationForTravelTimesMSA <= iterationNumber) {
             map = processTravelTime(links, map, maxHour);
             travelTimes = previousTravelTime;
         }
+
 
         router.tell(new BeamRouter.TryToSerialize(map), ActorRef.noSender());
         router.tell(new BeamRouter.UpdateTravelTimeRemote(map), ActorRef.noSender());

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -12,7 +12,6 @@ import beam.agentsim.agents.vehicles.FuelType.FuelType
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events.SpaceTime
-import beam.agentsim.infrastructure.taz.TAZTreeMap
 import beam.router.BeamRouter._
 import beam.router.Modes.BeamMode.{CAR, WALK}
 import beam.router.Modes._
@@ -985,9 +984,6 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
           assert(link != null)
           val physSimTravelTime = travelTime.getLinkTravelTime(link, time, null, null).ceil.toInt
           val linkTravelTime = Math.max(physSimTravelTime, minTravelTime)
-          if (linkTravelTime > maxTravelTime) {
-            println("wurst")
-          }
           Math.min(linkTravelTime, maxTravelTime)
         }
       }

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -176,9 +176,13 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
 
   private var travelTime: TravelTime = new FreeFlowTravelTime
 
-  val linksBelowMinCarSpeed = networkHelper.allLinks.count(l => l.getFreespeed < beamConfig.beam.physsim.quick_fix_minCarSpeedInMetersPerSecond)
+  val linksBelowMinCarSpeed =
+    networkHelper.allLinks.count(l => l.getFreespeed < beamConfig.beam.physsim.quick_fix_minCarSpeedInMetersPerSecond)
   if (linksBelowMinCarSpeed > 0) {
-    log.warning("{} links are below quick_fix_minCarSpeedInMetersPerSecond, already in free-flow", linksBelowMinCarSpeed)
+    log.warning(
+      "{} links are below quick_fix_minCarSpeedInMetersPerSecond, already in free-flow",
+      linksBelowMinCarSpeed
+    )
   }
 
   private def agencyAndRoute(vehicleId: Id[Vehicle]): (String, String) = {

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -176,6 +176,11 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
 
   private var travelTime: TravelTime = new FreeFlowTravelTime
 
+  val linksBelowMinCarSpeed = networkHelper.allLinks.count(l => l.getFreespeed < beamConfig.beam.physsim.quick_fix_minCarSpeedInMetersPerSecond)
+  if (linksBelowMinCarSpeed > 0) {
+    log.warning("{} links are below quick_fix_minCarSpeedInMetersPerSecond, already in free-flow", linksBelowMinCarSpeed)
+  }
+
   private def agencyAndRoute(vehicleId: Id[Vehicle]): (String, String) = {
     val route = transitSchedule(Id.createVehicleId(vehicleId.toString))._1
     (route.agency_id, route.route_id)
@@ -975,7 +980,11 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
           val link = networkHelper.getLinkUnsafe(linkId)
           assert(link != null)
           val physSimTravelTime = travelTime.getLinkTravelTime(link, time, null, null).ceil.toInt
-          Math.min(Math.max(physSimTravelTime, minTravelTime), maxTravelTime)
+          val linkTravelTime = Math.max(physSimTravelTime, minTravelTime)
+          if (linkTravelTime > maxTravelTime) {
+            println("wurst")
+          }
+          Math.min(linkTravelTime, maxTravelTime)
         }
       }
   }


### PR DESCRIPTION
The router was logging cases with extremely low reported link speeds before, and I removed that while working on the travel times per vehicle type, and forgot to put it back in. (Only the logging, the fix was never removed.)

Here, I put in pack in, but where the link travel times are computed, not where they are used.

It happens a lot, even in BeamVille. There it is because of busses, they take like a day to traverse a link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1912)
<!-- Reviewable:end -->
