### PR TITLE
Fix inflated generalized times (#2153)

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -637,7 +637,7 @@ trait ChoosesMode {
     val indexFromBeg = theLinkIds.length - indexFromEnd
     val firstTravelTimes = leg.beamLeg.travelPath.linkTravelTime.take(indexFromBeg)
     val secondPathLinkIds = theLinkIds.takeRight(indexFromEnd + 1)
-    val secondTravelTimes = leg.beamLeg.travelPath.linkTravelTime.takeRight(indexFromEnd + 1).updated(0, 0.0)
+    val secondTravelTimes = leg.beamLeg.travelPath.linkTravelTime.takeRight(indexFromEnd + 1)
     val secondDuration = Math.min(math.round(secondTravelTimes.tail.sum.toFloat), leg.beamLeg.duration)
     val firstDuration = leg.beamLeg.duration - secondDuration
     val secondDistance = Math.min(secondPathLinkIds.tail.map(lengthOfLink).sum, leg.beamLeg.travelPath.distanceInM)

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -637,7 +637,7 @@ trait ChoosesMode {
     val indexFromBeg = theLinkIds.length - indexFromEnd
     val firstTravelTimes = leg.beamLeg.travelPath.linkTravelTime.take(indexFromBeg)
     val secondPathLinkIds = theLinkIds.takeRight(indexFromEnd + 1)
-    val secondTravelTimes = leg.beamLeg.travelPath.linkTravelTime.takeRight(indexFromEnd + 1)
+    val secondTravelTimes = leg.beamLeg.travelPath.linkTravelTime.takeRight(indexFromEnd + 1).updated(0, 0.0)
     val secondDuration = Math.min(math.round(secondTravelTimes.tail.sum.toFloat), leg.beamLeg.duration)
     val firstDuration = leg.beamLeg.duration - secondDuration
     val secondDistance = Math.min(secondPathLinkIds.tail.map(lengthOfLink).sum, leg.beamLeg.travelPath.distanceInM)

--- a/src/main/scala/beam/sim/population/PopulationAttributes.scala
+++ b/src/main/scala/beam/sim/population/PopulationAttributes.scala
@@ -86,8 +86,8 @@ case class AttributesOfIndividual(
     embodiedBeamLeg.beamLeg.mode match {
       case CAR => // NOTE: Ride hail legs are classified as CAR mode. For now we only need to loop through links here
         val idsAndTravelTimes =
-          embodiedBeamLeg.beamLeg.travelPath.linkIds
-            .zip(embodiedBeamLeg.beamLeg.travelPath.linkTravelTime.map(time => math.round(time.toFloat)))
+          embodiedBeamLeg.beamLeg.travelPath.linkIds.tail // ignore the first link because activities are located along links
+            .zip(embodiedBeamLeg.beamLeg.travelPath.linkTravelTime.tail.map(time => math.round(time.toFloat)))
         idsAndTravelTimes.foldLeft(0.0)(
           _ + getGeneralizedTimeOfLinkForMNL(
             _,


### PR DESCRIPTION
We've observed some generalized times in the skims that are higher than they should be based on the config VOTT multipliers, implying that generalized times are getting artificially inflated somewhere. 

I think this is because generalized TT is calculated by looping over all links in car paths, whereas the driver does not necessarily need to drive the full distance of the first and last link. By matsim convention this means ignoring the first link when calculating travel time and distance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2155)
<!-- Reviewable:end -->
