### PR TITLE
Warmstart: Read ride-hail fleet state

### DIFF
--- a/src/main/scala/beam/sim/BeamWarmStart.scala
+++ b/src/main/scala/beam/sim/BeamWarmStart.scala
@@ -251,6 +251,12 @@ object BeamWarmStart extends LazyLogging {
 
       val vehiclesCsv = instance.notCompressedLocation("Households", "vehicles.csv", true)
 
+      val rideHailFleetCsv = instance.compressedLocation("Ride-hail fleet state", "rideHailFleet.csv.gz")
+      val newRideHailInit = {
+        val updatedInitCfg = configAgents.rideHail.initialization.copy(filePath = rideHailFleetCsv, initType = "FILE")
+        configAgents.rideHail.copy(initialization = updatedInitCfg)
+      }
+
       val newConfigAgents = {
         val newPlans = {
           configAgents.plans
@@ -261,7 +267,12 @@ object BeamWarmStart extends LazyLogging {
 
         val newVehicles = configAgents.vehicles.copy(vehiclesFilePath = vehiclesCsv)
 
-        configAgents.copy(plans = newPlans, households = newHouseHolds, vehicles = newVehicles)
+        configAgents.copy(
+          plans = newPlans,
+          households = newHouseHolds,
+          vehicles = newVehicles,
+          rideHail = newRideHailInit
+        )
       }
 
       val newAgentSim = beamConfig.beam.agentsim.copy(agents = newConfigAgents)

--- a/src/test/scala/beam/agentsim/agents/GenericEventsSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/GenericEventsSpec.scala
@@ -31,7 +31,7 @@ trait GenericEventsSpec extends WordSpecLike with IntegrationSpecCommon with Bea
 
     val injector = org.matsim.core.controler.Injector.createInjector(
       matsimConfig,
-      module(baseConfig, scenario, beamScenario)
+      module(baseConfig, beamConfig, scenario, beamScenario)
     )
 
     beamServices = injector.getInstance(classOf[BeamServices])

--- a/src/test/scala/beam/agentsim/agents/ridehail/AlonsoMoraPoolingAlgForRideHailSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/AlonsoMoraPoolingAlgForRideHailSpec.scala
@@ -52,7 +52,7 @@ class AlonsoMoraPoolingAlgForRideHailSpec
   val beamExecConfig: BeamExecutionConfig = setupBeamWithConfig(system.settings.config)
   implicit lazy val beamScenario = loadScenario(beamExecConfig.beamConfig)
   lazy val scenario = buildScenarioFromMatsimConfig(beamExecConfig.matsimConfig, beamScenario)
-  lazy val injector = buildInjector(system.settings.config, scenario, beamScenario)
+  lazy val injector = buildInjector(system.settings.config, beamExecConfig.beamConfig, scenario, beamScenario)
   lazy val services = buildBeamServices(injector, scenario)
 
   describe("AlonsoMoraPoolingAlgForRideHail") {

--- a/src/test/scala/beam/agentsim/agents/ridehail/AsyncAlonsoMoraAlgForRideHailSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/AsyncAlonsoMoraAlgForRideHailSpec.scala
@@ -52,7 +52,7 @@ class AsyncAlonsoMoraAlgForRideHailSpec
   val beamExecConfig: BeamExecutionConfig = setupBeamWithConfig(system.settings.config)
   implicit lazy val beamScenario = loadScenario(beamExecConfig.beamConfig)
   lazy val scenario = buildScenarioFromMatsimConfig(beamExecConfig.matsimConfig, beamScenario)
-  lazy val injector = buildInjector(system.settings.config, scenario, beamScenario)
+  lazy val injector = buildInjector(system.settings.config, beamExecConfig.beamConfig, scenario, beamScenario)
   lazy val services = buildBeamServices(injector, scenario)
   private val householdsFactory: HouseholdsFactoryImpl = new HouseholdsFactoryImpl()
 

--- a/src/test/scala/beam/agentsim/agents/ridehail/RideHailPassengersEventsSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/RideHailPassengersEventsSpec.scala
@@ -32,7 +32,7 @@ class RideHailPassengersEventsSpec extends WordSpecLike with Matchers with BeamH
 
       val injector = org.matsim.core.controler.Injector.createInjector(
         scenario.getConfig,
-        module(baseConfig, scenario, beamScenario)
+        module(baseConfig, beamConfig, scenario, beamScenario)
       )
 
       val beamServices: BeamServices =

--- a/src/test/scala/beam/agentsim/agents/ridehail/RideHailSurgePricingManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/ridehail/RideHailSurgePricingManagerSpec.scala
@@ -19,7 +19,7 @@ class RideHailSurgePricingManagerSpec extends WordSpecLike with Matchers with Mo
   val beamExecConfig: BeamExecutionConfig = setupBeamWithConfig(config)
   lazy val beamScenario = loadScenario(beamExecConfig.beamConfig)
   lazy val scenario = buildScenarioFromMatsimConfig(beamExecConfig.matsimConfig, beamScenario)
-  lazy val injector = buildInjector(config, scenario, beamScenario)
+  lazy val injector = buildInjector(config, beamExecConfig.beamConfig, scenario, beamScenario)
   lazy val beamServices = buildBeamServices(injector, scenario)
 
   "RideHailSurgePricingManager" must {

--- a/src/test/scala/beam/integration/CAVSpec.scala
+++ b/src/test/scala/beam/integration/CAVSpec.scala
@@ -48,7 +48,7 @@ class CAVSpec extends FlatSpec with Matchers with BeamHelper {
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addEventHandlerBinding().toInstance(new BasicEventHandler {
             override def handleEvent(event: Event): Unit = {
               event match {

--- a/src/test/scala/beam/integration/CarSharingSpec.scala
+++ b/src/test/scala/beam/integration/CarSharingSpec.scala
@@ -88,7 +88,7 @@ class CarSharingSpec extends FlatSpec with Matchers with BeamHelper {
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addEventHandlerBinding().toInstance(new BasicEventHandler {
             override def handleEvent(event: Event): Unit = {
               event match {
@@ -204,7 +204,7 @@ class CarSharingSpec extends FlatSpec with Matchers with BeamHelper {
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addEventHandlerBinding().toInstance(new BasicEventHandler {
             override def handleEvent(event: Event): Unit = {
               event match {

--- a/src/test/scala/beam/integration/DriveTransitSpec.scala
+++ b/src/test/scala/beam/integration/DriveTransitSpec.scala
@@ -55,7 +55,7 @@ class DriveTransitSpec extends WordSpecLike with Matchers with BeamHelper {
         scenario.getConfig,
         new AbstractModule() {
           override def install(): Unit = {
-            install(module(config, scenario, beamScenario))
+            install(module(config, beamConfig, scenario, beamScenario))
             addEventHandlerBinding().toInstance(new BasicEventHandler {
               override def handleEvent(event: Event): Unit = {
                 event match {

--- a/src/test/scala/beam/integration/EventsFileSpec.scala
+++ b/src/test/scala/beam/integration/EventsFileSpec.scala
@@ -36,12 +36,11 @@ class EventsFileSpec extends FlatSpec with BeforeAndAfterAll with Matchers with 
     val beamExecutionConfig: BeamExecutionConfig = setupBeamWithConfig(config)
 
     val (scenarioBuilt, beamScenario) = buildBeamServicesAndScenario(
-      config,
       beamExecutionConfig.beamConfig,
       beamExecutionConfig.matsimConfig
     )
     scenario = scenarioBuilt
-    val injector = buildInjector(config, scenario, beamScenario)
+    val injector = buildInjector(config, beamExecutionConfig.beamConfig, scenario, beamScenario)
     val services = buildBeamServices(injector, scenario)
 
     runBeam(services, scenario, beamScenario, scenario.getConfig.controler().getOutputDirectory)

--- a/src/test/scala/beam/integration/LCCMSpec.scala
+++ b/src/test/scala/beam/integration/LCCMSpec.scala
@@ -39,7 +39,7 @@ class LCCMSpec extends FlatSpec with BeamHelper with MockitoSugar {
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addControlerListenerBinding().toInstance(iterationCounter)
         }
       }

--- a/src/test/scala/beam/integration/ridehail/RideHailAllocationRandomRepositioningSpec.scala
+++ b/src/test/scala/beam/integration/ridehail/RideHailAllocationRandomRepositioningSpec.scala
@@ -31,7 +31,7 @@ class RideHailAllocationRandomRepositioningSpec extends FlatSpec with BeamHelper
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addControlerListenerBinding().toInstance(iterationCounter)
         }
       }

--- a/src/test/scala/beam/integration/ridehail/RideHailReplaceAllocationSpec.scala
+++ b/src/test/scala/beam/integration/ridehail/RideHailReplaceAllocationSpec.scala
@@ -34,7 +34,7 @@ class RideHailReplaceAllocationSpec extends FlatSpec with BeamHelper with Mockit
       scenario.getConfig,
       new AbstractModule() {
         override def install(): Unit = {
-          install(module(config, scenario, beamScenario))
+          install(module(config, beamConfig, scenario, beamScenario))
           addControlerListenerBinding().toInstance(iterationCounter)
         }
       }

--- a/src/test/scala/beam/sflight/CaccSpec.scala
+++ b/src/test/scala/beam/sflight/CaccSpec.scala
@@ -41,7 +41,7 @@ class CaccSpec extends WordSpecLike with Matchers with BeamHelper with BeforeAnd
     val scenario = ScenarioUtils.loadScenario(matsimConfig).asInstanceOf[MutableScenario]
     scenario.setNetwork(beamScenario.network)
 
-    val services = buildBeamServices(buildInjector(config, scenario, beamScenario), scenario)
+    val services = buildBeamServices(buildInjector(config, beamConfig, scenario, beamScenario), scenario)
     DefaultPopulationAdjustment(services).update(scenario)
 
     val controller = services.controler

--- a/src/test/scala/beam/sflight/SfLightRunSpec.scala
+++ b/src/test/scala/beam/sflight/SfLightRunSpec.scala
@@ -57,7 +57,7 @@ class SfLightRunSpec extends WordSpecLike with Matchers with BeamHelper with Bef
         scenario.getConfig,
         new AbstractModule() {
           override def install(): Unit = {
-            install(module(config, scenario, beamScenario))
+            install(module(config, beamConfig, scenario, beamScenario))
             addEventHandlerBinding().toInstance(new BasicEventHandler {
               override def handleEvent(event: Event): Unit = {
                 event match {

--- a/src/test/scala/beam/utils/SimRunnerForTest.scala
+++ b/src/test/scala/beam/utils/SimRunnerForTest.scala
@@ -30,7 +30,7 @@ trait SimRunnerForTest extends BeamHelper with BeforeAndAfterAll { this: Suite =
     super.beforeAll()
     beamScenario = loadScenario(beamConfig)
     scenario = buildScenarioFromMatsimConfig(matsimConfig, beamScenario)
-    injector = buildInjector(config, scenario, beamScenario)
+    injector = buildInjector(config, beamConfig, scenario, beamScenario)
     services = new BeamServicesImpl(injector)
     services.modeChoiceCalculatorFactory = ModeChoiceCalculator(
       services.beamConfig.beam.agentsim.agents.modalBehaviors.modeChoiceClass,

--- a/test/input/sf-light/urbansim-100k-warmstart.conf
+++ b/test/input/sf-light/urbansim-100k-warmstart.conf
@@ -1,4 +1,4 @@
-include "urbansim-100k-warmstart.conf"
+include "urbansim-100k.conf"
 
 beam.agentsim.simulationName = "urbansim-100k-warmstart"
 beam.warmStart.enabled = true

--- a/test/input/sf-light/urbansim-100k-warmstart.conf
+++ b/test/input/sf-light/urbansim-100k-warmstart.conf
@@ -1,0 +1,5 @@
+include "urbansim-100k-warmstart.conf"
+
+beam.agentsim.simulationName = "urbansim-100k-warmstart"
+beam.warmStart.enabled = true
+beam.warmStart.path = "https://s3.us-east-2.amazonaws.com/beam-outputs/output/sf-light/urbansim-100k__2019-07-16_18-09-53-30it.zip"

--- a/test/input/sf-light/urbansim-100k.conf
+++ b/test/input/sf-light/urbansim-100k.conf
@@ -11,7 +11,7 @@ include "../common/matsim.conf"
 beam.agentsim.simulationName = "urbansim-100k"
 beam.agentsim.agentSampleSizeAsFractionOfPopulation = 1.0
 beam.agentsim.firstIteration = 0
-beam.agentsim.lastIteration = 10
+beam.agentsim.lastIteration = 20
 beam.agentsim.thresholdForWalkingInMeters = 100
 beam.agentsim.timeBinSize = 3600
 beam.agentsim.startTime = "00:00:00"
@@ -77,10 +77,7 @@ beam.agentsim.tuning.rideHailPrice = 1.0
 beam.physsim.inputNetworkFilePath = ${beam.inputDirectory}"/r5/physsim-network.xml"
 beam.physsim.flowCapacityFactor = 0.01
 beam.physsim.storageCapacityFactor = 1.0
-beam.physsim.writeEventsInterval = 0
-beam.physsim.writePlansInterval = 0
 beam.physsim.writeMATSimNetwork = false
-beam.physsim.linkStatsWriteInterval = 1
 beam.physsim.linkStatsBinSize = 3600
 beam.physsim.ptSampleSize = 0.03
 beam.physsim.jdeqsim.agentSimPhysSimInterfaceDebugger.enabled = false
@@ -164,12 +161,13 @@ beam.outputs.baseOutputDirectory = ${?BEAM_OUTPUT}
 beam.outputs.addTimestampToOutputDirectory = true
 
 # To keep all logging params in one place, BEAM overrides MATSim params normally in the controller config module
-beam.outputs.writePlansInterval = 1
-beam.outputs.writeEventsInterval = 1
-beam.outputs.writeLinkTraversalInterval = 0
+beam.physsim.linkStatsWriteInterval = 5
+beam.outputs.writeSkimsInterval = 5
+beam.outputs.writePlansInterval = 5
+beam.outputs.writeEventsInterval = 5
 
 # The remaining params customize how events are written to output files
-beam.outputs.events.fileOutputFormats = "csv.gz,xml" # valid options: xml(.gz) , csv(.gz), none - DEFAULT: csv.gz
+beam.outputs.events.fileOutputFormats = "csv.gz,xml.gz" # valid options: xml(.gz) , csv(.gz), none - DEFAULT: csv.gz
 
 # Events Writing Logging Levels:
 # Any event types not explicitly listed in overrideWritingLevels take on defaultWritingLevel


### PR DESCRIPTION
- Warmstart respects ride-hail fleet state
- `module` uses passed `beamConfig` instead of creating new instance
- We still need `typesafeConfig` for `ConfigModule`

Closes #1985 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1986)
<!-- Reviewable:end -->
