### PR TITLE
zn/#1998 fix energy calcs

### DIFF
--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
@@ -120,7 +120,8 @@ class BeamVehicle(
     *
     */
   def useFuel(beamLeg: BeamLeg, beamScenario: BeamScenario, networkHelper: NetworkHelper): FuelConsumed = {
-    val fuelConsumptionDataWithOnlyLength_Id_And_Type = !beamScenario.vehicleEnergy.vehicleEnergyMappingExistsFor(beamVehicleType)
+    val fuelConsumptionDataWithOnlyLength_Id_And_Type =
+      !beamScenario.vehicleEnergy.vehicleEnergyMappingExistsFor(beamVehicleType)
     val fuelConsumptionData =
       BeamVehicle.collectFuelConsumptionData(
         beamLeg,

--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
@@ -291,12 +291,12 @@ object BeamVehicle {
     beamLeg: BeamLeg,
     theVehicleType: BeamVehicleType,
     networkHelper: NetworkHelper,
-    onlyLength_Id_And_Type: Boolean = false
+    vehicleMappingExists: Boolean = false
   ): IndexedSeq[FuelConsumptionData] = {
     //TODO: This method is becoming a little clunky. If it has to grow again then maybe refactor/break it out
     if (beamLeg.mode.isTransit & !Modes.isOnStreetTransit(beamLeg.mode)) {
       Vector.empty
-    } else if (onlyLength_Id_And_Type) {
+    } else if (!vehicleMappingExists) {
       beamLeg.travelPath.linkIds
         .drop(1)
         .map(

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleEnergy.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleEnergy.scala
@@ -116,7 +116,11 @@ class ConsumptionRateFilterStoreImpl(
       .foreach(csvRecord => {
         val speedInMilesPerHourBin = convertRecordStringToRange(csvRecord.getString(speedBinHeader), isDouble = true)
         val gradePercentBin = convertRecordStringToRange(csvRecord.getString(gradeBinHeader), isDouble = true)
-        val numberOfLanesBin = convertRecordStringToRange(csvRecord.getString(lanesBinHeader))
+        val numberOfLanesBin = if (csvRecord.getMetaData.containsColumn(lanesBinHeader)) {
+          convertRecordStringToRange(csvRecord.getString(lanesBinHeader))
+        } else {
+          convertRecordStringToRange("(0,100]")
+        }
         val rawRate = csvRecord.getDouble(rateHeader)
         if (rawRate == null)
           throw new Exception(

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleEnergy.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleEnergy.scala
@@ -234,8 +234,8 @@ class VehicleEnergy(
         numberOfLanesOption,
         _,
         _,
-        _,
         speedInMetersPerSecondOption,
+        _,
         _,
         _,
         _


### PR DESCRIPTION
Two small fixes:

1: when the `num_lanes_int_bins` column doesn't exist, it assumes that all rows are for a bin of 0-100 lanes.

2: negates what was previously called `onlyLength_Id_And_Type` in BeamVehicle.scala so that the link speed is set as none if the vehicle mapping file does not exist.

Fixes #1998

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/1999)
<!-- Reviewable:end -->
