### PR TITLE
Relay Failure responses from router

### DIFF
--- a/src/main/scala/beam/router/BeamRouter.scala
+++ b/src/main/scala/beam/router/BeamRouter.scala
@@ -3,6 +3,7 @@ package beam.router
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.concurrent.TimeUnit
 
+import akka.actor.Status.Failure
 import akka.actor.{
   Actor,
   ActorLogging,
@@ -222,7 +223,10 @@ class BeamRouter(
       }
     case routingResp: RoutingResponse =>
       pipeResponseToOriginalSender(routingResp)
-      logIfResponseTookExcessiveTime(routingResp)
+      logIfResponseTookExcessiveTime(routingResp.requestId)
+    case routingFailure: RoutingFailure =>
+      pipeTransformedFailureToOriginalSender(routingFailure)
+      logIfResponseTookExcessiveTime(routingFailure.requestId)
     case ClearRoutedWorkerTracker(workIdToClear) =>
       //TODO: Maybe do this for all tracker removals?
       removeOutstandingWorkBy(workIdToClear)
@@ -346,14 +350,24 @@ class BeamRouter(
         )
     }
 
-  private def logIfResponseTookExcessiveTime(routingResp: RoutingResponse): Unit =
-    outstandingWorkIdToTimeSent.remove(routingResp.requestId) match {
+  private def pipeTransformedFailureToOriginalSender(routingFailure: RoutingFailure): Unit =
+    outstandingWorkIdToOriginalSenderMap.remove(routingFailure.requestId) match {
+      case Some(originalSender) => originalSender ! Failure(routingFailure.cause)
+      case None =>
+        log.error(
+          "Received a RoutingFailure that does not match a tracked WorkId: {}",
+          routingFailure.requestId
+        )
+    }
+
+  private def logIfResponseTookExcessiveTime(requestId: Int): Unit =
+    outstandingWorkIdToTimeSent.remove(requestId) match {
       case Some(timeSent) =>
         val secondsSinceSent = timeSent.until(getCurrentTime, java.time.temporal.ChronoUnit.SECONDS)
         if (secondsSinceSent > 30)
           log.warning(
             "Took longer than 30 seconds to hear back from work id '{}' - {} seconds",
-            routingResp.requestId,
+            requestId,
             secondsSinceSent
           )
       case None => //No matching id. No need to log since this is more for analysis
@@ -449,6 +463,8 @@ object BeamRouter {
     itineraries: Seq[EmbodiedBeamTrip],
     requestId: Int
   )
+
+  case class RoutingFailure(cause: Throwable, requestId: Int)
 
   object RoutingResponse {
     val dummyRoutingResponse = Some(RoutingResponse(Vector(), IdGeneratorImpl.nextId))

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -252,12 +252,11 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
             .copy(requestId = request.requestId)
         }
       }
-      eventualResponse.onComplete {
-        case scala.util.Failure(ex) =>
-          log.error(ex, "calcRoute failed")
-        case _ =>
-      }
-      eventualResponse pipeTo sender
+      eventualResponse.recover {
+        case e =>
+          log.error(e, "calcRoute failed")
+          RoutingFailure(e, request.requestId)
+      } pipeTo sender
       askForMoreWork()
 
     case UpdateTravelTimeLocal(newTravelTime) =>


### PR DESCRIPTION
When the `R5RoutingWorker` has an Exception while serving a request, it would reply with a `Status.Failure(_)`, because it pipes a `Future`.

`BeamRouter` would not relay that reply.

With this change, that reply is relayed to the agent who makes the request. Implemented by using another message type between `BeamRouter` and `R5RoutingWorker`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1924)
<!-- Reviewable:end -->
