### PR TITLE
make dummy walk trip start at the time of the ridehail request

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -892,7 +892,7 @@ trait ChoosesMode {
           }).map { partialItin =>
             EmbodiedBeamTrip(
               (EmbodiedBeamLeg.dummyLegAt(
-                partialItin.head.beamLeg.startTime,
+                _currentTick.get,
                 body.id,
                 false,
                 partialItin.head.beamLeg.travelPath.startPoint.loc,


### PR DESCRIPTION
fixes an issue with initial waiting time not being factored in to ridehail mode choice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2139)
<!-- Reviewable:end -->
