### PR TITLE
fix ridehail wait time

### DIFF
--- a/src/main/java/beam/analysis/plots/RideHailWaitingAnalysis.java
+++ b/src/main/java/beam/analysis/plots/RideHailWaitingAnalysis.java
@@ -31,6 +31,7 @@ import static java.lang.Integer.max;
 public class RideHailWaitingAnalysis implements GraphAnalysis, IterationSummaryAnalysis {
 
     public static final String RIDE_HAIL = "ride_hail";
+    public static final String RIDE_HAIL_POOLED = "ride_hail_pooled";
     public static final String WALK_TRANSIT = "walk_transit";
 
     public RideHailWaitingAnalysis(StatsComputation<Tuple<List<Double>, Map<Integer, List<Double>>>, Tuple<Map<Integer, Map<Double, Integer>>, double[][]>> statComputation) {
@@ -174,7 +175,7 @@ public class RideHailWaitingAnalysis implements GraphAnalysis, IterationSummaryA
         if (event instanceof ModeChoiceEvent) {
             ModeChoiceEvent modeChoiceEvent = (ModeChoiceEvent) event;
             String mode = modeChoiceEvent.mode;
-            if (mode.equalsIgnoreCase(RIDE_HAIL)) {
+            if (mode.equalsIgnoreCase(RIDE_HAIL) || mode.equalsIgnoreCase(RIDE_HAIL_POOLED)) {
 
                 Id<Person> personId = modeChoiceEvent.getPersonId();
                 rideHailWaiting.put(personId.toString(), event);

--- a/src/main/scala/beam/agentsim/agents/choice/mode/ModeChoiceMultinomialLogit.scala
+++ b/src/main/scala/beam/agentsim/agents/choice/mode/ModeChoiceMultinomialLogit.scala
@@ -113,7 +113,9 @@ class ModeChoiceMultinomialLogit(
     attributesOfIndividual: Option[AttributesOfIndividual],
     destinationActivity: Option[Activity]
   ): Double = {
-    val waitingTime = embodiedBeamTrip.totalTravelTimeInSecs - embodiedBeamTrip.legs.map(_.beamLeg.duration).sum
+    val waitingTime = embodiedBeamTrip.totalTravelTimeInSecs - embodiedBeamTrip.legs
+      .map(_.beamLeg.duration)
+      .sum + embodiedBeamTrip.totalInitialWaitTimeInSecs
     embodiedBeamTrip.legs
       .map(x => getGeneralizedTimeOfLeg(x, attributesOfIndividual, destinationActivity))
       .sum + getGeneralizedTime(waitingTime, None, None)

--- a/src/main/scala/beam/router/model/EmbodiedBeamTrip.scala
+++ b/src/main/scala/beam/router/model/EmbodiedBeamTrip.scala
@@ -37,6 +37,8 @@ case class EmbodiedBeamTrip(legs: IndexedSeq[EmbodiedBeamLeg]) {
 
   val totalTravelTimeInSecs: Int = legs.lastOption.map(_.beamLeg.endTime - legs.head.beamLeg.startTime).getOrElse(0)
 
+  val totalInitialWaitTimeInSecs: Int = legs.map(_.beamLeg.initialWaitTime).sum
+
   def beamLegs: IndexedSeq[BeamLeg] = legs.map(embodiedLeg => embodiedLeg.beamLeg)
 
   def toBeamTrip: BeamTrip = BeamTrip(beamLegs)


### PR DESCRIPTION
Addresses two issues:

1. Ride hail waiting stats were only considering solo ride hail wait times. 

2. Initial time to a ridehail pickup is no longer being accounted for in that option's wait time during mode choice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2138)
<!-- Reviewable:end -->
