### PR TITLE
Simplify the reading/writing of ride-hail fleet

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -414,7 +414,7 @@ class RideHailManager(
       new RideHailFleetInitializer().init(beamServices) foreach { fleetData =>
         createRideHailVehicleAndAgent(
           fleetData.id.split("-").toList.tail.mkString("-"),
-          beamScenario.vehicleTypes(Id.create("Car", classOf[BeamVehicleType])),
+          beamScenario.vehicleTypes(Id.create(fleetData.vehicleType, classOf[BeamVehicleType])),
           new Coord(fleetData.initialLocationX, fleetData.initialLocationY),
           fleetData.shifts,
           fleetData.toGeofence

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -407,11 +407,12 @@ class RideHailManager(
         }
       }
 
-      new RideHailFleetInitializer().writeFleetData(beamServices, fleetData)
+      RideHailFleetInitializer.writeFleetData(beamServices, fleetData)
       log.info("Initialized {} ride hailing shifts", idx)
 
     case "FILE" =>
-      new RideHailFleetInitializer().init(beamServices) foreach { fleetData =>
+      val fleetFilePath = beamServices.beamConfig.beam.agentsim.agents.rideHail.initialization.filePath
+      RideHailFleetInitializer.readFleetFromCSV(fleetFilePath).foreach { fleetData =>
         createRideHailVehicleAndAgent(
           fleetData.id.split("-").toList.tail.mkString("-"),
           beamScenario.vehicleTypes(Id.create(fleetData.vehicleType, classOf[BeamVehicleType])),

--- a/src/main/scala/beam/sim/RideHailFleetInitializer.scala
+++ b/src/main/scala/beam/sim/RideHailFleetInitializer.scala
@@ -1,21 +1,20 @@
 package beam.sim
 
-import java.io.{BufferedInputStream, File, FileInputStream, FileNotFoundException}
-import java.util.zip.GZIPInputStream
-
 import beam.analysis.plots.GraphsStatsAgentSimEventsListener
 import beam.sim.RideHailFleetInitializer.RideHailAgentInputData
 import beam.sim.common.Range
-import beam.utils.{FileUtils, OutputDataDescriptor}
+import beam.utils.OutputDataDescriptor
+import beam.utils.csv.{CsvWriter, GenericCsvReader}
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.collection.mutable
-import scala.io.{BufferedSource, Source}
+import scala.util.Try
+import scala.util.control.NonFatal
 
 class RideHailFleetInitializer extends LazyLogging {
 
   /**
     * Initializes [[beam.agentsim.agents.ridehail.RideHailAgent]] fleet
+    *
     * @param beamServices beam services instance
     * @return list of [[beam.agentsim.agents.ridehail.RideHailAgent]] objects
     */
@@ -31,6 +30,7 @@ class RideHailFleetInitializer extends LazyLogging {
 
   /**
     * Reads the ride hail fleet csv as [[beam.agentsim.agents.ridehail.RideHailAgent]] objects
+    *
     * @param filePath path to the csv file
     * @return list of [[beam.agentsim.agents.ridehail.RideHailAgent]] objects
     */
@@ -38,135 +38,91 @@ class RideHailFleetInitializer extends LazyLogging {
     filePath: String,
     beamServices: BeamServices
   ): List[RideHailAgentInputData] = {
+    def toRideHailAgentInputData(rec: java.util.Map[String, String]): RideHailAgentInputData = {
+      val id = GenericCsvReader.getIfNotNull(rec, "id")
+      val rideHailManagerId = GenericCsvReader.getIfNotNull(rec, "rideHailManagerId")
+      val vehicleType = GenericCsvReader.getIfNotNull(rec, "vehicleType")
+      val initialLocationX = GenericCsvReader.getIfNotNull(rec, "initialLocationX").toDouble
+      val initialLocationY = GenericCsvReader.getIfNotNull(rec, "initialLocationY").toDouble
+      val shifts = Option(rec.get("shifts"))
+      val geofenceX = Option(rec.get("geofenceX")).map(_.toDouble)
+      val geofenceY = Option(rec.get("geofenceY")).map(_.toDouble)
+      val geofenceRadius = Option(rec.get("geofenceRadius")).map(_.toDouble)
+      RideHailAgentInputData(
+        id = id,
+        rideHailManagerId = rideHailManagerId,
+        vehicleType = vehicleType,
+        initialLocationX = initialLocationX,
+        initialLocationY = initialLocationY,
+        shifts = shifts,
+        geofenceX = geofenceX,
+        geofenceY = geofenceY,
+        geofenceRadius = geofenceRadius
+      )
+    }
+    // This is lazy, to make it to read the data we need to call `.toList`
+    val (iter, toClose) = GenericCsvReader.readAs[RideHailAgentInputData](filePath, toRideHailAgentInputData, x => true)
     try {
-      //read csv data from the given file path
-      val bufferedSource: BufferedSource = if (filePath.endsWith(".gz")) {
-        Source.fromInputStream(new GZIPInputStream(new BufferedInputStream(new FileInputStream(filePath))))
-      } else {
-        Source.fromFile(filePath)
-      }
-      val data = bufferedSource.getLines()
-      // if the file is empty proceed , else throw an error
-      if (data.nonEmpty) {
-        val headerKeys: Array[String] = data.next().split(",").map(_.trim)
-        import RideHailFleetInitializer._
-        val keys = mutable.LinkedHashSet(
-          attr_id,
-          attr_rideHailManagerId,
-          attr_vehicleType,
-          attr_initialLocationX,
-          attr_initialLocationY,
-          attr_shifts,
-          attr_geofenceX,
-          attr_geofenceY,
-          attr_geofenceRadius
-        )
-        // compute the indices for all header keys in the csv
-        val keyIndices: Map[String, Int] = (keys map { k =>
-          k -> headerKeys.indexOf(k)
-        }).toMap
-        val invalidIndices: Map[String, Int] = keyIndices.filter(k => k._2 == -1)
-        // validate for any missing fields and throw an error (if any)
-        if (invalidIndices.isEmpty) {
-          val rideHailAgents: Seq[RideHailAgentInputData] =
-            //for each data entry in the csv file
-            bufferedSource.getLines().toList.map(s => s.split(",", -1)).flatMap { row =>
-              try {
-                //generate the FleetData object from the csv entry
-                val geofenceX =
-                  if (row(keyIndices.getOrElse(attr_geofenceX, -1)).isEmpty) None
-                  else Some(row(keyIndices.getOrElse(attr_geofenceX, -1)).toDouble)
-                val geofenceY =
-                  if (row(keyIndices.getOrElse(attr_geofenceY, -1)).isEmpty) None
-                  else Some(row(keyIndices.getOrElse(attr_geofenceY, -1)).toDouble)
-                val geofenceRadius =
-                  if (row(keyIndices.getOrElse(attr_geofenceRadius, -1)).isEmpty) None
-                  else Some(row(keyIndices.getOrElse(attr_geofenceRadius, -1)).toDouble)
-
-                val fleetData: RideHailAgentInputData = RideHailAgentInputData(
-                  id = row(keyIndices.getOrElse(attr_id, -1)),
-                  rideHailManagerId = row(keyIndices.getOrElse(attr_rideHailManagerId, -1)),
-                  vehicleType = row(keyIndices.getOrElse(attr_vehicleType, -1)),
-                  initialLocationX =
-                    if (row(keyIndices.getOrElse(attr_initialLocationX, -1)).isEmpty) 0.0
-                    else row(keyIndices.getOrElse(attr_initialLocationX, -1)).toDouble,
-                  initialLocationY =
-                    if (row(keyIndices.getOrElse(attr_initialLocationY, -1)).isEmpty) 0.0
-                    else row(keyIndices.getOrElse(attr_initialLocationY, -1)).toDouble,
-                  shifts =
-                    if (row(keyIndices.getOrElse(attr_shifts, -1)).isEmpty) None
-                    else Some(row(keyIndices.getOrElse(attr_shifts, -1))),
-                  geofenceX = geofenceX,
-                  geofenceY = geofenceY,
-                  geofenceRadius = geofenceRadius
-                )
-                Some(fleetData)
-              } catch {
-                case e: Exception =>
-                  logger
-                    .error("Error while reading an entry of ride-hail-fleet.csv as RideHailAgent : " + e.getMessage, e)
-                  None
-              }
-            }
-          //return the list of initialized fleet data objects
-          rideHailAgents.toList
-        } else {
-          logger.error(s"Fields not found in csv header - ${invalidIndices.keySet.mkString(", ")}")
-          List.empty
-        }
-      } else {
-        logger.error(s"Input file is empty - $filePath")
-        List.empty[RideHailAgentInputData]
-      }
+      // Read the data
+      val fleetData = iter.toList
+      logger.info(s"Read fleet data with ${fleetData.size} entries from '$filePath'")
+      fleetData
     } catch {
-      case fne: FileNotFoundException =>
-        logger.error(s"No file found at path - $filePath", fne)
-        List.empty[RideHailAgentInputData]
-      case e: Exception =>
-        logger.error("Error while reading an entry of ride-hail-fleet.csv as RideHailAgent : " + e.getMessage, e)
-        List.empty[RideHailAgentInputData]
+      case NonFatal(ex) =>
+        logger.error(s"Could not initialize fleet from '$filePath': ${ex.getMessage}", ex)
+        List.empty
+    } finally {
+      toClose.close()
     }
   }
 
   /**
     * A writer that writes the initialized fleet data to a csv on all iterations
+    *
     * @param beamServices beam services isntance
     * @param fleetData data to be written
     */
   def writeFleetData(beamServices: BeamServices, fleetData: Seq[RideHailAgentInputData]): Unit = {
     try {
-      // Not sure this can even happen..
-      if (beamServices.matsimServices == null || beamServices.matsimServices.getControlerIO == null) return
-      // If iteration directory doesn't exist, we are not in an iteration and shouldn't write anything
-      // (Class is run on its own.)
-      // (Normally, only ControlerListeners write things to the OutputDirectoryHierarchy.)
-      if (!new File(
-            beamServices.matsimServices.getControlerIO.getIterationPath(beamServices.matsimServices.getIterationNumber)
-          ).exists()) return
       val filePath = beamServices.matsimServices.getControlerIO
         .getIterationFilename(
           beamServices.matsimServices.getIterationNumber,
           RideHailFleetInitializer.outputFileBaseName + ".csv.gz"
         )
-      val fileHeader = classOf[RideHailAgentInputData].getDeclaredFields.map(_.getName).mkString(", ")
-      val data = fleetData map { f =>
-        f.productIterator.map(
-          f =>
-            f match {
-              case Some(x: String) => x
-              case x: String       => x
-              case None            => ""
-              case _               => f
-          }
-        ) mkString ", "
-      } mkString "\n"
-      FileUtils.writeToFile(filePath, Some(fileHeader), data, None)
+      val fileHeader: Array[String] = Array[String](
+        "id",
+        "rideHailManagerId",
+        "vehicleType",
+        "initialLocationX",
+        "initialLocationY",
+        "shifts",
+        "geofenceX",
+        "geofenceY",
+        "geofenceRadius"
+      )
+      val csvWriter = new CsvWriter(filePath, fileHeader)
+      Try {
+        fleetData.foreach { fleetData =>
+          csvWriter.write(
+            fleetData.id,
+            fleetData.rideHailManagerId,
+            fleetData.vehicleType,
+            fleetData.initialLocationX,
+            fleetData.initialLocationY,
+            fleetData.shifts.getOrElse(""),
+            fleetData.geofenceX.getOrElse(""),
+            fleetData.geofenceY.getOrElse(""),
+            fleetData.geofenceRadius.getOrElse("")
+          )
+        }
+      }
+      csvWriter.close()
+      logger.info(s"Fleet data with ${fleetData.size} entries is written to '${filePath}'")
     } catch {
       case e: Exception =>
         logger.error("Error while writing procedurally initialized ride hail fleet data to csv ", e)
     }
   }
-
 }
 
 object RideHailFleetInitializer extends OutputDataDescriptor {
@@ -175,6 +131,7 @@ object RideHailFleetInitializer extends OutputDataDescriptor {
 
   /**
     * Generates Ranges from the range value as string
+    *
     * @param rangesAsString ranges as string value
     * @return List of ranges
     */
@@ -215,6 +172,7 @@ object RideHailFleetInitializer extends OutputDataDescriptor {
 
   /**
     * An intermediary class to hold the ride hail fleet data read from the file.
+    *
     * @param id id of the vehicle
     * @param rideHailManagerId id of the ride hail manager
     * @param vehicleType type of the beam vehicle

--- a/src/main/scala/beam/utils/csv/CsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/CsvWriter.scala
@@ -1,0 +1,77 @@
+package beam.utils.csv
+
+import java.io.Writer
+import org.matsim.core.utils.io.IOUtils
+import scala.util.Try
+
+case class Delimiter(value: String = ",")
+case class LineSeparator(value: String = System.lineSeparator())
+
+class CsvWriter(
+  path: String,
+  headers: IndexedSeq[String],
+  implicit val delimiter: Delimiter = Delimiter(),
+  implicit val lineSeparator: LineSeparator = LineSeparator()
+) extends AutoCloseable {
+  implicit val writer: Writer = IOUtils.getBufferedWriter(path)
+  CsvWriter.writeHeader(headers)
+
+  def writeColumn(value: Any, shouldAddDelimiter: Boolean = true): Unit = {
+    CsvWriter.writeColumnValue(value, shouldAddDelimiter)
+  }
+
+  def write(xs: Any*): Unit = {
+    writeRow(xs.toVector)
+  }
+
+  def writeRow(values: IndexedSeq[Any]): Unit = {
+    values.zipWithIndex.foreach {
+      case (value, idx) =>
+        val shouldAddDelimiter = idx != values.length - 1
+        CsvWriter.writeColumnValue(value, shouldAddDelimiter)
+    }
+    CsvWriter.writeLineSeparator
+  }
+
+  def writeNewLine(): Unit = {
+    CsvWriter.writeLineSeparator
+  }
+
+  override def close(): Unit = {
+    Try(writer.close())
+  }
+}
+
+object CsvWriter {
+
+  def writeColumnValue(
+    value: Any,
+    shouldAddDelimiter: Boolean = true
+  )(implicit wrt: Writer, delimiter: Delimiter): Unit = {
+    // Make sure Option is handled properly (None -> "", Some(x) -> x)
+    val toWrite = value match {
+      case None    => ""
+      case Some(x) => x
+      case x       => x
+    }
+    wrt.append(toWrite.toString)
+    if (shouldAddDelimiter)
+      wrt.append(delimiter.value)
+  }
+
+  def writeHeader(
+    headers: IndexedSeq[String]
+  )(implicit wrt: Writer, delimiter: Delimiter, lineSeparator: LineSeparator): Unit = {
+    headers.zipWithIndex.foreach {
+      case (header, idx) =>
+        val shouldAddDelimiter = idx != headers.size - 1
+        writeColumnValue(header, shouldAddDelimiter)
+    }
+    wrt.append(lineSeparator.value)
+    wrt.flush()
+  }
+
+  def writeLineSeparator(implicit wrt: Writer, lineSeparator: LineSeparator): Unit = {
+    wrt.write(lineSeparator.value)
+  }
+}

--- a/src/main/scala/beam/utils/csv/GenericCsvReader.scala
+++ b/src/main/scala/beam/utils/csv/GenericCsvReader.scala
@@ -1,0 +1,33 @@
+package beam.utils.csv
+
+import java.io.Closeable
+
+import beam.utils.FileUtils
+import org.supercsv.io.CsvMapReader
+import org.supercsv.prefs.CsvPreference
+
+import scala.reflect.ClassTag
+
+trait GenericCsvReader {
+
+  def readAs[T](path: String, mapper: java.util.Map[String, String] => T, filterPredicate: T => Boolean)(
+    implicit ct: ClassTag[T]
+  ): (Iterator[T], Closeable) = {
+    val csvRdr = new CsvMapReader(FileUtils.readerFromFile(path), CsvPreference.STANDARD_PREFERENCE)
+    val header = csvRdr.getHeader(true)
+    val iterator = Iterator
+      .continually(csvRdr.read(header: _*))
+      .takeWhile(_ != null)
+      .map(mapper)
+      .filter(filterPredicate)
+    (iterator, csvRdr)
+  }
+
+  def getIfNotNull(rec: java.util.Map[String, String], column: String): String = {
+    val v = rec.get(column)
+    assert(v != null, s"Value in column '$column' is null")
+    v
+  }
+}
+
+object GenericCsvReader extends GenericCsvReader

--- a/src/test/scala/beam/sim/RideHailFleetInitializerSpec.scala
+++ b/src/test/scala/beam/sim/RideHailFleetInitializerSpec.scala
@@ -1,0 +1,82 @@
+package beam.sim
+
+import java.io.File
+import java.nio.file.Files
+
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.util.Try
+import scala.collection.JavaConverters._
+
+class RideHailFleetInitializerSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+  val filePath: String = File.createTempFile("0.rideHailFleet", ".csv.gz").getAbsolutePath
+  println(filePath)
+
+  override def afterAll(): Unit = {
+    Try {
+      Files.delete(new File(filePath).toPath)
+    }
+    super.afterAll()
+  }
+
+  "RideHailFleetInitializer" should {
+    "be able to write fleet data to CSV and read it back" in {
+      val data1 = RideHailFleetInitializer.RideHailAgentInputData(
+        "1",
+        "2",
+        "CAR",
+        1.0,
+        2.0,
+        Some("{1:2}"),
+        Some(3.0),
+        Some(4.0),
+        Some(5.0)
+      )
+      val data2 = RideHailFleetInitializer.RideHailAgentInputData(
+        "2",
+        "2",
+        "CAV",
+        6.0,
+        7.0,
+        None,
+        None,
+        None,
+        None
+      )
+      val expectedFleetData = Seq(data1, data2)
+
+      RideHailFleetInitializer.writeFleetData(filePath, expectedFleetData)
+
+      val readFleetData = RideHailFleetInitializer.readFleetFromCSV(filePath)
+      readFleetData shouldBe expectedFleetData
+    }
+
+    "be able to create RideHailAgentInputData from the map" in {
+      val map = Map[String, String](
+        "id"                -> "1",
+        "rideHailManagerId" -> "2",
+        "vehicleType"       -> "CAR",
+        "initialLocationX"  -> "1.0",
+        "initialLocationY"  -> "2.0",
+        "shifts"            -> "{1:2}",
+        "geofenceX"         -> null, // Yes, non-exist value of column is `null`
+        "geofenceY"         -> null,
+        "geofenceRadius"    -> null
+      )
+
+      val data = RideHailFleetInitializer.toRideHailAgentInputData(map.asJava)
+      data shouldBe RideHailFleetInitializer.RideHailAgentInputData(
+        "1",
+        "2",
+        "CAR",
+        1.0,
+        2.0,
+        Some("{1:2}"),
+        None,
+        None,
+        None
+      )
+    }
+
+  }
+}


### PR DESCRIPTION
- Simplify the reading/writing of ride-hail fleet
- When read ride-hail fleet from file, use `fleetData.vehicleType` as vehicle type
- Added test for `RideHailFleetInitializer`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1978)
<!-- Reviewable:end -->
