### PR TITLE
rjf/#2038-beamville-parking-config-bug

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
@@ -46,7 +46,7 @@ object ChargingPointType {
   // provide custom charging points
   case class CustomChargingPoint(id: String, installedCapacity: Double, electricCurrentType: ElectricCurrentType)
       extends ChargingPointType {
-    override def toString: String = s"$id($installedCapacity,$electricCurrentType)"
+    override def toString: String = s"$id($installedCapacity|$electricCurrentType)"
   }
 
   case object CustomChargingPoint {

--- a/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/charging/ChargingPointType.scala
@@ -30,12 +30,18 @@ object ChargingPointType {
 
   case object TeslaSuperCharger extends ChargingPointType
 
-  // added back in because of integration tests which work with old files
-  case object Level1 extends ChargingPointType
-  case object Level2 extends ChargingPointType
-  case object DCFast extends ChargingPointType
-  case object UltraFast extends ChargingPointType
-  case object NoCharger extends ChargingPointType
+  val AllFormalChargingPointTypes = List(
+    HouseholdSocket,
+    BlueHouseholdSocket,
+    Cee16ASocket,
+    Cee32ASocket,
+    Cee63ASocket,
+    ChargingStationType1,
+    ChargingStationType2,
+    ChargingStationCcsComboType1,
+    ChargingStationCcsComboType2,
+    TeslaSuperCharger
+  )
 
   // provide custom charging points
   case class CustomChargingPoint(id: String, installedCapacity: Double, electricCurrentType: ElectricCurrentType)
@@ -52,13 +58,13 @@ object ChargingPointType {
         case Failure(_) =>
           throw new IllegalArgumentException(s"provided 'installed capacity' $installedCapacity is invalid.")
         case Success(installedCapacityDouble) =>
-          CustomChargingPoint(id, installedCapacityDouble, ElectricCurrentType(electricCurrentType))
+          CustomChargingPoint(id, installedCapacityDouble, ElectricCurrentType(electricCurrentType.toUpperCase))
       }
     }
   }
 
   private[ChargingPointType] val CustomChargingPointRegex: Regex =
-    "(\\w+\\d*)\\((\\d+\\.?\\d+\\s*)\\|(\\s*\\w{2})\\)".r.unanchored
+    """(\w+\d*)\s*\(\s*(\d+\.?\d+)\s*\|\s*(\w{2})\s*\)""".r.unanchored
 
   // matches either the standard ones or a custom one
   def apply(s: String): Option[ChargingPointType] = {

--- a/src/test/scala/beam/agentsim/infrastructure/charging/ChargingPointTypeSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/charging/ChargingPointTypeSpec.scala
@@ -1,0 +1,135 @@
+package beam.agentsim.infrastructure.charging
+
+import beam.agentsim.infrastructure.charging.ChargingPointType.CustomChargingPoint
+import org.scalactic.source
+import org.scalatest.{Matchers, WordSpec}
+
+class ChargingPointTypeSpec extends WordSpec with Matchers {
+  "ChargingPointType" when {
+    "formal charging point types" when {
+      "given string names of built-in charging point types" should {
+        "construct that charging point type" in {
+          for {
+            expectedChargingPointType <- ChargingPointType.AllFormalChargingPointTypes
+            chargingPointTypeString = expectedChargingPointType.toString
+          } {
+            ChargingPointType(chargingPointTypeString) match {
+              case None =>
+                fail(s"name $chargingPointTypeString did not map to a ChargingPointType object")
+              case Some(chargingPointType) =>
+                chargingPointType should equal(expectedChargingPointType)
+            }
+          }
+        }
+      }
+    }
+    "custom charging point types" when {
+      "given a string describing a valid custom ChargingPointType with correct formatting" should {
+        "construct that charging point type" in {
+          val input = "test(250|DC)"
+          ChargingPointTypeSpec.expectsACustomChargingPoint(input) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.id should equal("test")
+              result.installedCapacity should equal(250.0)
+              result.electricCurrentType should equal(ElectricCurrentType.DC)
+          }
+        }
+      }
+      "given a string with valid CustomChargingPoint data but extra spaces" should {
+        "still correctly parse and construct that ChargingPointType" in {
+          val input = "test ( 250 | DC )"
+          ChargingPointTypeSpec.expectsACustomChargingPoint(input) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.id should equal("test")
+              result.installedCapacity should equal(250.0)
+              result.electricCurrentType should equal(ElectricCurrentType.DC)
+          }
+        }
+      }
+      "given strings with invalid installed capacity values" should {
+        "throw an exception" in {
+          val twoPeriods = "test ( 250.. | DC )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(twoPeriods)
+          val hasLetters = "test ( 25a0 | DC )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(hasLetters)
+          val comma = "test ( 250,0 | DC )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(comma)
+          val negativeValue = "test ( -250 | DC )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(
+            negativeValue
+          )
+
+        }
+      }
+      "given strings with varying character case for electricCurrentType" should {
+        "still correctly parse and construct that ChargingPointType" in {
+          val bothUpper = "test ( 250 | AC )"
+          val lowerFirst = "test ( 250 | dC )"
+          val lowerSecond = "test ( 250 | Ac )"
+          val bothLower = "test ( 250 | dc )"
+          ChargingPointTypeSpec.expectsACustomChargingPoint(bothUpper) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.electricCurrentType should equal(ElectricCurrentType.AC)
+          }
+          ChargingPointTypeSpec.expectsACustomChargingPoint(lowerFirst) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.electricCurrentType should equal(ElectricCurrentType.DC)
+          }
+          ChargingPointTypeSpec.expectsACustomChargingPoint(lowerSecond) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.electricCurrentType should equal(ElectricCurrentType.AC)
+          }
+          ChargingPointTypeSpec.expectsACustomChargingPoint(bothLower) match {
+            case Left(e) => fail(e)
+            case Right(result) =>
+              result.electricCurrentType should equal(ElectricCurrentType.DC)
+          }
+        }
+      }
+      "given strings with invalid electricCurrentType values" should {
+        "throw an exception" in {
+          val badLetters = "test ( 250 | AB )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(badLetters)
+          val spaceBetweenLetters = "test ( 250 | A C )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(
+            spaceBetweenLetters
+          )
+          val containsValidButTooLong = "test ( 25a0 | aaaDCaaa )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(
+            containsValidButTooLong
+          )
+          val flipped = "test ( DC | 1234 )"
+          an[IllegalArgumentException] should be thrownBy ChargingPointTypeSpec.expectsACustomChargingPoint(flipped)
+        }
+      }
+    }
+  }
+}
+
+object ChargingPointTypeSpec extends org.scalatest.Assertions {
+
+  /**
+    * helper test function which handles the common parsing failures
+    * @param input a string representation of a CustomChargingPoint
+    * @param pos required for calling "fail" here, an implicit that tracks the call point of an error
+    * @return either an error string, or a CustomChargingPoint
+    */
+  def expectsACustomChargingPoint(input: String)(implicit pos: source.Position): Either[String, CustomChargingPoint] = {
+    ChargingPointType(input) match {
+      case None =>
+        Left { s"input '$input' failed to parse" }
+      case Some(chargingPointType) =>
+        chargingPointType match {
+          case result: CustomChargingPoint =>
+            Right { result }
+          case _ =>
+            Left { s"a CustomChargingPoint was not parsed from provided string description '$input'" }
+        }
+    }
+  }
+}

