### PR TITLE
Use ReservationRequestIdGenerator to generate requestId for reservation  #2191

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -2,19 +2,18 @@ package beam.agentsim.agents.ridehail
 
 import java.awt.Color
 import java.io.File
-import java.lang.reflect.Method
 import java.util
 import java.util.concurrent.TimeUnit
 
 import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, OneForOneStrategy, Props, Stash, Terminated}
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Stash, Terminated}
 import akka.event.LoggingReceive
 import akka.pattern._
 import akka.util.Timeout
 import beam.agentsim
 import beam.agentsim.Resource._
 import beam.agentsim.agents.BeamAgent.Finish
-import beam.agentsim.agents.{Dropoff, InitializeTrigger, MobilityRequest, Pickup}
+import beam.agentsim.agents.choice.logit.UtilityFunctionOperation
 import beam.agentsim.agents.household.CAVSchedule.RouteOrEmbodyRequest
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle._
 import beam.agentsim.agents.ridehail.RideHailAgent._
@@ -29,16 +28,9 @@ import beam.agentsim.agents.vehicles.AccessErrorCodes.{
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
 import beam.agentsim.agents.vehicles.{PassengerSchedule, _}
+import beam.agentsim.agents.{Dropoff, InitializeTrigger, MobilityRequest, Pickup}
 import beam.agentsim.events.SpaceTime
-import beam.agentsim.infrastructure.ZonalParkingManager.logger
-import beam.agentsim.infrastructure.parking.{
-  ParkingMNL,
-  ParkingType,
-  ParkingZone,
-  ParkingZoneFileUtils,
-  ParkingZoneSearch
-}
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.parking.ParkingMNL
 import beam.agentsim.infrastructure.{ParkingInquiry, ParkingInquiryResponse, ParkingStall}
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger}
 import beam.agentsim.scheduler.Trigger
@@ -57,7 +49,6 @@ import beam.utils.logging.LogActorState
 import beam.utils.matsim_conversion.ShapeUtils.QuadTreeBounds
 import beam.utils.reflection.ReflectionUtils
 import com.conveyal.r5.transit.TransportNetwork
-import com.eaio.uuid.UUIDGen
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.vividsolutions.jts.geom.Envelope
 import org.apache.commons.math3.distribution.UniformRealDistribution
@@ -65,17 +56,14 @@ import org.matsim.api.core.v01.population.{Activity, Person}
 import org.matsim.api.core.v01.{Coord, Id, Scenario}
 import org.matsim.core.api.experimental.events.EventsManager
 import org.matsim.vehicles.Vehicle
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.math.{max, min}
-import scala.util.{Failure, Random, Success, Try}
-
-import beam.agentsim.agents.choice.logit.{MultinomialLogit, UtilityFunctionOperation}
-import beam.agentsim.infrastructure.parking.ParkingMNL.RemainingTripData
-import beam.agentsim.infrastructure.parking.ParkingZoneSearch.ParkingAlternative
+import scala.util.Random
 
 object RideHailManager {
   val INITIAL_RIDE_HAIL_LOCATION_HOME = "HOME"
@@ -83,10 +71,6 @@ object RideHailManager {
   val INITIAL_RIDE_HAIL_LOCATION_UNIFORM_RANDOM = "UNIFORM_RANDOM"
   val INITIAL_RIDE_HAIL_LOCATION_ALL_AT_CENTER = "ALL_AT_CENTER"
   val INITIAL_RIDE_HAIL_LOCATION_ALL_IN_CORNER = "ALL_IN_CORNER"
-
-  def nextRideHailInquiryId: Id[RideHailRequest] = {
-    Id.create(UUIDGen.createTime(UUIDGen.newTime()).toString, classOf[RideHailRequest])
-  }
 
   sealed trait RideHailServiceStatus
 

--- a/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/VehicleAccessRequest.scala
@@ -3,19 +3,11 @@ package beam.agentsim.agents.vehicles
 import beam.agentsim.events.resources.ReservationErrorCode._
 import beam.agentsim.events.resources._
 import beam.agentsim.scheduler.BeamAgentScheduler.ScheduleTrigger
-import beam.router.Modes.BeamMode
 import beam.router.model.BeamLeg
-import com.eaio.uuid.UUIDGen
-import org.matsim.api.core.v01.Id
-
-object Reservation {
-
-  def nextReservationId: Id[ReservationRequest] =
-    Id.create(UUIDGen.createTime(UUIDGen.newTime()).toString, classOf[ReservationRequest])
-}
+import beam.utils.ReservationRequestIdGenerator
 
 case class ReservationRequest(
-  requestId: Id[ReservationRequest],
+  requestId: Int,
   departFrom: BeamLeg,
   arriveAt: BeamLeg,
   passengerVehiclePersonId: PersonIdWithActorRef
@@ -29,7 +21,7 @@ object ReservationRequest {
     passengerVehiclePersonId: PersonIdWithActorRef
   ): ReservationRequest =
     ReservationRequest(
-      Reservation.nextReservationId,
+      ReservationRequestIdGenerator.nextId,
       departFrom,
       arriveAt,
       passengerVehiclePersonId

--- a/src/main/scala/beam/utils/IdGenerator.scala
+++ b/src/main/scala/beam/utils/IdGenerator.scala
@@ -36,3 +36,11 @@ object InterruptIdIdGenerator extends IdGenerator {
     id.getAndIncrement()
   }
 }
+
+object ReservationRequestIdGenerator extends IdGenerator {
+  private val id: AtomicInteger = new AtomicInteger(0)
+
+  def nextId: Int = {
+    id.getAndIncrement()
+  }
+}

--- a/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonAndTransitDriverSpec.scala
@@ -65,7 +65,7 @@ class PersonAndTransitDriverSpec
     .withFallback(testConfig("test/input/beamville/beam.conf"))
     .resolve()
 
-  lazy implicit val system: ActorSystem = ActorSystem("PersonWithVehicleSharingSpec", config)
+  lazy implicit val system: ActorSystem = ActorSystem("PersonAndTransitDriverSpec", config)
 
   override def outputDirPath: String = TestConfigUtils.testOutputDir
 

--- a/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/RideHailAgentSpec.scala
@@ -53,7 +53,7 @@ class RideHailAgentSpec
     .withFallback(testConfig("test/input/beamville/beam.conf"))
     .resolve()
 
-  lazy implicit val system: ActorSystem = ActorSystem("PersonWithPersonalVehiclePlanSpec", config)
+  lazy implicit val system: ActorSystem = ActorSystem("RideHailAgentSpec", config)
 
   override def outputDirPath: String = TestConfigUtils.testOutputDir
 

--- a/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
+++ b/src/test/scala/beam/integration/AgentsimWithMaximallyBadRouterSpec.scala
@@ -38,7 +38,7 @@ class AgentsimWithMaximallyBadRouterSpec
 
   def outputDirPath: String = basePath + "/" + testOutputDir + "bad-router-test"
 
-  lazy implicit val system: ActorSystem = ActorSystem("AgentSimWithBadRouterSpec", config)
+  lazy implicit val system: ActorSystem = ActorSystem("AgentsimWithMaximallyBadRouterSpec", config)
 
   "The agentsim" must {
     "not get stuck even if the router only throws exceptions" in {


### PR DESCRIPTION
- Added `ReservationRequestIdGenerator`
- `ReservationRequest.requestId` is an integer and it uses `ReservationRequestIdGenerator`

===
I've just removed an unused method from `RideHailManager.scala` and optimized its imports that's why so many changes in that file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2195)
<!-- Reviewable:end -->
