### PR TITLE
Pooling should not be aware of reposition manager

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
@@ -23,7 +23,6 @@ import scala.concurrent.{Await, TimeoutException}
 class PoolingAlonsoMora(val rideHailManager: RideHailManager)
     extends RideHailResourceAllocationManager(rideHailManager) {
 
-  val randomRepositioning: RandomRepositioning = new RandomRepositioning(rideHailManager)
   val tempScheduleStore: mutable.Map[Int, List[MobilityRequest]] = mutable.Map()
 
   val spatialPoolCustomerReqs: QuadTree[CustomerRequest] = new QuadTree[CustomerRequest](
@@ -356,8 +355,4 @@ class PoolingAlonsoMora(val rideHailManager: RideHailManager)
     )
     VehicleAllocations(allocResponses)
   }
-  override def repositionVehicles(tick: Int): Vector[(Id[Vehicle], Location)] = {
-    randomRepositioning.repositionVehicles(tick)
-  }
-
 }

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/RideHailResourceAllocationManager.scala
@@ -230,7 +230,6 @@ object RideHailResourceAllocationManager {
   val IMMEDIATE_DISPATCH_WITH_OVERWRITE = "IMMEDIATE_DISPATCH_WITH_OVERWRITE"
   val POOLING = "POOLING"
   val POOLING_ALONSO_MORA = "POOLING_ALONSO_MORA"
-  val REPOSITIONING_LOW_WAITING_TIMES = "REPOSITIONING_LOW_WAITING_TIMES"
   val DUMMY_DISPATCH_WITH_BUFFERING = "DUMMY_DISPATCH_WITH_BUFFERING"
 
   def apply(
@@ -247,8 +246,6 @@ object RideHailResourceAllocationManager {
         new Pooling(rideHailManager)
       case RideHailResourceAllocationManager.POOLING_ALONSO_MORA =>
         new PoolingAlonsoMora(rideHailManager)
-      case RideHailResourceAllocationManager.REPOSITIONING_LOW_WAITING_TIMES =>
-        ???
       case classFullName =>
         try {
           Class


### PR DESCRIPTION
`RideHailResourceAllocationManager` already creates reposition manager internally, no need to do it in `PoolingAlonsoMora`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2023)
<!-- Reviewable:end -->
