### PR TITLE
Refer to transit segments by index, not by leg

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -701,9 +701,9 @@ class PersonAgent(
       val legSegment = nextLeg :: tailOfCurrentTrip.takeWhile(
         leg => leg.beamVehicleId == nextLeg.beamVehicleId
       )
-      val resRequest = ReservationRequest(
-        legSegment.head.beamLeg,
-        legSegment.last.beamLeg,
+      val resRequest = TransitReservationRequest(
+        nextLeg.beamLeg.travelPath.transitStops.get.fromIdx,
+        nextLeg.beamLeg.travelPath.transitStops.get.toIdx,
         PersonIdWithActorRef(id, self)
       )
       TransitDriverAgent.selectByVehicleId(legSegment.head.beamVehicleId) ! resRequest

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -695,7 +695,8 @@ class PersonAgent(
         isWithinTripReplanning = true
       )
     // TRANSIT
-    case Event(StateTimeout, BasePersonData(_, _, nextLeg :: _, _, _, _, _, _, _, _, _)) if nextLeg.beamLeg.mode.isTransit =>
+    case Event(StateTimeout, BasePersonData(_, _, nextLeg :: _, _, _, _, _, _, _, _, _))
+        if nextLeg.beamLeg.mode.isTransit =>
       val resRequest = TransitReservationRequest(
         nextLeg.beamLeg.travelPath.transitStops.get.fromIdx,
         nextLeg.beamLeg.travelPath.transitStops.get.toIdx,

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -488,9 +488,9 @@ class PersonAgent(
       eventsManager.processEvent(new PersonEntersVehicleEvent(tick, id, vehicleToEnter))
 
       if (currentLeg.cost > 0.0) {
-        beamScenario.transitSchedule.get(Id.create(vehicleToEnter.toString, classOf[BeamVehicle])).foreach { trip =>
-          // If not in the transit schedule, it is not a transit but a ridehailing trip
-          eventsManager.processEvent(new AgencyRevenueEvent(tick, trip._1.agency_id, currentLeg.cost))
+        currentLeg.beamLeg.travelPath.transitStops.foreach { transitStopInfo =>
+          // If it doesn't have transitStopInfo, it is not a transit but a ridehailing trip
+          eventsManager.processEvent(new AgencyRevenueEvent(tick, transitStopInfo.agencyId, currentLeg.cost))
         }
         eventsManager.processEvent(
           new PersonCostEvent(

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -30,9 +30,8 @@ import beam.router.Modes.BeamMode.{CAR, CAV, WALK, WALK_TRANSIT}
 import beam.router.model.{EmbodiedBeamLeg, EmbodiedBeamTrip}
 import beam.router.osm.TollCalculator
 import beam.router.{BeamSkimmer, RouteHistory, TravelTimeObserved}
-import beam.sim.{BeamServices, Geofence}
 import beam.sim.population.AttributesOfIndividual
-import beam.sim.{BeamScenario, BeamServices}
+import beam.sim.{BeamScenario, BeamServices, Geofence}
 import com.conveyal.r5.transit.TransportNetwork
 import com.vividsolutions.jts.geom.Envelope
 import org.matsim.api.core.v01.Id
@@ -430,11 +429,11 @@ class PersonAgent(
 
   when(WaitingForReservationConfirmation) {
     // TRANSIT SUCCESS
-    case Event(ReservationResponse(_, Right(response), _), data: BasePersonData) =>
+    case Event(ReservationResponse(Right(response), _), data: BasePersonData) =>
       handleSuccessfulReservation(response.triggersToSchedule, data)
     // TRANSIT FAILURE
     case Event(
-        ReservationResponse(_, Left(firstErrorResponse), _),
+        ReservationResponse(Left(firstErrorResponse), _),
         data @ BasePersonData(_, _, nextLeg :: _, _, _, _, _, _, _, _, _)
         ) =>
       logDebug(s"replanning because ${firstErrorResponse.errorCode}")

--- a/src/main/scala/beam/agentsim/agents/TransitSystem.scala
+++ b/src/main/scala/beam/agentsim/agents/TransitSystem.scala
@@ -7,7 +7,7 @@ import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType}
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger}
 import beam.agentsim.scheduler.Trigger.TriggerWithId
-import beam.router.Modes
+import beam.router.{BeamRouter, Modes, TransitInitializer}
 import beam.router.Modes.BeamMode.{BUS, CABLE_CAR, FERRY, GONDOLA, RAIL, SUBWAY, TRAM}
 import beam.router.model.BeamLeg
 import beam.router.osm.TollCalculator
@@ -70,7 +70,14 @@ class TransitSystem(
 
   private def initDriverAgents(): Unit = {
     val initializer = new TransitVehicleInitializer(beamScenario.beamConfig, beamScenario.vehicleTypes)
-    beamScenario.transitSchedule.foreach {
+    val transitSchedule = new TransitInitializer(
+      beamScenario.beamConfig,
+      beamScenario.dates,
+      beamScenario.vehicleTypes,
+      beamScenario.transportNetwork,
+      BeamRouter.oneSecondTravelTime
+    ).initMap
+    transitSchedule.foreach {
       case (tripVehId, (route, legs)) =>
         initializer.createTransitVehicle(tripVehId, route, legs).foreach { vehicle =>
           val transitDriverId = TransitDriverAgent.createAgentIdFromVehicleId(tripVehId)

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
@@ -570,7 +570,7 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash {
           currentBeamVehicle
         ) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)
-      stay() replying ReservationResponse(Left(VehicleFullError), TRANSIT)
+      stay() replying ReservationResponse(Left(VehicleFullError))
 
     case ev @ Event(req: ReservationRequest, data) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)
@@ -640,12 +640,9 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash {
           data.passengerSchedule.addPassenger(req.passengerVehiclePersonId, legs)
         )
         .asInstanceOf[T] replying
-      ReservationResponse(
-        Right(
+      ReservationResponse(Right(
           ReserveConfirmInfo(boardTrigger ++ alightTrigger ++ boardTrigger2)
-        ),
-        TRANSIT
-      )
+        ))
 
     case ev @ Event(RemovePassengerFromTrip(id), data) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
@@ -570,7 +570,7 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash {
           currentBeamVehicle
         ) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)
-      stay() replying ReservationResponse(req.requestId, Left(VehicleFullError), TRANSIT)
+      stay() replying ReservationResponse(Left(VehicleFullError), TRANSIT)
 
     case ev @ Event(req: ReservationRequest, data) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)
@@ -641,14 +641,8 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash {
         )
         .asInstanceOf[T] replying
       ReservationResponse(
-        req.requestId,
         Right(
-          ReserveConfirmInfo(
-            req.departFrom,
-            req.arriveAt,
-            req.passengerVehiclePersonId,
-            boardTrigger ++ alightTrigger ++ boardTrigger2
-          )
+          ReserveConfirmInfo(boardTrigger ++ alightTrigger ++ boardTrigger2)
         ),
         TRANSIT
       )

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
@@ -640,9 +640,11 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash {
           data.passengerSchedule.addPassenger(req.passengerVehiclePersonId, legs)
         )
         .asInstanceOf[T] replying
-      ReservationResponse(Right(
+      ReservationResponse(
+        Right(
           ReserveConfirmInfo(boardTrigger ++ alightTrigger ++ boardTrigger2)
-        ))
+        )
+      )
 
     case ev @ Event(RemovePassengerFromTrip(id), data) =>
       log.debug("state(DrivesVehicle.drivingBehavior): {}", ev)

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
@@ -36,6 +36,8 @@ object ReservationRequest {
     )
 }
 
+case class TransitReservationRequest(fromIdx: Int, toIdx: Int, passenger: PersonIdWithActorRef)
+
 case class ReservationResponse(
   requestId: Id[ReservationRequest],
   response: Either[ReservationError, ReserveConfirmInfo],

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
@@ -38,18 +38,9 @@ object ReservationRequest {
 
 case class TransitReservationRequest(fromIdx: Int, toIdx: Int, passenger: PersonIdWithActorRef)
 
-case class ReservationResponse(
-  requestId: Id[ReservationRequest],
-  response: Either[ReservationError, ReserveConfirmInfo],
-  reservedMode: BeamMode
-)
+case class ReservationResponse(response: Either[ReservationError, ReserveConfirmInfo], reservedMode: BeamMode)
 
-case class ReserveConfirmInfo(
-  departFrom: BeamLeg,
-  arriveAt: BeamLeg,
-  passengerVehiclePersonId: PersonIdWithActorRef,
-  triggersToSchedule: Vector[ScheduleTrigger] = Vector()
-)
+case class ReserveConfirmInfo(triggersToSchedule: Vector[ScheduleTrigger] = Vector())
 
 case object AccessErrorCodes {
 

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
@@ -38,7 +38,7 @@ object ReservationRequest {
 
 case class TransitReservationRequest(fromIdx: Int, toIdx: Int, passenger: PersonIdWithActorRef)
 
-case class ReservationResponse(response: Either[ReservationError, ReserveConfirmInfo], reservedMode: BeamMode)
+case class ReservationResponse(response: Either[ReservationError, ReserveConfirmInfo])
 
 case class ReserveConfirmInfo(triggersToSchedule: Vector[ScheduleTrigger] = Vector())
 

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -69,7 +69,7 @@ class TransitInitializer(
         BeamPath(
           Vector(),
           Vector(),
-          Option(TransitStopsInfo(agencyId, routeId, vehicleId, -1, -1)),
+          None,
           SpaceTime(fromCoord, departureTime),
           SpaceTime(toCoord, departureTime + duration),
           0
@@ -109,7 +109,7 @@ class TransitInitializer(
             linksTimesAndDistances.travelTimes.sum,
             linksTimesAndDistances.travelTimes
           ),
-          Option(TransitStopsInfo(agencyId, routeId, vehicleId, -1, -1)),
+          None,
           SpaceTime(
             startEdge.getGeometry.getStartPoint.getX,
             startEdge.getGeometry.getStartPoint.getY,

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -69,7 +69,7 @@ class TransitInitializer(
         BeamPath(
           Vector(),
           Vector(),
-          Option(TransitStopsInfo(fromStop, agencyId, routeId, vehicleId, toStop)),
+          Option(TransitStopsInfo(agencyId, routeId, vehicleId, -1, -1)),
           SpaceTime(fromCoord, departureTime),
           SpaceTime(toCoord, departureTime + duration),
           0
@@ -109,7 +109,7 @@ class TransitInitializer(
             linksTimesAndDistances.travelTimes.sum,
             linksTimesAndDistances.travelTimes
           ),
-          Option(TransitStopsInfo(fromStop, agencyId, routeId, vehicleId, toStop)),
+          Option(TransitStopsInfo(agencyId, routeId, vehicleId, -1, -1)),
           SpaceTime(
             startEdge.getGeometry.getStartPoint.getX,
             startEdge.getGeometry.getStartPoint.getY,

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -46,7 +46,7 @@ class TransitInitializer(
     val start = System.currentTimeMillis()
     val activeServicesToday = transportNetwork.transitLayer.getActiveServicesForDate(dates.localBaseDate)
     val stopToStopStreetSegmentCache = mutable.Map[(Int, Int), Option[StreetPath]]()
-    def pathWithoutStreetRoute(fromStop: Int, agencyId: String, routeId: String, toStop: Int) = {
+    def pathWithoutStreetRoute(fromStop: Int, toStop: Int) = {
       val from = transportNetwork.transitLayer.streetVertexForStop.get(fromStop)
       val fromVertex = transportNetwork.streetLayer.vertexStore.getCursor(from)
       val to = transportNetwork.transitLayer.streetVertexForStop.get(toStop)
@@ -89,7 +89,7 @@ class TransitInitializer(
       }
     }
 
-    def pathWithStreetRoute(fromStop: Int, agencyId: String, routeId: String, toStop: Int, streetSeg: StreetPath) = {
+    def pathWithStreetRoute(fromStop: Int, toStop: Int, streetSeg: StreetPath) = {
       val edges = streetSeg.getEdges.asScala
       val startEdge = transportNetwork.streetLayer.edgeStore.getCursor(edges.head)
       val endEdge = transportNetwork.streetLayer.edgeStore.getCursor(edges.last)
@@ -139,12 +139,12 @@ class TransitInitializer(
                 routeTransitPathThroughStreets(fromStop, toStop)
               ) match {
                 case Some(streetSeg) =>
-                  pathWithStreetRoute(fromStop, route.agency_id, route.route_id, toStop, streetSeg)
+                  pathWithStreetRoute(fromStop, toStop, streetSeg)
                 case None =>
-                  pathWithoutStreetRoute(fromStop, route.agency_id, route.route_id, toStop)
+                  pathWithoutStreetRoute(fromStop, toStop)
               }
             } else {
-              pathWithoutStreetRoute(fromStop, route.agency_id, route.route_id, toStop)
+              pathWithoutStreetRoute(fromStop, toStop)
             }
         }
         .toSeq

--- a/src/main/scala/beam/router/model/RoutingModel.scala
+++ b/src/main/scala/beam/router/model/RoutingModel.scala
@@ -70,8 +70,8 @@ object RoutingModel {
     agencyId: String,
     routeId: String,
     vehicleId: Id[Vehicle],
-    fromIdx: Int = -1,
-    toIdx: Int = -1
+    fromIdx: Int,
+    toIdx: Int
   )
 
 }

--- a/src/main/scala/beam/router/model/RoutingModel.scala
+++ b/src/main/scala/beam/router/model/RoutingModel.scala
@@ -66,6 +66,6 @@ object RoutingModel {
     distances: IndexedSeq[Double]
   )
 
-  case class TransitStopsInfo(fromStopId: Int, vehicleId: Id[Vehicle], toStopId: Int)
+  case class TransitStopsInfo(fromStopId: Int, agencyId: String, routeId: String, vehicleId: Id[Vehicle], toStopId: Int)
 
 }

--- a/src/main/scala/beam/router/model/RoutingModel.scala
+++ b/src/main/scala/beam/router/model/RoutingModel.scala
@@ -66,6 +66,12 @@ object RoutingModel {
     distances: IndexedSeq[Double]
   )
 
-  case class TransitStopsInfo(agencyId: String, routeId: String, vehicleId: Id[Vehicle], fromIdx: Int = -1, toIdx: Int = -1)
+  case class TransitStopsInfo(
+    agencyId: String,
+    routeId: String,
+    vehicleId: Id[Vehicle],
+    fromIdx: Int = -1,
+    toIdx: Int = -1
+  )
 
 }

--- a/src/main/scala/beam/router/model/RoutingModel.scala
+++ b/src/main/scala/beam/router/model/RoutingModel.scala
@@ -66,6 +66,6 @@ object RoutingModel {
     distances: IndexedSeq[Double]
   )
 
-  case class TransitStopsInfo(fromStopId: Int, agencyId: String, routeId: String, vehicleId: Id[Vehicle], toStopId: Int)
+  case class TransitStopsInfo(agencyId: String, routeId: String, vehicleId: Id[Vehicle], fromIdx: Int = -1, toIdx: Int = -1)
 
 }

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -19,7 +19,7 @@ import beam.router._
 import beam.router.gtfs.FareCalculator
 import beam.router.gtfs.FareCalculator._
 import beam.router.model.BeamLeg._
-import beam.router.model.RoutingModel.LinksTimesDistances
+import beam.router.model.RoutingModel.{LinksTimesDistances, TransitStopsInfo}
 import beam.router.model.{EmbodiedBeamTrip, RoutingModel, _}
 import beam.router.osm.TollCalculator
 import beam.router.r5.R5RoutingWorker.{R5Request, TripWithFares}
@@ -34,7 +34,7 @@ import com.conveyal.r5.api.ProfileResponse
 import com.conveyal.r5.api.util._
 import com.conveyal.r5.profile._
 import com.conveyal.r5.streets._
-import com.conveyal.r5.transit.{RouteInfo, TransportNetwork}
+import com.conveyal.r5.transit.{TransitLayer, TransportNetwork}
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.config.Config
@@ -63,8 +63,7 @@ case class WorkerParameters(
   networkHelper: NetworkHelper,
   fareCalculator: FareCalculator,
   tollCalculator: TollCalculator,
-  travelTimeAndCost: TravelTimeAndCost,
-  transitSchedule: Map[Id[BeamVehicle], (RouteInfo, ArrayBuffer[BeamLeg])]
+  travelTimeAndCost: TravelTimeAndCost
 )
 
 case class LegWithFare(leg: BeamLeg, fare: Double)
@@ -109,13 +108,6 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
           mode: BeamMode
         ): TimeAndCost = TimeAndCost(None, None)
       }
-      val transitSchedule = new TransitInitializer(
-        beamConfig,
-        dates,
-        vehicleTypes,
-        networkCoordinator.transportNetwork,
-        BeamRouter.oneSecondTravelTime
-      ).initMap
       BeamRouter.checkForConsistentTimeZoneOffsets(dates, networkCoordinator.transportNetwork)
       WorkerParameters(
         beamConfig,
@@ -128,8 +120,7 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
         new NetworkHelperImpl(networkCoordinator.network),
         fareCalculator,
         tollCalculator,
-        travelTimeAndCost,
-        transitSchedule
+        travelTimeAndCost
       )
     })
   }
@@ -145,8 +136,7 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
     networkHelper,
     fareCalculator,
     tollCalculator,
-    travelTimeAndCost,
-    transitSchedule
+    travelTimeAndCost
   ) = workerParams
 
   private val numOfThreads: Int =
@@ -696,6 +686,7 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
                   isRouteForPerson,
                   maybeWalkToVehicle,
                   maybeUseVehicleOnEgress,
+                  profileResponse,
                   option,
                   itinerary,
                   request,
@@ -1002,6 +993,7 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
     isRouteForPerson: Boolean,
     maybeWalkToVehicle: Option[BeamLeg],
     maybeUseVehicleOnEgress: Seq[LegWithFare],
+    response: ProfileResponse,
     option: ProfileOption,
     itinerary: Itinerary,
     routingRequest: RoutingRequest,
@@ -1054,17 +1046,53 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
         case (transitSegment, transitJourneyID) =>
           val segmentPattern =
             transitSegment.segmentPatterns.get(transitJourneyID.pattern)
+          val tripPattern = response.getPatterns.asScala
+            .find { tp =>
+              tp.getTripPatternIdx == segmentPattern.patternIdx
+            }
+            .getOrElse(throw new RuntimeException())
           val tripId = segmentPattern.tripIds.get(transitJourneyID.time)
+          val route = transportNetwork.transitLayer.routes.get(tripPattern.getRouteIdx)
           val fs =
             fares.view
               .filter(_.patternIndex == segmentPattern.patternIdx)
               .map(_.fare.price)
           val fare = if (fs.nonEmpty) fs.min else 0.0
-          val segmentLegs =
-            transitSchedule(Id.createVehicleId(tripId))._2
-              .slice(segmentPattern.fromIndex, segmentPattern.toIndex)
-          legsWithFares ++= segmentLegs.zipWithIndex
-            .map(beamLeg => LegWithFare(beamLeg._1, if (beamLeg._2 == 0) fare else 0.0))
+          val fromStop = tripPattern.getStops.get(segmentPattern.fromIndex)
+          val toStop = tripPattern.getStops.get(segmentPattern.toIndex)
+          val startTime = dates
+            .toBaseMidnightSeconds(segmentPattern.fromDepartureTime.get(transitJourneyID.time), hasTransit = true)
+            .toInt
+          val endTime = dates
+            .toBaseMidnightSeconds(segmentPattern.toArrivalTime.get(transitJourneyID.time), hasTransit = true)
+            .toInt
+          val segmentLeg = BeamLeg(
+            startTime,
+            Modes.mapTransitMode(TransitLayer.getTransitModes(route.route_type)),
+            java.time.temporal.ChronoUnit.SECONDS
+              .between(
+                segmentPattern.fromDepartureTime.get(transitJourneyID.time),
+                segmentPattern.toArrivalTime.get(transitJourneyID.time)
+              )
+              .toInt,
+            BeamPath(
+              Vector(),
+              Vector(),
+              Some(
+                TransitStopsInfo(
+                  route.agency_id,
+                  tripPattern.getRouteId,
+                  Id.createVehicleId(tripId),
+                  segmentPattern.fromIndex,
+                  segmentPattern.toIndex
+                )
+              ),
+              SpaceTime(fromStop.lon, fromStop.lat, startTime),
+              SpaceTime(toStop.lon, toStop.lat, endTime),
+              0.0
+            )
+          )
+          legsWithFares += LegWithFare(segmentLeg, fare)
           arrivalTime = dates
             .toBaseMidnightSeconds(
               segmentPattern.toArrivalTime.get(transitJourneyID.time),
@@ -1190,8 +1218,7 @@ object R5RoutingWorker {
         networkHelper,
         fareCalculator,
         tollCalculator,
-        travelTimeAndCost,
-        beamScenario.transitSchedule
+        travelTimeAndCost
       )
     )
   )

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -184,11 +184,6 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
     )
   }
 
-  private def agencyAndRoute(vehicleId: Id[Vehicle]): (String, String) = {
-    val route = transitSchedule(Id.createVehicleId(vehicleId.toString))._1
-    (route.agency_id, route.route_id)
-  }
-
   private val cache = CacheBuilder
     .newBuilder()
     .recordStats()
@@ -718,7 +713,8 @@ class R5RoutingWorker(workerParams: WorkerParameters) extends Actor with ActorLo
                 var cost = tripWithFares.legFares.getOrElse(index, 0.0)
                 val age = request.attributesOfIndividual.flatMap(_.age)
                 if (Modes.isR5TransitMode(beamLeg.mode)) {
-                  val (agencyId, routeId) = agencyAndRoute(beamLeg.travelPath.transitStops.get.vehicleId)
+                  val agencyId = beamLeg.travelPath.transitStops.get.agencyId
+                  val routeId = beamLeg.travelPath.transitStops.get.routeId
                   cost = ptFares.getPtFare(Some(agencyId), Some(routeId), age).getOrElse(cost)
                 }
                 if (Modes.isR5TransitMode(beamLeg.mode)) {

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -232,13 +232,6 @@ trait BeamHelper extends LazyLogging {
     )
 
     val networkCoordinator = buildNetworkCoordinator(beamConfig)
-    val transitSchedule = new TransitInitializer(
-      beamConfig,
-      dates,
-      vehicleTypes,
-      networkCoordinator.transportNetwork,
-      BeamRouter.oneSecondTravelTime
-    ).initMap
 
     BeamScenario(
       readFuelTypeFile(beamConfig.beam.agentsim.agents.vehicles.fuelTypesFilePath).toMap,
@@ -252,7 +245,6 @@ trait BeamHelper extends LazyLogging {
       dates,
       PtFares(beamConfig.beam.agentsim.agents.ptFare.filePath),
       networkCoordinator.transportNetwork,
-      transitSchedule,
       networkCoordinator.network,
       TAZTreeMap.getTazTreeMap(beamConfig.beam.agentsim.taz.filePath),
       ModeIncentive(beamConfig.beam.agentsim.agents.modeIncentive.filePath)

--- a/src/main/scala/beam/sim/BeamScenario.scala
+++ b/src/main/scala/beam/sim/BeamScenario.scala
@@ -5,15 +5,13 @@ import beam.agentsim.agents.vehicles.FuelType.FuelTypePrices
 import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType, VehicleEnergy}
 import beam.agentsim.infrastructure.taz.TAZTreeMap
 import beam.router.Modes.BeamMode
-import beam.router.model.BeamLeg
 import beam.sim.config.BeamConfig
 import beam.utils.DateUtils
-import com.conveyal.r5.transit.{RouteInfo, TransportNetwork}
+import com.conveyal.r5.transit.TransportNetwork
 import org.matsim.api.core.v01.Id
 import org.matsim.api.core.v01.network.Network
 
 import scala.collection.concurrent.TrieMap
-import scala.collection.mutable.ArrayBuffer
 
 /**
   * This holds together a couple of containers of simulation data, all of which are immutable.
@@ -39,7 +37,6 @@ case class BeamScenario(
   dates: DateUtils,
   ptFares: PtFares,
   transportNetwork: TransportNetwork,
-  transitSchedule: Map[Id[BeamVehicle], (RouteInfo, ArrayBuffer[BeamLeg])],
   network: Network,
   tazTreeMap: TAZTreeMap,
   modeIncentives: ModeIncentive

--- a/src/main/scala/beam/sim/monitoring/ErrorListener.scala
+++ b/src/main/scala/beam/sim/monitoring/ErrorListener.scala
@@ -33,7 +33,7 @@ class ErrorListener() extends Actor with ActorLogging {
           log.warning(
             s"Person ${d.sender} attempted to reserve ride with agent ${d.recipient} that was not found, message sent to dead letters."
           )
-          d.sender ! ReservationResponse(m.requestId, Left(DriverNotFoundError), TRANSIT)
+          d.sender ! ReservationResponse(Left(DriverNotFoundError), TRANSIT)
         case _: RemovePassengerFromTrip =>
         // Can be safely skipped
         case TriggerWithId(trigger, triggerId) =>

--- a/src/main/scala/beam/sim/monitoring/ErrorListener.scala
+++ b/src/main/scala/beam/sim/monitoring/ErrorListener.scala
@@ -33,7 +33,7 @@ class ErrorListener() extends Actor with ActorLogging {
           log.warning(
             s"Person ${d.sender} attempted to reserve ride with agent ${d.recipient} that was not found, message sent to dead letters."
           )
-          d.sender ! ReservationResponse(Left(DriverNotFoundError), TRANSIT)
+          d.sender ! ReservationResponse(Left(DriverNotFoundError))
         case _: RemovePassengerFromTrip =>
         // Can be safely skipped
         case TriggerWithId(trigger, triggerId) =>

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -299,7 +299,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -319,7 +319,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -339,7 +339,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             linkIds = Vector(),
             linkTravelTime = Vector(),
-            transitStops = Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
+            transitStops = Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
             startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             distanceInM = 1.0
@@ -588,7 +588,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -608,7 +608,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -628,7 +628,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
+            Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             1.0
@@ -648,7 +648,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
+            Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 35000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 35600),
             1.0

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -8,7 +8,7 @@ import beam.agentsim.agents.choice.mode.ModeChoiceUniformRandom
 import beam.agentsim.agents.household.HouseholdActor.HouseholdActor
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle.{AlightVehicleTrigger, BoardVehicleTrigger}
 import beam.agentsim.agents.ridehail.{RideHailRequest, RideHailResponse}
-import beam.agentsim.agents.vehicles.{ReservationRequest, ReservationResponse, ReserveConfirmInfo, _}
+import beam.agentsim.agents.vehicles.{ReservationResponse, ReserveConfirmInfo, _}
 import beam.agentsim.events._
 import beam.agentsim.infrastructure.{TrivialParkingManager, ZonalParkingManager}
 import beam.agentsim.scheduler.BeamAgentScheduler
@@ -23,8 +23,6 @@ import beam.router.{BeamSkimmer, RouteHistory, TravelTimeObserved}
 import beam.utils.TestConfigUtils.testConfig
 import beam.utils.{SimRunnerForTest, StuckFinder, TestConfigUtils}
 import com.typesafe.config.{Config, ConfigFactory}
-import com.typesafe.config.ConfigFactory
-import com.vividsolutions.jts.geom.Envelope
 import org.matsim.api.core.v01.events._
 import org.matsim.api.core.v01.network.Link
 import org.matsim.api.core.v01.{Coord, Id}
@@ -38,7 +36,7 @@ import org.matsim.households.{Household, HouseholdsFactoryImpl}
 import org.scalatest.FunSpecLike
 import org.scalatest.mockito.MockitoSugar
 
-import scala.collection.{mutable, JavaConverters}
+import scala.collection.{JavaConverters, mutable}
 
 class PersonAgentSpec
     extends FunSpecLike
@@ -473,7 +471,7 @@ class PersonAgentSpec
       events.expectMsgType[VehicleLeavesTrafficEvent]
       events.expectMsgType[PathTraversalEvent]
 
-      val reservationRequestBus = expectMsgType[ReservationRequest]
+      expectMsgType[TransitReservationRequest]
       scheduler ! ScheduleTrigger(
         BoardVehicleTrigger(28800, busLeg.beamVehicleId),
         personActor
@@ -483,13 +481,8 @@ class PersonAgentSpec
         personActor
       )
       lastSender ! ReservationResponse(
-        reservationRequestBus.requestId,
         Right(
-          ReserveConfirmInfo(
-            busLeg.beamLeg,
-            busLeg2.beamLeg,
-            reservationRequestBus.passengerVehiclePersonId
-          )
+          ReserveConfirmInfo()
         ),
         TRANSIT
       )
@@ -503,14 +496,10 @@ class PersonAgentSpec
 
       events.expectMsgType[PersonLeavesVehicleEvent]
 
-      val reservationRequestTram = expectMsgType[ReservationRequest]
+      expectMsgType[TransitReservationRequest]
       lastSender ! ReservationResponse(
-        reservationRequestTram.requestId,
         Right(
           ReserveConfirmInfo(
-            tramLeg.beamLeg,
-            tramLeg.beamLeg,
-            reservationRequestTram.passengerVehiclePersonId,
             Vector(
               ScheduleTrigger(
                 BoardVehicleTrigger(
@@ -797,16 +786,11 @@ class PersonAgentSpec
       events.expectMsgType[VehicleLeavesTrafficEvent]
       events.expectMsgType[PathTraversalEvent]
 
-      val reservationRequestBus = expectMsgType[ReservationRequest]
+      expectMsgType[TransitReservationRequest]
 
       lastSender ! ReservationResponse(
-        reservationRequestBus.requestId,
         Right(
-          ReserveConfirmInfo(
-            busLeg.beamLeg,
-            busLeg2.beamLeg,
-            reservationRequestBus.passengerVehiclePersonId
-          )
+          ReserveConfirmInfo()
         ),
         TRANSIT
       )
@@ -856,14 +840,10 @@ class PersonAgentSpec
       events.expectMsgType[VehicleLeavesTrafficEvent]
       events.expectMsgType[PathTraversalEvent]
 
-      val reservationRequestTram = expectMsgType[ReservationRequest]
+      expectMsgType[TransitReservationRequest]
       lastSender ! ReservationResponse(
-        reservationRequestTram.requestId,
         Right(
           ReserveConfirmInfo(
-            tramLeg.beamLeg,
-            tramLeg.beamLeg,
-            reservationRequestBus.passengerVehiclePersonId,
             Vector(
               ScheduleTrigger(
                 BoardVehicleTrigger(

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -299,7 +299,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, busId, 2)),
+            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -319,7 +319,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, busId, 3)),
+            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -339,7 +339,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             linkIds = Vector(),
             linkTravelTime = Vector(),
-            transitStops = Some(TransitStopsInfo(3, tramId, 4)),
+            transitStops = Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
             startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             distanceInM = 1.0
@@ -588,7 +588,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, busId, 2)),
+            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -608,7 +608,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, busId, 3)),
+            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -628,7 +628,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(3, tramId, 4)),
+            Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             1.0
@@ -648,7 +648,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(3, tramId, 4)),
+            Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 35000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 35600),
             1.0

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -36,7 +36,7 @@ import org.matsim.households.{Household, HouseholdsFactoryImpl}
 import org.scalatest.FunSpecLike
 import org.scalatest.mockito.MockitoSugar
 
-import scala.collection.{JavaConverters, mutable}
+import scala.collection.{mutable, JavaConverters}
 
 class PersonAgentSpec
     extends FunSpecLike
@@ -289,18 +289,18 @@ class PersonAgentSpec
         }
       )
 
-      val busLeg = EmbodiedBeamLeg(
-        BeamLeg(
+      val busPassengerLeg = EmbodiedBeamLeg(
+        beamLeg = BeamLeg(
           startTime = 28800,
           mode = BeamMode.BUS,
-          duration = 600,
+          duration = 1200,
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId, 0, 2)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
-            SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
-            1.0
+            SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
+            2.0
           )
         ),
         beamVehicleId = busId,
@@ -309,27 +309,8 @@ class PersonAgentSpec
         cost = 2.75,
         unbecomeDriverOnCompletion = false
       )
-      val busLeg2 = EmbodiedBeamLeg(
-        beamLeg = BeamLeg(
-          startTime = 29400,
-          mode = BeamMode.BUS,
-          duration = 600,
-          travelPath = BeamPath(
-            Vector(),
-            Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
-            SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
-            SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
-            1.0
-          )
-        ),
-        beamVehicleId = busId,
-        Id.create("TRANSIT-TYPE-DEFAULT", classOf[BeamVehicleType]),
-        asDriver = false,
-        cost = 0.0,
-        unbecomeDriverOnCompletion = false
-      )
-      val tramLeg = EmbodiedBeamLeg(
+
+      val tramPassengerLeg = EmbodiedBeamLeg(
         beamLeg = BeamLeg(
           startTime = 30000,
           mode = BeamMode.TRAM,
@@ -337,7 +318,7 @@ class PersonAgentSpec
           travelPath = BeamPath(
             linkIds = Vector(),
             linkTravelTime = Vector(),
-            transitStops = Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
+            transitStops = Some(TransitStopsInfo("someAgency", "someRoute", tramId, 0, 1)),
             startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             distanceInM = 1.0
@@ -433,9 +414,8 @@ class PersonAgentSpec
                 cost = 0.0,
                 unbecomeDriverOnCompletion = false
               ),
-              busLeg,
-              busLeg2,
-              tramLeg,
+              busPassengerLeg,
+              tramPassengerLeg,
               EmbodiedBeamLeg(
                 beamLeg = BeamLeg(
                   startTime = 30600,
@@ -473,16 +453,14 @@ class PersonAgentSpec
 
       expectMsgType[TransitReservationRequest]
       scheduler ! ScheduleTrigger(
-        BoardVehicleTrigger(28800, busLeg.beamVehicleId),
+        BoardVehicleTrigger(28800, busPassengerLeg.beamVehicleId),
         personActor
       )
       scheduler ! ScheduleTrigger(
-        AlightVehicleTrigger(30000, busLeg.beamVehicleId),
+        AlightVehicleTrigger(30000, busPassengerLeg.beamVehicleId),
         personActor
       )
-      lastSender ! ReservationResponse(Right(
-          ReserveConfirmInfo()
-        ))
+      lastSender ! ReservationResponse(Right(ReserveConfirmInfo()))
 
       events.expectMsgType[PersonEntersVehicleEvent]
 
@@ -494,26 +472,28 @@ class PersonAgentSpec
       events.expectMsgType[PersonLeavesVehicleEvent]
 
       expectMsgType[TransitReservationRequest]
-      lastSender ! ReservationResponse(Right(
+      lastSender ! ReservationResponse(
+        Right(
           ReserveConfirmInfo(
             Vector(
               ScheduleTrigger(
                 BoardVehicleTrigger(
                   30000,
-                  tramLeg.beamVehicleId
+                  tramPassengerLeg.beamVehicleId
                 ),
                 personActor
               ),
               ScheduleTrigger(
                 AlightVehicleTrigger(
                   32000,
-                  tramLeg.beamVehicleId
+                  tramPassengerLeg.beamVehicleId
                 ),
                 personActor
               ) // My tram is late!
             )
           )
-        ))
+        )
+      )
 
       //expects a message of type PersonEntersVehicleEvent
       events.expectMsgType[PersonEntersVehicleEvent]
@@ -563,38 +543,18 @@ class PersonAgentSpec
         "BeamMobsim.iteration"
       )
 
-      val busLeg = EmbodiedBeamLeg(
+      val busPassengerLeg = EmbodiedBeamLeg(
         BeamLeg(
           28800,
           BeamMode.BUS,
-          600,
+          1200,
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId, 0, 2)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
-            SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
-            1.0
-          )
-        ),
-        busId,
-        Id.create("beamVilleCar", classOf[BeamVehicleType]),
-        asDriver = false,
-        0,
-        unbecomeDriverOnCompletion = false
-      )
-      val busLeg2 = EmbodiedBeamLeg(
-        BeamLeg(
-          29400,
-          BeamMode.BUS,
-          600,
-          BeamPath(
-            Vector(),
-            Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
-            SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
-            1.0
+            2.0
           )
         ),
         busId,
@@ -603,7 +563,7 @@ class PersonAgentSpec
         0,
         unbecomeDriverOnCompletion = false
       )
-      val tramLeg = EmbodiedBeamLeg(
+      val tramPassengerLeg = EmbodiedBeamLeg(
         BeamLeg(
           30000,
           BeamMode.TRAM,
@@ -611,7 +571,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
+            Some(TransitStopsInfo("someAgency", "someRoute", tramId, 0, 1)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             1.0
@@ -631,7 +591,7 @@ class PersonAgentSpec
           BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", tramId)),
+            Some(TransitStopsInfo("someAgency", "someRoute", tramId, 0, 1)),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 35000),
             SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 35600),
             1.0
@@ -710,11 +670,11 @@ class PersonAgentSpec
       val personActor = lastSender
 
       scheduler ! ScheduleTrigger(
-        BoardVehicleTrigger(28800, busLeg.beamVehicleId),
+        BoardVehicleTrigger(28800, busPassengerLeg.beamVehicleId),
         personActor
       )
       scheduler ! ScheduleTrigger(
-        AlightVehicleTrigger(34400, busLeg.beamVehicleId),
+        AlightVehicleTrigger(34400, busPassengerLeg.beamVehicleId),
         personActor
       )
 
@@ -742,9 +702,8 @@ class PersonAgentSpec
                 0,
                 unbecomeDriverOnCompletion = false
               ),
-              busLeg,
-              busLeg2,
-              tramLeg,
+              busPassengerLeg,
+              tramPassengerLeg,
               EmbodiedBeamLeg(
                 BeamLeg(
                   30600,
@@ -782,9 +741,11 @@ class PersonAgentSpec
 
       expectMsgType[TransitReservationRequest]
 
-      lastSender ! ReservationResponse(Right(
+      lastSender ! ReservationResponse(
+        Right(
           ReserveConfirmInfo()
-        ))
+        )
+      )
       events.expectMsgType[PersonEntersVehicleEvent]
 
       //Generating 2 events of PersonCost having 0.0 cost in between PersonEntersVehicleEvent & PersonLeavesVehicleEvent
@@ -832,7 +793,8 @@ class PersonAgentSpec
       events.expectMsgType[PathTraversalEvent]
 
       expectMsgType[TransitReservationRequest]
-      lastSender ! ReservationResponse(Right(
+      lastSender ! ReservationResponse(
+        Right(
           ReserveConfirmInfo(
             Vector(
               ScheduleTrigger(
@@ -851,7 +813,8 @@ class PersonAgentSpec
               ) // My tram is late!
             )
           )
-        ))
+        )
+      )
 
       events.expectMsgType[PersonEntersVehicleEvent]
 

--- a/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAgentSpec.scala
@@ -480,12 +480,9 @@ class PersonAgentSpec
         AlightVehicleTrigger(30000, busLeg.beamVehicleId),
         personActor
       )
-      lastSender ! ReservationResponse(
-        Right(
+      lastSender ! ReservationResponse(Right(
           ReserveConfirmInfo()
-        ),
-        TRANSIT
-      )
+        ))
 
       events.expectMsgType[PersonEntersVehicleEvent]
 
@@ -497,8 +494,7 @@ class PersonAgentSpec
       events.expectMsgType[PersonLeavesVehicleEvent]
 
       expectMsgType[TransitReservationRequest]
-      lastSender ! ReservationResponse(
-        Right(
+      lastSender ! ReservationResponse(Right(
           ReserveConfirmInfo(
             Vector(
               ScheduleTrigger(
@@ -517,9 +513,7 @@ class PersonAgentSpec
               ) // My tram is late!
             )
           )
-        ),
-        TRANSIT
-      )
+        ))
 
       //expects a message of type PersonEntersVehicleEvent
       events.expectMsgType[PersonEntersVehicleEvent]
@@ -788,12 +782,9 @@ class PersonAgentSpec
 
       expectMsgType[TransitReservationRequest]
 
-      lastSender ! ReservationResponse(
-        Right(
+      lastSender ! ReservationResponse(Right(
           ReserveConfirmInfo()
-        ),
-        TRANSIT
-      )
+        ))
       events.expectMsgType[PersonEntersVehicleEvent]
 
       //Generating 2 events of PersonCost having 0.0 cost in between PersonEntersVehicleEvent & PersonLeavesVehicleEvent
@@ -841,8 +832,7 @@ class PersonAgentSpec
       events.expectMsgType[PathTraversalEvent]
 
       expectMsgType[TransitReservationRequest]
-      lastSender ! ReservationResponse(
-        Right(
+      lastSender ! ReservationResponse(Right(
           ReserveConfirmInfo(
             Vector(
               ScheduleTrigger(
@@ -861,9 +851,7 @@ class PersonAgentSpec
               ) // My tram is late!
             )
           )
-        ),
-        TRANSIT
-      )
+        ))
 
       events.expectMsgType[PersonEntersVehicleEvent]
 

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -138,7 +138,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, busId, 2)),
+            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -158,7 +158,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, busId, 3)),
+            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -178,7 +178,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             linkIds = Vector(),
             linkTravelTime = Vector(),
-            transitStops = Some(TransitStopsInfo(3, tramId, 4)),
+            transitStops = Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
             startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             distanceInM = 1.0

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -138,7 +138,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(1, "someAgency", "someRoute", busId, 2)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -158,7 +158,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo(2, "someAgency", "someRoute", busId, 3)),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -170,6 +170,26 @@ class PersonAndTransitDriverSpec
         cost = 0.0,
         unbecomeDriverOnCompletion = false
       )
+      val busPassengerLeg = EmbodiedBeamLeg(
+        BeamLeg(
+          startTime = 28800,
+          mode = BeamMode.BUS,
+          duration = 1200,
+          travelPath = BeamPath(
+            Vector(),
+            Vector(),
+            Some(TransitStopsInfo("someAgency", "someRoute", busId, 0, 2)),
+            SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
+            SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
+            2.0
+          )
+        ),
+        beamVehicleId = busId,
+        Id.create("TRANSIT-TYPE-DEFAULT", classOf[BeamVehicleType]),
+        asDriver = false,
+        cost = 2.75,
+        unbecomeDriverOnCompletion = false
+      )
       val tramLeg = EmbodiedBeamLeg(
         beamLeg = BeamLeg(
           startTime = 30000,
@@ -178,7 +198,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             linkIds = Vector(),
             linkTravelTime = Vector(),
-            transitStops = Some(TransitStopsInfo(3, "someAgency", "someRoute", tramId, 4)),
+            transitStops = Some(TransitStopsInfo("someAgency", "someRoute", tramId, 0, 1)),
             startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
             distanceInM = 1.0
@@ -338,8 +358,7 @@ class PersonAndTransitDriverSpec
                 cost = 0.0,
                 unbecomeDriverOnCompletion = false
               ),
-              busLeg,
-              busLeg2,
+              busPassengerLeg,
               tramLeg,
               EmbodiedBeamLeg(
                 beamLeg = BeamLeg(

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -138,7 +138,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
+            None,
             SpaceTime(services.geo.utm2Wgs(new Coord(166321.9, 1568.87)), 28800),
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             1.0
@@ -158,7 +158,7 @@ class PersonAndTransitDriverSpec
           travelPath = BeamPath(
             Vector(),
             Vector(),
-            Some(TransitStopsInfo("someAgency", "someRoute", busId)),
+            None,
             SpaceTime(services.geo.utm2Wgs(new Coord(167138.4, 1117)), 29400),
             SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
             1.0
@@ -191,6 +191,27 @@ class PersonAndTransitDriverSpec
         unbecomeDriverOnCompletion = false
       )
       val tramLeg = EmbodiedBeamLeg(
+        beamLeg = BeamLeg(
+          startTime = 30000,
+          mode = BeamMode.TRAM,
+          duration = 600,
+          travelPath = BeamPath(
+            linkIds = Vector(),
+            linkTravelTime = Vector(),
+            transitStops = None,
+            startPoint = SpaceTime(services.geo.utm2Wgs(new Coord(180000.4, 1200)), 30000),
+            endPoint = SpaceTime(services.geo.utm2Wgs(new Coord(190000.4, 1300)), 30600),
+            distanceInM = 1.0
+          )
+        ),
+        beamVehicleId = tramId,
+        Id.create("TRANSIT-TYPE-DEFAULT", classOf[BeamVehicleType]),
+        asDriver = false,
+        cost = 0.0,
+        unbecomeDriverOnCompletion = false
+      )
+
+      val tramPassengerLeg = EmbodiedBeamLeg(
         beamLeg = BeamLeg(
           startTime = 30000,
           mode = BeamMode.TRAM,
@@ -359,7 +380,7 @@ class PersonAndTransitDriverSpec
                 unbecomeDriverOnCompletion = false
               ),
               busPassengerLeg,
-              tramLeg,
+              tramPassengerLeg,
               EmbodiedBeamLeg(
                 beamLeg = BeamLeg(
                   startTime = 30600,

--- a/src/test/scala/beam/sflight/SfLightRouterSpec.scala
+++ b/src/test/scala/beam/sflight/SfLightRouterSpec.scala
@@ -5,7 +5,7 @@ import beam.agentsim.agents.vehicles.BeamVehicleType
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.events.SpaceTime
 import beam.router.BeamRouter._
-import beam.router.Modes.BeamMode.{BIKE, CAR, RIDE_HAIL, WALK, WALK_TRANSIT}
+import beam.router.Modes.BeamMode.{BIKE, CAR, RIDE_HAIL, TRAM, WALK, WALK_TRANSIT}
 import beam.router.model.{BeamLeg, BeamPath, BeamTrip, EmbodiedBeamTrip}
 import beam.router.{BeamRouter, Modes}
 import org.matsim.api.core.v01.{Coord, Id}
@@ -65,6 +65,8 @@ class SfLightRouterSpec extends AbstractSfLightSpec("SfLightRouterSpec") with In
       assert(response.itineraries.exists(_.tripClassifier == WALK_TRANSIT))
       val transitOption = response.itineraries.find(_.tripClassifier == WALK_TRANSIT).get
       assertMakesSense(transitOption.toBeamTrip)
+      assert(transitOption.totalTravelTimeInSecs == 1116)
+      assert(transitOption.legs(1).beamLeg.mode == TRAM)
       assert(transitOption.costEstimate == 2.75)
       assert(transitOption.legs.head.beamLeg.startTime == 25992)
     }


### PR DESCRIPTION
As a precondition to #1711, don't require passengers to present the exact same sequence of legs to the bus driver that they are going to ride. Instead, tell them the "slice" of the trip we want to take, by start and end index into the stop sequence.

As a side effect, the big global transit map isn't required anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1928)
<!-- Reviewable:end -->
