### PR TITLE
only park at charger if you plan to charge

### DIFF
--- a/src/main/scala/beam/agentsim/agents/household/HouseholdActor.scala
+++ b/src/main/scala/beam/agentsim/agents/household/HouseholdActor.scala
@@ -457,7 +457,7 @@ object HouseholdActor {
           veh.manager = Some(self)
           veh.spaceTime = SpaceTime(homeCoord.getX, homeCoord.getY, 0)
           for {
-            ParkingInquiryResponse(stall, _) <- parkingManager ? ParkingInquiry(homeCoord, "home", 0.0, None, 0)
+            ParkingInquiryResponse(stall, _) <- parkingManager ? ParkingInquiry(homeCoord, "init", 0.0, None, 0)
           } {
             veh.useParkingStall(stall)
           }

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -55,10 +55,16 @@ trait ChoosesMode {
 
   def boundingBox: Envelope
 
-  def currentTourBeamVehicle: BeamVehicle =
-    beamVehicles(stateData.asInstanceOf[ChoosesModeData].personData.currentTourPersonalVehicle.get)
-      .asInstanceOf[ActualVehicle]
-      .vehicle
+  def currentTourBeamVehicle: Option[BeamVehicle] =
+    stateData.asInstanceOf[ChoosesModeData].personData.currentTourPersonalVehicle match {
+      case Some(personalVehicle) =>
+        Option(
+          beamVehicles(personalVehicle)
+            .asInstanceOf[ActualVehicle]
+            .vehicle
+        )
+      case _ => None
+    }
 
   onTransition {
     case _ -> ChoosingMode =>
@@ -736,7 +742,7 @@ trait ChoosesMode {
       attributes.valueOfTime,
       None,
       duration,
-      Option(currentTourBeamVehicle.beamVehicleType),
+      currentTourBeamVehicle,
       reserveStall = false,
     )
     parkingManager ! inquiry

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -736,7 +736,8 @@ trait ChoosesMode {
       attributes.valueOfTime,
       None,
       duration,
-      reserveStall = false
+      Option(currentTourBeamVehicle.beamVehicleType),
+      reserveStall = false,
     )
     parkingManager ! inquiry
     Some(inquiry.requestId)

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingInquiry.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingInquiry.scala
@@ -1,5 +1,5 @@
 package beam.agentsim.infrastructure
-import beam.agentsim.agents.vehicles.BeamVehicleType
+import beam.agentsim.agents.vehicles.BeamVehicle
 import beam.agentsim.infrastructure.charging.ChargingInquiryData
 import beam.router.BeamRouter.Location
 import beam.utils.ParkingManagerIdGenerator
@@ -19,7 +19,7 @@ case class ParkingInquiry(
   valueOfTime: Double,
   chargingInquiryData: Option[ChargingInquiryData[String, String]],
   parkingDuration: Double,
-  vehicleType: Option[BeamVehicleType] = None,
+  vehicleType: Option[BeamVehicle] = None,
   reserveStall: Boolean = true,
   requestId: Int = ParkingManagerIdGenerator.nextId // note, this expects all Agents exist in the same JVM to rely on calling this singleton
 )

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingInquiry.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingInquiry.scala
@@ -1,4 +1,5 @@
 package beam.agentsim.infrastructure
+import beam.agentsim.agents.vehicles.BeamVehicleType
 import beam.agentsim.infrastructure.charging.ChargingInquiryData
 import beam.router.BeamRouter.Location
 import beam.utils.ParkingManagerIdGenerator
@@ -18,6 +19,7 @@ case class ParkingInquiry(
   valueOfTime: Double,
   chargingInquiryData: Option[ChargingInquiryData[String, String]],
   parkingDuration: Double,
+  vehicleType: Option[BeamVehicleType] = None,
   reserveStall: Boolean = true,
   requestId: Int = ParkingManagerIdGenerator.nextId // note, this expects all Agents exist in the same JVM to rely on calling this singleton
 )

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -46,7 +46,7 @@ class ZonalParkingManager(
         case _                                   => Seq(ParkingType.Public)
       }
 
-      val vehicleIntendsToCharge: Boolean = inquiry.vehicleType match {
+      val vehicleCanParkAtCharger: Boolean = inquiry.vehicleType match {
         case Some(vehicleType)
             if vehicleType.beamVehicleType.primaryFuelType == Electricity || vehicleType.beamVehicleType.secondaryFuelType
               .contains(Electricity) =>
@@ -68,7 +68,7 @@ class ZonalParkingManager(
         tazTreeMap.tazQuadTree,
         geo.distUTMInMeters,
         rand,
-        vehicleIntendsToCharge,
+        vehicleCanParkAtCharger,
         boundingBox
       )
 
@@ -219,7 +219,7 @@ object ZonalParkingManager extends LazyLogging {
     tazQuadTree: QuadTree[TAZ],
     distanceFunction: (Coord, Coord) => Double,
     random: Random,
-    vehicleIntendsToCharge: Boolean,
+    vehicleCanParkAtCharger: Boolean,
     boundingBox: Envelope
   ): (ParkingZone, ParkingStall) = {
 
@@ -248,7 +248,7 @@ object ZonalParkingManager extends LazyLogging {
           stalls,
           distanceFunction,
           random,
-          vehicleIntendsToCharge
+          vehicleCanParkAtCharger
         ) match {
           case Some(
               ParkingRanking.RankingAccumulator(

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearch.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearch.scala
@@ -86,8 +86,11 @@ object ParkingZoneSearch {
       parkingType         <- parkingTypes
       parkingZoneIds      <- parkingTypesSubtree.get(parkingType).toList
       parkingZoneId       <- parkingZoneIds
-      if parkingZones(parkingZoneId).stallsAvailable > 0 & (parkingZones(parkingZoneId).chargingPointType
-        .getOrElse(ChargingPointType.NoCharger) == ChargingPointType.NoCharger || vehicleIntendsToCharge)
+      if parkingZones(parkingZoneId).stallsAvailable > 0 & canThisCarParkHere(
+        parkingZones(parkingZoneId),
+        parkingType,
+        vehicleIntendsToCharge
+      )
     } yield {
       // get the zone
       Try {
@@ -110,6 +113,8 @@ object ParkingZoneSearch {
     parkingType: ParkingType,
     vehicleIntendsToCharge: Boolean
   ): Boolean = {
+
+    // Cars can park at residential spots with a slow charger. Mainly added to allow for flexibility later
     parkingType match {
       case ParkingType.Residential =>
         ChargingPointType.getChargingPointCurrent(parkingZone.chargingPointType.getOrElse(ChargingPointType.NoCharger)) match {

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearch.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearch.scala
@@ -2,7 +2,6 @@ package beam.agentsim.infrastructure.parking
 
 import scala.collection.Map
 import scala.util.{Failure, Random, Success, Try}
-
 import beam.agentsim.infrastructure.charging._
 import beam.agentsim.infrastructure.parking.ParkingRanking.RankingAccumulator
 import beam.agentsim.infrastructure.taz.TAZ
@@ -42,10 +41,19 @@ object ParkingZoneSearch {
     tree: ZoneSearch[TAZ],
     parkingZones: Array[ParkingZone],
     distanceFunction: (Coord, Coord) => Double,
-    random: Random
+    random: Random,
+    canParkAtFastCharger: Boolean = false
   ): Option[RankingAccumulator] = {
     val found = findParkingZones(destinationUTM, tazList, parkingTypes, tree, parkingZones, random)
-    takeBestByRanking(destinationUTM, valueOfTime, parkingDuration, found, chargingInquiryData, distanceFunction)
+    takeBestByRanking(
+      destinationUTM,
+      valueOfTime,
+      parkingDuration,
+      found,
+      chargingInquiryData,
+      distanceFunction,
+      canParkAtFastCharger
+    )
   }
 
   /**
@@ -106,7 +114,8 @@ object ParkingZoneSearch {
     parkingDuration: Double,
     found: Iterable[(TAZ, ParkingType, ParkingZone, Coord)],
     chargingInquiryData: Option[ChargingInquiryData[String, String]],
-    distanceFunction: (Coord, Coord) => Double
+    distanceFunction: (Coord, Coord) => Double,
+    canParkAtFastCharger: Boolean = false
   ): Option[RankingAccumulator] = {
     found.foldLeft(Option.empty[RankingAccumulator]) { (accOption, parkingZoneTuple) =>
       val (thisTAZ: TAZ, thisParkingType: ParkingType, thisParkingZone: ParkingZone, stallLocation: Coord) =

--- a/src/test/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearchSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/parking/ParkingZoneSearchSpec.scala
@@ -25,7 +25,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           tree,
           zones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result should be(None)
@@ -43,7 +44,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           parkingSearchTree,
           parkingZones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result match {
@@ -79,7 +81,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           parkingSearchTree,
           parkingZones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result match {
@@ -121,7 +124,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           parkingSearchTree,
           parkingZones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result match {
@@ -157,7 +161,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           parkingSearchTree,
           parkingZones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result match {
@@ -193,7 +198,8 @@ class ParkingZoneSearchSpec extends WordSpec with Matchers {
           parkingSearchTree,
           parkingZones,
           ParkingZoneSearchSpec.mockGeoUtils.distUTMInMeters,
-          ParkingZoneSearchSpec.random
+          ParkingZoneSearchSpec.random,
+          true
         )
 
         result match {


### PR DESCRIPTION
Modify parkingZoneSearch such that non-EVs don't get see the option of parking at fast chargers (or all chargers?). To figure out still:

-- All chargers or just fast chargers?
-- Should it depend on the state of charge of the vehicle?
-- Should any vehicles be initialized at fast chargers at the beginning of the day?

Closes #1963 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1968)
<!-- Reviewable:end -->
