### PR TITLE
Cs/depot queue

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -155,6 +155,10 @@ object RideHailManager {
 
   case class ContinueBufferedRideHailRequests(tick: Int)
 
+  sealed trait RefuelSource
+  case object JustArrivedAtDepot extends RefuelSource
+  case object DequeuedToCharge extends RefuelSource
+
   final val fileBaseName = "rideHailInitialLocation"
 
   class OutputData extends OutputDataDescriptor {
@@ -967,11 +971,13 @@ class RideHailManager(
       )
     vehicleManager.vehicleState.put(vehicleId, beamVehicleState)
 
-    removeVehicleArrivedAtRefuelingDepot(vehicleId) match {
+    val triggerToSend = removeVehicleArrivedAtRefuelingDepot(vehicleId) match {
       case Some(parkingStall) =>
-        attemptToRefuel(vehicleId, parkingStall, whenWhere.time, triggerId, "JustArrivedAtDepot")
+        attemptToRefuel(vehicleId, beamVehicle.driver.get, parkingStall, whenWhere.time, triggerId, JustArrivedAtDepot)
       //If not arrived for refueling;
       case _ => {
+        log.debug("Making vehicle {} available", vehicleId)
+        vehicleManager.makeAvailable(rideHailAgentLocation)
         removeFromCharging(vehicleId) match {
           case Some(parkingStall) => {
             rideHailDepotParkingManager.releaseStall(parkingStall)
@@ -979,18 +985,18 @@ class RideHailManager(
             //QUESTION: Maybe a new trigger should be set to check for queue instead of this inline?
             dequeueNextVehicleForRefuelingFrom(depotId) match {
               case Some((nextVehicleId, nextVehiclesParkingStall)) => {
-                attemptToRefuel(nextVehicleId, nextVehiclesParkingStall, whenWhere.time, triggerId, "DequeuedToCharge")
+                attemptToRefuel(nextVehicleId, vehicleManager.getRideHailAgentLocation(nextVehicleId).rideHailAgent, nextVehiclesParkingStall, whenWhere.time, triggerId, DequeuedToCharge)
               }
               case None =>
+                Vector()
             }
           }
           case None =>
+            Vector()
         }
-        log.debug("Making vehicle {} available", vehicleId)
-        vehicleManager.makeAvailable(rideHailAgentLocation)
-        rideHailAgentLocation.rideHailAgent ! NotifyVehicleResourceIdleReply(triggerId, Vector[ScheduleTrigger]())
       }
     }
+    rideHailAgentLocation.rideHailAgent ! NotifyVehicleResourceIdleReply(triggerId, triggerToSend)
   }
 
   def dieIfNoChildren(): Unit = {
@@ -1066,7 +1072,7 @@ class RideHailManager(
   def addVehicleAndStallToRefuelingQueueFor(
     vehicleId: VehicleId,
     parkingStall: ParkingStall,
-    source: String
+    source: RefuelSource
   ): Unit = {
     depotToRefuelingQueuesMap.get(parkingStall.parkingZoneId) match {
       case Some(depotQueue) => {
@@ -1106,7 +1112,7 @@ class RideHailManager(
   private val chargingVehicleToParkingStallMap: mutable.Map[VehicleId, ParkingStall] =
     mutable.Map.empty[VehicleId, ParkingStall]
 
-  def addVehicleToChargingInDepotUsing(stall: ParkingStall, vehicleId: VehicleId, source: String): Unit = {
+  def addVehicleToChargingInDepotUsing(stall: ParkingStall, vehicleId: VehicleId, source: RefuelSource): Unit = {
     if (chargingVehicleToParkingStallMap.keys.exists(_ == vehicleId)) {
       log.warning(
         "{} is already charging in {}, yet it is being added to {}. Source: {} THIS SHOULD NOT HAPPEN!",
@@ -1140,28 +1146,28 @@ class RideHailManager(
 
   def attemptToRefuel(
     vehicleId: VehicleId,
+    driverAgent: ActorRef,
     originalParkingStallFoundDuringAssignment: ParkingStall,
     time: Int,
     triggerId: Option[Long],
-    source: String
-  ): Unit = {
+    source: RefuelSource
+  ): Vector[ScheduleTrigger] = {
     val beamVehicleOption = findBeamVehicleUsing(vehicleId)
     rideHailDepotParkingManager.findAndClaimStallAtDepot(originalParkingStallFoundDuringAssignment) match {
       case Some(claimedParkingStall: ParkingStall) => {
         beamVehicleOption match {
           case Some(beamVehicle) =>
             beamVehicle.useParkingStall(claimedParkingStall)
-            beamVehicle.driver.foreach(driverAgent => {
-              addVehicleToChargingInDepotUsing(claimedParkingStall, vehicleId, source)
-              driverAgent ! NotifyVehicleResourceIdleReply(
-                triggerId,
-                Vector(ScheduleTrigger(StartRefuelSessionTrigger(time), driverAgent))
-              )
-            })
-          case None => log.warning("Unable to find vehicle {} to start depot refueling")
+            addVehicleToChargingInDepotUsing(claimedParkingStall, vehicleId, source)
+            Vector(ScheduleTrigger(StartRefuelSessionTrigger(time), driverAgent))
+          case None =>
+            log.warning("Unable to find vehicle {} to start depot refueling")
+            Vector()
         }
       }
-      case None => addVehicleAndStallToRefuelingQueueFor(vehicleId, originalParkingStallFoundDuringAssignment, source)
+      case None =>
+        addVehicleAndStallToRefuelingQueueFor(vehicleId, originalParkingStallFoundDuringAssignment, source)
+        Vector()
     }
   }
   /* END: Refueling Logic */

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -985,7 +985,14 @@ class RideHailManager(
             //QUESTION: Maybe a new trigger should be set to check for queue instead of this inline?
             dequeueNextVehicleForRefuelingFrom(depotId) match {
               case Some((nextVehicleId, nextVehiclesParkingStall)) => {
-                attemptToRefuel(nextVehicleId, vehicleManager.getRideHailAgentLocation(nextVehicleId).rideHailAgent, nextVehiclesParkingStall, whenWhere.time, triggerId, DequeuedToCharge)
+                attemptToRefuel(
+                  nextVehicleId,
+                  vehicleManager.getRideHailAgentLocation(nextVehicleId).rideHailAgent,
+                  nextVehiclesParkingStall,
+                  whenWhere.time,
+                  triggerId,
+                  DequeuedToCharge
+                )
               }
               case None =>
                 Vector()

--- a/src/main/scala/beam/utils/scripts/FailFast.scala
+++ b/src/main/scala/beam/utils/scripts/FailFast.scala
@@ -45,7 +45,7 @@ object FailFast extends LazyLogging {
      * We don't expect "Electricity" to be a secondary powertrain type and it can produce unexpected results if set as such. So we fail.
      */
 
-    if (beamServices.beamScenario.vehicleTypes.find(_._2.secondaryFuelType == Some(Electricity)).isDefined){
+    if (beamServices.beamScenario.vehicleTypes.find(_._2.secondaryFuelType == Some(Electricity)).isDefined) {
       throw new RuntimeException(
         s"Found BeamVehicleType ${beamServices.beamScenario.vehicleTypes.find(_._2.secondaryFuelType == Some(Electricity)).get._2.id} with 'Electricity' specified as a FuelType for the secondary powertrain. This is likely a mistake and we are failing so it can be corrected otherwise unexpected behavior will result. For a BEV the primary fuel type should be Electricity and secondary should be empty / blank. For PHEV the primary should be Electricity and secondary should be Gasoline."
       )


### PR DESCRIPTION
There was a bug when RHA added to a queue at a depot... the NotifyVehicleIdleReply wasn't sent which means the RHA never released their trigger so run got stuck.

Only surfaced when we ran a limited charing infrastructure scenario for the first time. 

Fixed by some refactoring to make sure that a NotifyVehicleIdleReply is sent in all cases and with the proper trigger (either for the current RHA in question or for the new RHA who is dequeued and will start charging).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2094)
<!-- Reviewable:end -->
