### PR TITLE
Use InterruptIdIdGenerator to generate interrupt ids

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
@@ -115,30 +115,28 @@ object RideHailAgent {
 
   case class ModifyPassengerScheduleAcks(acks: List[ModifyPassengerScheduleAck])
 
-  case class Interrupt(interruptId: Id[Interrupt], tick: Int)
+  case class Interrupt(interruptId: Int, tick: Int)
 
   case object Resume
 
   sealed trait InterruptReply {
-    val interruptId: Id[Interrupt]
+    val interruptId: Int
     val vehicleId: Id[Vehicle]
     val tick: Int
   }
 
   case class InterruptedWhileDriving(
-    interruptId: Id[Interrupt],
+    interruptId: Int,
     vehicleId: Id[Vehicle],
     tick: Int,
     passengerSchedule: PassengerSchedule,
     currentPassengerScheduleIndex: Int,
   ) extends InterruptReply
 
-  case class InterruptedWhileIdle(interruptId: Id[Interrupt], vehicleId: Id[Vehicle], tick: Int) extends InterruptReply
+  case class InterruptedWhileIdle(interruptId: Int, vehicleId: Id[Vehicle], tick: Int) extends InterruptReply
 
-  case class InterruptedWhileOffline(interruptId: Id[Interrupt], vehicleId: Id[Vehicle], tick: Int)
-      extends InterruptReply
-  case class InterruptedWhileWaitingToDrive(interruptId: Id[Interrupt], vehicleId: Id[Vehicle], tick: Int)
-      extends InterruptReply
+  case class InterruptedWhileOffline(interruptId: Int, vehicleId: Id[Vehicle], tick: Int) extends InterruptReply
+  case class InterruptedWhileWaitingToDrive(interruptId: Int, vehicleId: Id[Vehicle], tick: Int) extends InterruptReply
 
   case object Idle extends BeamAgentState
 
@@ -311,7 +309,7 @@ class RideHailAgent(
         Some(triggerId)
       )
       goto(Idle)
-    case ev @ Event(Interrupt(interruptId: Id[Interrupt], tick), _) =>
+    case ev @ Event(Interrupt(interruptId, tick), _) =>
       log.debug("state(RideHailingAgent.Offline): {}", ev)
       goto(OfflineInterrupted) replying InterruptedWhileOffline(interruptId, vehicle.id, latestObservedTick)
     case ev @ Event(Resume, _) =>
@@ -386,7 +384,7 @@ class RideHailAgent(
       }
       rideHailManager ! NotifyVehicleOutOfService(vehicle.id)
       goto(Offline) replying CompletionNotice(triggerId, newShiftToSchedule)
-    case ev @ Event(Interrupt(interruptId: Id[Interrupt], tick), _) =>
+    case ev @ Event(Interrupt(interruptId, tick), _) =>
       log.debug("state(RideHailingAgent.Idle): {}", ev)
       goto(IdleInterrupted) replying InterruptedWhileIdle(interruptId, vehicle.id, latestObservedTick)
     case ev @ Event(
@@ -480,7 +478,7 @@ class RideHailAgent(
     case ev @ Event(Resume, _) =>
       log.debug("state(RideHailingAgent.IdleInterrupted): {}", ev)
       goto(Idle)
-    case ev @ Event(Interrupt(interruptId: Id[Interrupt], tick), _) =>
+    case ev @ Event(Interrupt(interruptId, tick), _) =>
       log.debug("state(RideHailingAgent.IdleInterrupted): {}", ev)
       stay() replying InterruptedWhileIdle(interruptId, vehicle.id, latestObservedTick)
     case ev @ Event(

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailModifyPassengerScheduleManager.scala
@@ -6,14 +6,11 @@ import beam.agentsim.agents.HasTickAndTrigger
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle.StopDriving
 import beam.agentsim.agents.ridehail.RideHailAgent._
 import beam.agentsim.agents.ridehail.RideHailManager.{BufferedRideHailRequestsTrigger, RideHailRepositioningTrigger}
-import beam.agentsim.agents.ridehail.RideHailVehicleManager.RideHailAgentLocation
 import beam.agentsim.agents.vehicles.PassengerSchedule
-import beam.agentsim.events.SpaceTime
 import beam.agentsim.scheduler.BeamAgentScheduler
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger}
 import beam.sim.config.BeamConfig
-import beam.utils.DebugLib
-import com.eaio.uuid.UUIDGen
+import beam.utils.InterruptIdIdGenerator
 import org.matsim.api.core.v01.Id
 import org.matsim.vehicles.Vehicle
 
@@ -28,7 +25,7 @@ class RideHailModifyPassengerScheduleManager(
 ) extends HasTickAndTrigger {
 
   private val interruptIdToModifyPassengerScheduleStatus =
-    mutable.Map[Id[Interrupt], RideHailModifyPassengerScheduleStatus]()
+    mutable.Map[Int, RideHailModifyPassengerScheduleStatus]()
   private val vehicleIdToModifyPassengerScheduleStatus =
     mutable.Map[Id[Vehicle], RideHailModifyPassengerScheduleStatus]()
   private val interruptedVehicleIds = mutable.Set[Id[Vehicle]]() // For debug only
@@ -367,7 +364,7 @@ class RideHailModifyPassengerScheduleManager(
     }
   }
   private def clearModifyStatusFromCacheWithInterruptId(
-    interruptId: Id[Interrupt]
+    interruptId: Int
   ): Unit = {
     log.debug("remove interrupt from clearModifyStatusFromCacheWithInterruptId {}", interruptId)
     interruptIdToModifyPassengerScheduleStatus.remove(interruptId).foreach { rideHailModifyPassengerScheduleStatus =>
@@ -435,7 +432,7 @@ case object Reposition extends InterruptOrigin
 case object HoldForPlanning extends InterruptOrigin
 
 case class RideHailModifyPassengerScheduleStatus(
-  interruptId: Id[Interrupt],
+  interruptId: Int,
   vehicleId: Id[Vehicle],
   modifyPassengerSchedule: ModifyPassengerSchedule,
   interruptOrigin: InterruptOrigin,
@@ -448,8 +445,5 @@ case class RideHailModifyPassengerScheduleStatus(
 case class ReduceAwaitingRepositioningAckMessagesByOne(vehicleId: Id[Vehicle])
 
 object RideHailModifyPassengerScheduleManager {
-
-  def nextRideHailAgentInterruptId: Id[Interrupt] = {
-    Id.create(UUIDGen.createTime(UUIDGen.newTime()).toString, classOf[Interrupt])
-  }
+  def nextRideHailAgentInterruptId: Int = InterruptIdIdGenerator.nextId
 }

--- a/src/main/scala/beam/utils/IdGenerator.scala
+++ b/src/main/scala/beam/utils/IdGenerator.scala
@@ -28,3 +28,11 @@ object ParkingManagerIdGenerator extends IdGenerator {
     id.getAndIncrement()
   }
 }
+
+object InterruptIdIdGenerator extends IdGenerator {
+  private val id: AtomicInteger = new AtomicInteger(0)
+
+  def nextId: Int = {
+    id.getAndIncrement()
+  }
+}

--- a/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
@@ -128,7 +128,7 @@ class RideHailAgentSpec
             )
           )
         )
-      rideHailAgent ! Interrupt(Id.create("1", classOf[Interrupt]), 30000)
+      rideHailAgent ! Interrupt(1, 30000)
       expectMsgType[InterruptedWhileIdle]
       rideHailAgent ! ModifyPassengerSchedule(passengerSchedule, 30000)
       rideHailAgent ! Resume
@@ -182,7 +182,7 @@ class RideHailAgentSpec
       // Now I want to interrupt the agent, and it will say that for any point in time after 28800,
       // I can tell it whatever I want. Even though it is already 30000 for me.
 
-      rideHailAgent ! Interrupt(Id.create("1", classOf[Interrupt]), 30000)
+      rideHailAgent ! Interrupt(1, 30000)
       val interruptedAt = expectMsgType[InterruptedWhileDriving]
       assert(interruptedAt.currentPassengerScheduleIndex == 0) // I know this agent hasn't picked up the passenger yet
       assert(rideHailAgent.stateName == DrivingInterrupted)
@@ -258,7 +258,7 @@ class RideHailAgentSpec
       // Now I want to interrupt the agent, and it will say that for any point in time after 28800,
       // I can tell it whatever I want. Even though it is already 30000 for me.
 
-      rideHailAgent ! Interrupt(Id.create("1", classOf[Interrupt]), 30000)
+      rideHailAgent ! Interrupt(1, 30000)
       val interruptedAt = expectMsgType[InterruptedWhileDriving]
       assert(interruptedAt.currentPassengerScheduleIndex == 0) // I know this agent hasn't picked up the passenger yet
       assert(rideHailAgent.stateName == DrivingInterrupted)
@@ -341,7 +341,7 @@ class RideHailAgentSpec
           t
       }
 
-      rideHailAgent ! Interrupt(Id.create("1", classOf[Interrupt]), 30000)
+      rideHailAgent ! Interrupt(1, 30000)
       val interruptedAt = expectMsgType[InterruptedWhileDriving]
       assert(interruptedAt.currentPassengerScheduleIndex == 1) // I know this agent has now picked up the passenger
       assert(rideHailAgent.stateName == DrivingInterrupted)


### PR DESCRIPTION
- Changed `interruptId` to be Int
- Added `InterruptIdIdGenerator` to generate monotonically increasing ids for interrupts

Solves https://github.com/LBNL-UCB-STI/beam/issues/2190

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2191)
<!-- Reviewable:end -->
