### PR TITLE
Exception-throwing-router stress test

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.agents
 
 import akka.actor.FSM.Failure
-import akka.actor.{ActorRef, FSM, Props, Stash}
+import akka.actor.{ActorRef, FSM, Props, Stash, Status}
 import beam.agentsim.Resource._
 import beam.agentsim.agents.BeamAgent._
 import beam.agentsim.agents.PersonAgent._
@@ -914,6 +914,8 @@ class PersonAgent(
 
   val myUnhandled: StateFunction = {
     case Event(IllegalTriggerGoToError(reason), _) =>
+      stop(Failure(reason))
+    case Event(Status.Failure(reason), _) =>
       stop(Failure(reason))
     case Event(StateTimeout, _) =>
       log.error("Events leading up to this point:\n\t" + getLog.mkString("\n\t"))

--- a/src/main/scala/beam/agentsim/agents/household/HouseholdActor.scala
+++ b/src/main/scala/beam/agentsim/agents/household/HouseholdActor.scala
@@ -2,8 +2,9 @@ package beam.agentsim.agents.household
 
 import java.util.concurrent.TimeUnit
 
+import akka.actor.FSM.Failure
 import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Terminated}
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Status, Terminated}
 import akka.pattern._
 import akka.util.Timeout
 import beam.agentsim.Resource.NotifyVehicleIdle
@@ -399,6 +400,9 @@ object HouseholdActor {
             .pipeTo(self)
         }
 
+      case Status.Failure(reason) =>
+        throw new RuntimeException(reason)
+
       case ModifyPassengerScheduleAcks(acks) =>
         val (_, triggerId) = releaseTickAndTriggerId()
         completeInitialization(triggerId, acks.flatMap(_.triggersToSchedule).toVector)
@@ -441,6 +445,7 @@ object HouseholdActor {
 
       case Terminated(_) =>
       // Do nothing
+
     }
 
     def completeInitialization(triggerId: Long, triggersToSchedule: Vector[ScheduleTrigger]): Unit = {

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.agents.ridehail
 
 import akka.actor.FSM.Failure
-import akka.actor.{ActorRef, Props, Stash}
+import akka.actor.{ActorRef, Props, Stash, Status}
 import beam.agentsim.Resource.{NotifyVehicleIdle, NotifyVehicleOutOfService, ReleaseParkingStall}
 import beam.agentsim.agents.BeamAgent._
 import beam.agentsim.agents.PersonAgent._
@@ -176,6 +176,9 @@ class RideHailAgent(
 
     case ev @ Event(IllegalTriggerGoToError(reason), _) =>
       log.debug("state(RideHailingAgent.myUnhandled): {}", ev)
+      stop(Failure(reason))
+
+    case Event(Status.Failure(reason), _) =>
       stop(Failure(reason))
 
     case ev @ Event(Finish, _) =>

--- a/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
+++ b/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
@@ -1,0 +1,84 @@
+package beam.integration
+
+import akka.actor.Status.Failure
+import akka.actor._
+import akka.testkit.{ImplicitSender, TestActorRef, TestKitBase}
+import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailSurgePricingManager}
+import beam.integration.AgentsimWithMaximallyBadRouterSpec.BadRouterForTest
+import beam.router.{BeamSkimmer, RouteHistory, TravelTimeObserved}
+import beam.sim.common.GeoUtilsImpl
+import beam.sim.{BeamHelper, BeamMobsim}
+import beam.utils.SimRunnerForTest
+import beam.utils.TestConfigUtils.testConfig
+import com.typesafe.config.ConfigFactory
+import org.scalatest._
+
+import scala.language.postfixOps
+
+class AgentsimWithMaximallyBadRouterSpec
+    extends WordSpecLike
+    with TestKitBase
+    with SimRunnerForTest
+    with BadRouterForTest
+    with BeamHelper
+    with Matchers {
+
+  def config: com.typesafe.config.Config =
+    ConfigFactory
+      .parseString("""akka.test.timefactor = 10
+          |akka.loglevel = off
+        """.stripMargin)
+      .withFallback(testConfig("test/input/beamville/beam.conf").resolve())
+
+  def outputDirPath: String = basePath + "/" + testOutputDir + "bad-router-test"
+
+  lazy implicit val system: ActorSystem = ActorSystem("AgentSimWithBadRouterSpec", config)
+
+  "The agentsim" must {
+    "not get stuck even if the router only throws exceptions" in {
+      val mobsim = new BeamMobsim(
+        services,
+        beamScenario,
+        beamScenario.transportNetwork,
+        services.tollCalculator,
+        scenario,
+        services.matsimServices.getEvents,
+        system,
+        new RideHailSurgePricingManager(services),
+        new RideHailIterationHistory(),
+        new RouteHistory(services.beamConfig),
+        new BeamSkimmer(beamScenario, services.geo),
+        new TravelTimeObserved(beamScenario, services.geo),
+        new GeoUtilsImpl(services.beamConfig),
+        services.networkHelper
+      )
+      mobsim.run()
+    }
+  }
+}
+
+object AgentsimWithMaximallyBadRouterSpec {
+
+  trait BadRouterForTest extends BeforeAndAfterAll with ImplicitSender {
+    this: Suite with SimRunnerForTest with TestKitBase =>
+
+    var router: ActorRef = _
+
+    override def beforeAll: Unit = {
+      super.beforeAll()
+      router = TestActorRef(Props(new Actor {
+        override def receive: Receive = {
+          case _ =>
+            sender ! Failure(new RuntimeException("No idea how to route."))
+        }
+      }))
+      services.beamRouter = router
+    }
+
+    override def afterAll(): Unit = {
+      router ! PoisonPill
+      super.afterAll()
+    }
+
+  }
+}

--- a/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
+++ b/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
@@ -3,8 +3,10 @@ package beam.integration
 import akka.actor.Status.Failure
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestActorRef, TestKitBase}
+import beam.agentsim.agents.PersonTestUtil
 import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailSurgePricingManager}
 import beam.integration.AgentsimWithMaximallyBadRouterSpec.BadRouterForTest
+import beam.router.Modes.BeamMode
 import beam.router.{BeamSkimmer, RouteHistory, TravelTimeObserved}
 import beam.sim.common.GeoUtilsImpl
 import beam.sim.{BeamHelper, BeamMobsim}
@@ -36,6 +38,9 @@ class AgentsimWithMaximallyBadRouterSpec
 
   "The agentsim" must {
     "not get stuck even if the router only throws exceptions" in {
+      scenario.getPopulation.getPersons.values
+        .forEach(p => PersonTestUtil.putDefaultBeamAttributes(p, BeamMode.allModes))
+
       val mobsim = new BeamMobsim(
         services,
         beamScenario,


### PR DESCRIPTION
Agents that talk to the router, and/or that pipe Futures to themselves, must receive Status.Failure() and deal with it by dying, otherwise they can get stuck.

Test this by letting the Agentsim talk to a bogus router.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1913)
<!-- Reviewable:end -->