--- a/test/input/beamville/parking/taz-parking-default.csv
+++ b/test/input/beamville/parking/taz-parking-default.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:650ed222fde9b3bb37bed9c98de22a1c9493f3486d8b381519b947d4bea48a3d
+oid sha256:34aa5df769f60ad6d7030b756f138b885525f25d9228c3cc9e8288e51fa02a2a
 size 6994

--- a/test/input/beamville/parking/taz-parking-default.csv
+++ b/test/input/beamville/parking/taz-parking-default.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34aa5df769f60ad6d7030b756f138b885525f25d9228c3cc9e8288e51fa02a2a
-size 6994
+oid sha256:8759c25e1704186fd713ad721358e7ef0495a9278d0faeafce0fa716edf088d8
+size 6995

--- a/test/input/beamville/parking/taz-parking-empty.csv
+++ b/test/input/beamville/parking/taz-parking-empty.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00431ff53ba5b0e8d44bafc48f0b4bb4d90352d68e8063922ee147c6c36fafe7
+oid sha256:5f02d0a30a355073998a70fa2296978aedfa21283a41853b0855a1f65e16658c
 size 5938

--- a/test/input/beamville/parking/taz-parking-empty.csv
+++ b/test/input/beamville/parking/taz-parking-empty.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f02d0a30a355073998a70fa2296978aedfa21283a41853b0855a1f65e16658c
-size 5938
+oid sha256:a3fd1181c73d86eae94a1c57c8922b89d31c90eb2e8deca2b532c2e3994fe00a
+size 5966

--- a/test/input/beamville/parking/taz-parking-expensive-old.csv
+++ b/test/input/beamville/parking/taz-parking-expensive-old.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7558ab3c7f097457f4ff44e17497507a683357060abba2a23c023ca4240d068
+oid sha256:e1fd75a78bc7627bcaeeca5b11471d2cf0530c06d73d814f476da649b5388b28
 size 7742

--- a/test/input/beamville/parking/taz-parking-expensive.csv
+++ b/test/input/beamville/parking/taz-parking-expensive.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7483c15da3372a7a6ff56bb710511760d02c0c7e3c6fb4c3140d871e4476fcf6
+oid sha256:f116cb18ddb131f26a347991e3dc8e4e04ecddafe159d7a528a5c9944127e02a
 size 7284

--- a/test/input/beamville/parking/taz-parking-limited.csv
+++ b/test/input/beamville/parking/taz-parking-limited.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92ae637ac7c0356c168bcdf658fb79288d928c9678609c7b0d1c94968581941b
+oid sha256:5ccfb6c7b1f5cb5a72d86df73e44fac8acc42f4b412c4d3339e195bd0a5ed0a5
 size 5938

--- a/test/input/beamville/parking/taz-parking.csv
+++ b/test/input/beamville/parking/taz-parking.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c454de37fa469fc97dae9f2d0d60838c4d8f323bb12aceac154662229b333bc6
+oid sha256:f33280b170ecd1fb26736033c2c9558808a0d6b87a21c7ee63e9756b88042104
 size 7020


### PR DESCRIPTION
This PR addresses a bug caused by errors in the parking configuration for the Beamville scenario. The expected format of a CustomChargingPoint is to be pipe-delimited instead of comma-delimited. In other words:

```scala
val good = "test(250|DC)"
val bad = "test(250,DC)"
```

After fixing these, other errors were still found. In fact, they seemed like remnants of someone testing for robustness in our parsing, because only a few of them were in place. One was whitespace, and the other was upper/lowercasing issues.

To address all parsing issues, I wrote a test spec for the `ChargingPointType.apply()` method which is used to parse strings into ChargingPointTypes.

All taz-parking files in Beamville were confirmed to now run correctly.

Closes #2038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2040)
<!-- Reviewable:end -->
