### PR TITLE
Write plans.csv before iteration starts instead of after finish

### DIFF
--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -205,12 +205,6 @@ class BeamSim @Inject()(
       }
       createGraphsFromEvents.createGraphs(event)
 
-//      val interval = beamConfig.beam.outputs.writePlansInterval
-//      val iterationNumber = event.getIteration
-//      val controllerIO = event.getServices.getControlerIO
-//      if (interval > 0 && iterationNumber % interval == 0) {
-//        PlansCsvWriter.toCsv(scenario, controllerIO.getIterationFilename(iterationNumber, "plans.csv"))
-//      }
       iterationSummaryStats += iterationStatsProviders
         .flatMap(_.getSummaryStats.asScala)
         .toMap

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -181,7 +181,7 @@ class BeamSim @Inject()(
     }
   }
 
-  private def shouldWritePlansAtCurrentIteration(iterationNumber: Int):Boolean = {
+  private def shouldWritePlansAtCurrentIteration(iterationNumber: Int): Boolean = {
     val beamConfig: BeamConfig = beamConfigChangesObservable.getUpdatedBeamConfig
     val interval = beamConfig.beam.outputs.writePlansInterval
     interval > 0 && iterationNumber % interval == 0


### PR DESCRIPTION
After run Beamville

## Iteration 0:

### Xml
```xml
<person id="47">
    <plan score="127.78246793517155" selected="yes">
        <attributes>
            <attribute name="modality-style" class="java.lang.String" >class2</attribute>
        </attributes>
        <activity type="Home" link="sfpt173961" x="170308.4" y="2964.6474" end_time="06:45:00" >
        </activity>
        <activity type="Work" link="sfpt539076" x="169346.4" y="876.7536" end_time="19:59:58" >
        </activity>
        <activity type="Home" link="sfpt173961" x="170308.4" y="2964.6474" >
        </activity>
    </plan>
</person>
```
### Csv:
```csv
47,0,activity,0,Home,170308.4,2964.6474,24300.0,
47,0,activity,1,Work,169346.4,876.7536,71998.0,
47,0,activity,2,Home,170308.4,2964.6474,-Infinity,
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1937)
<!-- Reviewable:end -->
