### PR TITLE
euclidean distance for non road transit

### DIFF
--- a/src/main/scala/beam/agentsim/agents/TransitSystem.scala
+++ b/src/main/scala/beam/agentsim/agents/TransitSystem.scala
@@ -72,6 +72,7 @@ class TransitSystem(
     val initializer = new TransitVehicleInitializer(beamScenario.beamConfig, beamScenario.vehicleTypes)
     val transitSchedule = new TransitInitializer(
       beamScenario.beamConfig,
+      geo,
       beamScenario.dates,
       beamScenario.vehicleTypes,
       beamScenario.transportNetwork,

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -74,7 +74,7 @@ class TransitInitializer(
           None,
           SpaceTime(fromCoord, departureTime),
           SpaceTime(toCoord, departureTime + duration),
-          geo.distLatLon2Meters(fromCoord,toCoord)
+          geo.distLatLon2Meters(fromCoord, toCoord)
         )
     }
 

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -17,6 +17,7 @@ import com.conveyal.r5.streets.StreetRouter
 import com.conveyal.r5.transit.{RouteInfo, TransitLayer, TransportNetwork}
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.vehicles.{Vehicle, Vehicles}
+import beam.sim.common.GeoUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -24,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class TransitInitializer(
   beamConfig: BeamConfig,
+  geo: GeoUtils,
   dates: DateUtils,
   vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleType],
   transportNetwork: TransportNetwork,
@@ -72,7 +74,7 @@ class TransitInitializer(
           None,
           SpaceTime(fromCoord, departureTime),
           SpaceTime(toCoord, departureTime + duration),
-          0
+          geo.distLatLon2Meters(fromCoord,toCoord)
         )
     }
 

--- a/src/main/scala/beam/router/r5/R5RoutingWorker.scala
+++ b/src/main/scala/beam/router/r5/R5RoutingWorker.scala
@@ -14,7 +14,7 @@ import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events.SpaceTime
 import beam.router.BeamRouter._
-import beam.router.Modes.BeamMode.WALK
+import beam.router.Modes.BeamMode.{CAR, WALK}
 import beam.router.Modes._
 import beam.router._
 import beam.router.gtfs.FareCalculator
@@ -284,7 +284,9 @@ class R5Wrapper(workerParams: WorkerParameters, travelTime: TravelTime) extends 
       ),
       linksTimesAndDistances.distances.tail.sum
     )
+    val toll = tollCalculator.calcTollByLinkIds(updatedTravelPath)
     val updatedLeg = leg.copy(travelPath = updatedTravelPath, duration = updatedTravelPath.duration)
+    val drivingCost = DrivingCost.estimateDrivingCost(leg, vehicleTypes(vehicleTypeId), fuelTypePrices)
     val response = RoutingResponse(
       Vector(
         EmbodiedBeamTrip(
@@ -294,7 +296,7 @@ class R5Wrapper(workerParams: WorkerParameters, travelTime: TravelTime) extends 
               vehicleId,
               vehicleTypeId,
               asDriver = true,
-              0,
+              drivingCost + toll,
               unbecomeDriverOnCompletion = true
             )
           )


### PR DESCRIPTION
We were defaulting to 0.0 in the length attribute for PathTraversals that don't follow the road network (i.e. rail modes). This fills in the euclidean distance between the start and end for each non-road transit leg between stops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2147)
<!-- Reviewable:end -->
