### PR TITLE
all pattern matching ops on ChargingPointType now cover all cases

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
@@ -56,30 +56,30 @@ object ChargingPointType {
 
   }
 
-  private[ChargingPointType] val CustomChargingPointRegex: Regex = "(\\w+)\\((\\d+),(\\w+)\\)".r
+  private[ChargingPointType] val CustomChargingPointRegex: Regex = "(\\w+)\\((\\d+),(\\w+)\\)".r.unanchored
 
   // matches either the standard ones or a custom one
   // these were breaking some tests with a ChargingPoint parsing error caused by Event handlers
   def apply(s: String): Option[ChargingPointType] = {
     s.trim.toLowerCase match {
-//      case "householdsocket"              => Some(HouseholdSocket)
-//      case "bluehouseholdsocket"          => Some(BlueHouseholdSocket)
-//      case "cee16asocket"                 => Some(Cee16ASocket)
-//      case "cee32asocket"                 => Some(Cee32ASocket)
-//      case "cee63asocket"                 => Some(Cee63ASocket)
-//      case "chargingstationtype1"         => Some(ChargingStationType1)
-//      case "chargingstationtype2"         => Some(ChargingStationType2)
-//      case "chargingstationccscombotype1" => Some(ChargingStationCcsComboType1)
-//      case "chargingstationccscombotype2" => Some(ChargingStationCcsComboType2)
-//      case "teslasupercharger"            => Some(TeslaSuperCharger)
+      case "householdsocket"              => Some(HouseholdSocket)
+      case "bluehouseholdsocket"          => Some(BlueHouseholdSocket)
+      case "cee16asocket"                 => Some(Cee16ASocket)
+      case "cee32asocket"                 => Some(Cee32ASocket)
+      case "cee63asocket"                 => Some(Cee63ASocket)
+      case "chargingstationtype1"         => Some(ChargingStationType1)
+      case "chargingstationtype2"         => Some(ChargingStationType2)
+      case "chargingstationccscombotype1" => Some(ChargingStationCcsComboType1)
+      case "chargingstationccscombotype2" => Some(ChargingStationCcsComboType2)
+      case "teslasupercharger"            => Some(TeslaSuperCharger)
       case "level1"    => Some(Level1)
       case "level2"    => Some(Level2)
       case "dcfast"    => Some(DCFast)
       case "ultrafast" => Some(UltraFast)
       case "nocharger" => Some(NoCharger)
 //      case ""                             => None
-//      case CustomChargingPointRegex(id, installedCapacity, currentType) =>
-//        Some(CustomChargingPoint(id, installedCapacity, currentType))
+      case CustomChargingPointRegex(id, installedCapacity, currentType) =>
+        Some(CustomChargingPoint(id, installedCapacity, currentType))
       case _ => None
 //        throw new IllegalArgumentException("invalid argument for ChargingPointType: " + s.trim)
     }
@@ -99,6 +99,12 @@ object ChargingPointType {
       case ChargingStationCcsComboType2 => 50
       case TeslaSuperCharger            => 135
       case CustomChargingPoint(_, v, _) => v
+      // legacy charging points (values taken from 2018 BEAM code)
+      case Level1                       => 1.5
+      case Level2                       => 6.7
+      case DCFast                       => 50
+      case UltraFast                    => 250
+      case NoCharger                    => 0
       case _                            => throw new IllegalArgumentException("invalid argument")
     }
   }
@@ -116,6 +122,12 @@ object ChargingPointType {
       case ChargingStationCcsComboType2 => DC
       case TeslaSuperCharger            => DC
       case CustomChargingPoint(_, _, c) => c
+      // legacy charging points
+      case Level2                       => AC
+      case Level1                       => AC
+      case DCFast                       => DC
+      case UltraFast                    => DC
+      case NoCharger                    => AC
       case _                            => throw new IllegalArgumentException("invalid argument")
     }
   }

--- a/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
@@ -72,11 +72,11 @@ object ChargingPointType {
       case "chargingstationccscombotype1" => Some(ChargingStationCcsComboType1)
       case "chargingstationccscombotype2" => Some(ChargingStationCcsComboType2)
       case "teslasupercharger"            => Some(TeslaSuperCharger)
-      case "level1"    => Some(Level1)
-      case "level2"    => Some(Level2)
-      case "dcfast"    => Some(DCFast)
-      case "ultrafast" => Some(UltraFast)
-      case "nocharger" => Some(NoCharger)
+      case "level1"                       => Some(Level1)
+      case "level2"                       => Some(Level2)
+      case "dcfast"                       => Some(DCFast)
+      case "ultrafast"                    => Some(UltraFast)
+      case "nocharger"                    => Some(NoCharger)
 //      case ""                             => None
       case CustomChargingPointRegex(id, installedCapacity, currentType) =>
         Some(CustomChargingPoint(id, installedCapacity, currentType))
@@ -100,12 +100,12 @@ object ChargingPointType {
       case TeslaSuperCharger            => 135
       case CustomChargingPoint(_, v, _) => v
       // legacy charging points (values taken from 2018 BEAM code)
-      case Level1                       => 1.5
-      case Level2                       => 6.7
-      case DCFast                       => 50
-      case UltraFast                    => 250
-      case NoCharger                    => 0
-      case _                            => throw new IllegalArgumentException("invalid argument")
+      case Level1    => 1.5
+      case Level2    => 6.7
+      case DCFast    => 50
+      case UltraFast => 250
+      case NoCharger => 0
+      case _         => throw new IllegalArgumentException("invalid argument")
     }
   }
 
@@ -123,12 +123,12 @@ object ChargingPointType {
       case TeslaSuperCharger            => DC
       case CustomChargingPoint(_, _, c) => c
       // legacy charging points
-      case Level2                       => AC
-      case Level1                       => AC
-      case DCFast                       => DC
-      case UltraFast                    => DC
-      case NoCharger                    => AC
-      case _                            => throw new IllegalArgumentException("invalid argument")
+      case Level2    => AC
+      case Level1    => AC
+      case DCFast    => DC
+      case UltraFast => DC
+      case NoCharger => AC
+      case _         => throw new IllegalArgumentException("invalid argument")
     }
   }
 


### PR DESCRIPTION
errors were occurring because the legacy `ChargingPointType`s were not properly "cased out" in pattern matching over `ChargingPointType` values.

i also modified the ChargingPointType Regex so that it is "unanchored" and can grab occurrences of the named charging point from a row at any position. that is consistent with the design, but, now that i'm thinking about it, if a user used a reserved ChargingPointType or PricingModel name in their TAZ name, then the regex would find that. maybe we should restrict our parsing to the row/column instead of the entire row.

anyhow, this fixes the bug. perhaps additionally we should add test class(es) for the charging code. 

Closes #1940.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1941)
<!-- Reviewable:end -->
