### PR TITLE
add new plot. expose parking type in RefuelSessionEvent.

### DIFF
--- a/src/main/scala/beam/agentsim/events/RefuelSessionEvent.scala
+++ b/src/main/scala/beam/agentsim/events/RefuelSessionEvent.scala
@@ -29,6 +29,7 @@ class RefuelSessionEvent(
 
   val pricingModelString = stall.pricingModel.map { _.toString }.getOrElse("None")
   val chargingPointString = stall.chargingPointType.map { _.toString }.getOrElse("None")
+  val parkingType: String = stall.parkingType.toString
 
   override def getAttributes: util.Map[String, String] = {
     val attributes = super.getAttributes
@@ -38,7 +39,7 @@ class RefuelSessionEvent(
     attributes.put(ATTRIBUTE_PRICE, stall.cost.toString)
     attributes.put(ATTRIBUTE_LOCATION_X, stall.locationUTM.getX.toString)
     attributes.put(ATTRIBUTE_LOCATION_Y, stall.locationUTM.getY.toString)
-    attributes.put(ATTRIBUTE_PARKING_TYPE, stall.parkingType.toString)
+    attributes.put(ATTRIBUTE_PARKING_TYPE, parkingType)
     attributes.put(ATTRIBUTE_PRICING_MODEL, pricingModelString)
     attributes.put(ATTRIBUTE_CHARGING_TYPE, chargingPointString)
     attributes.put(ATTRIBUTE_PARKING_TAZ, stall.tazId.toString)


### PR DESCRIPTION
adds an output plot for `chargingPowerByParkingType.png` which looks like this:

![0 chargingPowerByParkingType](https://user-images.githubusercontent.com/7003022/63538442-26d3be80-c4d5-11e9-8538-ba984dfcf078.png)

had to change RefuelSessionEvent so that the parkingType String was exposed from the class. 

Closes #2111.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2112)
<!-- Reviewable:end -->
