### PR TITLE
Fix the grow of idleRideHailAgentSpatialIndex

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailVehicleManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailVehicleManager.scala
@@ -340,6 +340,9 @@ class RideHailVehicleManager(val rideHailManager: RideHailManager, boundingBox: 
 }
 
 object RideHailVehicleManager {
+
+  /** Please be careful when use it as a Key in Map/Set. It has overridden `equals` and `hashCode` which only respects `vehicleId`
+    */
   case class RideHailAgentLocation(
     rideHailAgent: ActorRef,
     vehicleId: Id[Vehicle],
@@ -355,6 +358,19 @@ object RideHailVehicleManager {
     def toStreetVehicle: StreetVehicle = {
       StreetVehicle(vehicleId, vehicleType.id, currentLocationUTM, CAR, asDriver = true)
     }
+
+    override def equals(obj: Any): Boolean = {
+      obj match {
+        case that: RideHailAgentLocation =>
+          that.canEqual(this) && vehicleId == that.vehicleId
+      }
+    }
+
+    override def hashCode(): Int = {
+      vehicleId.hashCode()
+    }
+
+    def canEqual(other: Any): Boolean = other.isInstanceOf[RideHailAgentLocation]
   }
 
   case class RideHailAgentETA(

--- a/test/input/sf-light/sf-light-25k.conf
+++ b/test/input/sf-light/sf-light-25k.conf
@@ -130,8 +130,8 @@ beam.agentsim.agents.rideHail.surgePricing.minimumSurgeLevel = 0.1
 # priceAdjustmentStrategy(KEEP_PRICE_LEVEL_FIXED_AT_ONE | CONTINUES_DEMAND_SUPPLY_MATCHING)
 beam.agentsim.agents.rideHail.surgePricing.priceAdjustmentStrategy="KEEP_PRICE_LEVEL_FIXED_AT_ONE"
 # allocationManager(DEFAULT_MANAGER | STANFORD_V1 | BUFFERED_IMPL_TEMPLATE)
-beam.agentsim.agents.rideHail.allocationManager.name="DEFAULT_MANAGER"
-beam.agentsim.agents.rideHail.allocationManager.requestBufferTimeoutInSeconds = 0
+beam.agentsim.agents.rideHail.allocationManager.name="POOLING_ALONSO_MORA"
+beam.agentsim.agents.rideHail.allocationManager.requestBufferTimeoutInSeconds = 300
 # repositioningManager can be DEFAULT_REPOSITIONING_MANAGER | DEMAND_FOLLOWING_REPOSITIONING_MANAGER | REPOSITIONING_LOW_WAITING_TIMES
 beam.agentsim.agents.rideHail.repositioningManager.name="DEFAULT_REPOSITIONING_MANAGER"
 beam.agentsim.agents.rideHail.repositioningManager.timeout=300


### PR DESCRIPTION
`idleRideHailAgentSpatialIndex` is growing because of containing multiple `RideHailAgentLocation` for the same vehicle.
We have
```
08:02:41.370 [ClusterSystem-akka.actor.default-dispatcher-50] INFO  b.a.agents.ridehail.RideHailManager - Initialized 6946 ride hailing agents
```
But if you look to the result from spatial index, there are 7117 RideHailAgentLocations (which is more than the number of ride hail agents!), when it has only 993 unique vehicle id:
![image](https://user-images.githubusercontent.com/5107562/66712466-2c5bcf80-edc7-11e9-958f-191d0a3e4ab9.png)
If I group by vehicleId, the same vehicle has 10 entries:
![image](https://user-images.githubusercontent.com/5107562/66712471-409fcc80-edc7-11e9-80a0-ba8d64bc0dd2.png)

### How it is solved
Two instances of `RideHailAgentLocation` are equal if they have the same `vehicleId`. This solves problem when `RideHailAgentLocation` is removed from Spatial index: problem of having multiple `RideHailAgentLocation` for the single `vehicleId` in spatial index.

With this fix sf-light-25k with `beam.agentsim.agents.modalBehaviors.mulitnomialLogit.params.ride_hail_intercept = 100.0` runs in:
```
13:58:08.644 INFO  b.a.scheduler.BeamAgentScheduler - Stopping BeamAgentScheduler @ tick 108004. Iteration 0 executed in 1494 seconds
14:19:34.518 INFO  b.a.scheduler.BeamAgentScheduler - Stopping BeamAgentScheduler @ tick 108004. Iteration 1 executed in 1202 seconds
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2219)
<!-- Reviewable:end -->
