### PR TITLE
Idle vehicle should be in range by remainingPrimaryRangeInM to be able to serve customer

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,1 @@
-[lfs]
-  url = http://52.15.173.229:8080/LBNL-UCB-STI/beam.git
+

--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicle.scala
@@ -18,8 +18,9 @@ import beam.sim.BeamScenario
 import beam.sim.common.GeoUtils.TurningDirection
 import beam.utils.NetworkHelper
 import beam.utils.logging.ExponentialLazyLogging
-import org.matsim.api.core.v01.Id
+import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.api.core.v01.network.Link
+import org.matsim.core.utils.geometry.CoordUtils
 import org.matsim.vehicles.Vehicle
 
 import scala.util.Random
@@ -364,8 +365,25 @@ object BeamVehicle {
     stall: Option[ParkingStall]
   ) {
 
-    def totalRemainingRange = {
+    def totalRemainingRange: Double = {
       remainingPrimaryRangeInM + remainingSecondaryRangeInM.getOrElse(0.0)
+    }
+  }
+
+  object BeamVehicleState {
+
+    def haveEnoughFuel(
+      beamVehicleState: BeamVehicleState,
+      rideHailLocationUTM: Coord,
+      pickupLocationUTM: Coord,
+      travelDistance: Double,
+      distanceToDepot: Double,
+      marginFactor: Double = 2.0 // TODO Better name? Extract to config?
+    ): Boolean = {
+      require(travelDistance >= 0)
+      require(distanceToDepot >= 0)
+      val distance = marginFactor * (CoordUtils.calcProjectedEuclideanDistance(pickupLocationUTM, rideHailLocationUTM) + travelDistance + distanceToDepot)
+      distance <= beamVehicleState.remainingPrimaryRangeInM
     }
   }
 

--- a/src/test/scala/beam/agentsim/agents/vehicles/BeamVehicleStateTest.scala
+++ b/src/test/scala/beam/agentsim/agents/vehicles/BeamVehicleStateTest.scala
@@ -1,0 +1,45 @@
+package beam.agentsim.agents.vehicles
+
+import beam.agentsim.agents.vehicles.BeamVehicle.BeamVehicleState
+import org.matsim.api.core.v01.Coord
+import org.scalatest.{FunSuite, Matchers}
+
+class BeamVehicleStateTest extends FunSuite with Matchers {
+  test("haveEnoughFuel return true in case vehicle remaining distance >= marginFactor * distance to travel") {
+    val bvs = BeamVehicleState(
+      primaryFuelLevel = 100,
+      secondaryFuelLevel = None,
+      remainingPrimaryRangeInM = 100,
+      remainingSecondaryRangeInM = None,
+      driver = None,
+      stall = None
+    )
+    // Distance between (50, 50) and (10, 10) is 56.5685.
+    // Total distance = 56.5685 + 10 (travelDistance) + 10 (distanceToDepot) = 76.5685 * 1 (marginFactor) <= 100 (remainingPrimaryRangeInM)
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(10, 10), 10, 10, 1) shouldBe true
+    // Total distance = 56.5685 + 10 (travelDistance) + 10 (distanceToDepot) = 76.5685 * 0 (marginFactor) <= 100 (remainingPrimaryRangeInM)
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(10, 10), 10, 10, 0) shouldBe true
+
+    // Case when the same location
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(50, 50), 10, 10, 1) shouldBe true
+  }
+
+  test("haveEnoughFuel return false in case vehicle remaining distance < marginFactor * distance to travel") {
+    val bvs = BeamVehicleState(
+      primaryFuelLevel = 100,
+      secondaryFuelLevel = None,
+      remainingPrimaryRangeInM = 100,
+      remainingSecondaryRangeInM = None,
+      driver = None,
+      stall = None
+    )
+    // Distance between (50, 50) and (10, 10) is 56.5685.
+    // Total distance = 56.5685 + 10 (travelDistance) + 10 (distanceToDepot) = 76.5685 * 2 (marginFactor) > 100 (remainingPrimaryRangeInM)
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(10, 10), 10, 10, 2) shouldBe false
+    // Total distance = 56.5685 + 10 (travelDistance) + 10 (distanceToDepot) = 76.5685 * 3 (marginFactor) > 100 (remainingPrimaryRangeInM)
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(10, 10), 10, 10, 3) shouldBe false
+
+    // Case when the same location (10 (travelDistance) + 10 (distanceToDepot)) * 5.1 = 102 > 100 (remainingPrimaryRangeInM)
+    BeamVehicleState.haveEnoughFuel(bvs, new Coord(50, 50), new Coord(50, 50), 10, 10, 5.1) shouldBe false
+  }
+}


### PR DESCRIPTION
`getClosestIdleVehiclesWithinRadiusByETA` makes sure that idle vehicle has enough fuel (with some marginFactor) to make a trip to the customer, serve customer and go to charging.
Total travel distance can be represented graphically:
![Untitled Diagram](https://user-images.githubusercontent.com/5107562/69457102-e53a0480-0d9e-11ea-863b-9260d5b36183.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2289)
<!-- Reviewable:end -->
