### PR TITLE
add duration to dummy walk leg

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -216,12 +216,14 @@ object PersonAgent {
         legs = trip.legs
           .dropRight(1) :+ EmbodiedBeamLeg
           .dummyLegAt(
-            endTime,
+            endTime - trip.legs.last.beamLeg.duration,
             bodyVehicleId,
-            true,
+            isLastLeg = true,
             trip.legs.dropRight(1).last.beamLeg.travelPath.endPoint.loc,
             WALK,
-            bodyVehicleTypeId
+            bodyVehicleTypeId,
+            asDriver = true,
+            trip.legs.last.beamLeg.duration
           )
       )
     } else {

--- a/src/main/scala/beam/router/model/BeamLeg.scala
+++ b/src/main/scala/beam/router/model/BeamLeg.scala
@@ -92,11 +92,11 @@ case class BeamLeg(startTime: Int, mode: BeamMode, duration: Int, travelPath: Be
 
 object BeamLeg {
 
-  def dummyLeg(startTime: Int, location: Location, mode: BeamMode = WALK): BeamLeg =
+  def dummyLeg(startTime: Int, location: Location, mode: BeamMode = WALK, duration: Int = 0): BeamLeg =
     new BeamLeg(
       0,
       mode,
-      0,
+      duration,
       BeamPath(Vector(), Vector(), None, SpaceTime(location, startTime), SpaceTime(location, startTime), 0)
     ).updateStartTime(startTime)
 

--- a/src/main/scala/beam/router/model/EmbodiedBeamLeg.scala
+++ b/src/main/scala/beam/router/model/EmbodiedBeamLeg.scala
@@ -29,10 +29,11 @@ object EmbodiedBeamLeg {
     location: Location,
     mode: BeamMode,
     vehicleTypeId: Id[BeamVehicleType],
-    asDriver: Boolean = true
+    asDriver: Boolean = true,
+    duration: Int = 0
   ): EmbodiedBeamLeg = {
     EmbodiedBeamLeg(
-      BeamLeg.dummyLeg(start, location, mode),
+      BeamLeg.dummyLeg(start, location, mode, duration),
       vehicleId,
       vehicleTypeId,
       asDriver,


### PR DESCRIPTION
I think the problem is that the walk leg from a parking stall was given as having duration 0 despite starting/ending after the previous car leg finished. So its duration was being accounted for in `trip.totalTravelTimeInSecs` but not in generalized time, which sums the leg travel times multiplied by mode-specific VOTT factors.

should fix #2287 but still need to test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2288)
<!-- Reviewable:end -->
