### PR TITLE
do not re-calculate income group -> vehicle mapping unnecessarily

### DIFF
--- a/src/main/scala/beam/sim/vehicles/IncomeBasedVehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/IncomeBasedVehiclesAdjustment.scala
@@ -113,13 +113,13 @@ case class IncomeBasedVehiclesAdjustment(beamScenario: BeamScenario) extends Veh
             )
         }
       }
-      groupIDlist.zip(vehicleTypeAndProbabilityList).groupBy(_._1).map {
-        case (groupID, vehicleTypeAndProbability) =>
-          val probSum = vehicleTypeAndProbability.map(_._2._2).sum
-          val cumulativeProbabilities = vehicleTypeAndProbability.map(_._2._2 / probSum).scan(0.0)(_ + _).drop(1)
-          val vehicleTypes = vehicleTypeAndProbability.map(_._2._1)
-          groupIDs += (groupID -> vehicleTypes.zip(cumulativeProbabilities).toArray)
-      }
+    }
+    groupIDlist.zip(vehicleTypeAndProbabilityList).groupBy(_._1).map {
+      case (groupID, vehicleTypeAndProbability) =>
+        val probSum = vehicleTypeAndProbability.map(_._2._2).sum
+        val cumulativeProbabilities = vehicleTypeAndProbability.map(_._2._2 / probSum).scan(0.0)(_ + _).drop(1)
+        val vehicleTypes = vehicleTypeAndProbability.map(_._2._1)
+        groupIDs += (groupID -> vehicleTypes.zip(cumulativeProbabilities).toArray)
     }
     groupIDs
   }


### PR DESCRIPTION
Minor fix--realized the structure collecting income groups and vehicle probabilities was being re-made within a loop over vehicle types, where it should have only been made after the last vehicle type was looped through.

Shouldn't affect the results at all, just fixing for neatness

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2060)
<!-- Reviewable:end -->
