### PR TITLE
H3TAZ: Minor improvements

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/taz/H3TAZ.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/H3TAZ.scala
@@ -2,7 +2,9 @@ package beam.agentsim.infrastructure.taz
 
 import beam.agentsim.infrastructure.taz.H3TAZ.{fillBox, HexIndex}
 import beam.sim.config.BeamConfig
+import beam.utils.ProfilingUtils
 import beam.utils.matsim_conversion.ShapeUtils.QuadTreeBounds
+import com.typesafe.scalalogging.StrictLogging
 import com.uber.h3core.util.GeoCoord
 import com.vividsolutions.jts.geom.{Coordinate, Geometry, GeometryFactory}
 import org.matsim.api.core.v01.network.Network
@@ -12,9 +14,8 @@ import org.matsim.core.utils.geometry.transformations.GeotoolsTransformation
 import org.matsim.core.utils.gis.{PolygonFeatureFactory, ShapeFileWriter}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
-case class H3TAZ(network: Network, tazTreeMap: TAZTreeMap, beamConfig: BeamConfig) {
+case class H3TAZ(network: Network, tazTreeMap: TAZTreeMap, beamConfig: BeamConfig) extends StrictLogging {
   private val transformToH3Proj =
     new GeotoolsTransformation(beamConfig.matsim.modules.global.coordinateSystem, H3TAZ.H3Projection)
 
@@ -23,15 +24,26 @@ case class H3TAZ(network: Network, tazTreeMap: TAZTreeMap, beamConfig: BeamConfi
   )
   private val resolution = beamConfig.beam.h3.resolution
   private val lowerBoundResolution = beamConfig.beam.h3.lowerBoundResolution
-  private val tazToH3TAZMapping: mutable.HashMap[HexIndex, Id[TAZ]] = mutable.HashMap()
-  fillBox(boundingBox, resolution).foreach { hex =>
-    val hexCentroid = H3TAZ.hexToCoord(hex)
-    val hexCentroidBis =
-      new GeotoolsTransformation(H3TAZ.H3Projection, beamConfig.matsim.modules.global.coordinateSystem)
-        .transform(hexCentroid)
-    val tazId = tazTreeMap.getTAZ(hexCentroidBis.getX, hexCentroidBis.getY).tazId
-    tazToH3TAZMapping.put(hex, tazId)
-  }
+  private val fillBoxResult: Iterable[String] =
+    ProfilingUtils.timed(s"fillBox for boundingBox $boundingBox with resolution $resolution", x => logger.info(x)) {
+      fillBox(boundingBox, resolution)
+    }
+  logger.info(s"fillBox for boundingBox $boundingBox with resolution $resolution gives ${fillBoxResult.size} elemets")
+
+  private val tazToH3TAZMapping: Map[HexIndex, Id[TAZ]] =
+    ProfilingUtils.timed(s"Constructed tazToH3TAZMapping", str => logger.info(str)) {
+      val transformation =
+        new GeotoolsTransformation(H3TAZ.H3Projection, beamConfig.matsim.modules.global.coordinateSystem)
+      fillBoxResult.par
+        .map { hex =>
+          val hexCentroid = H3TAZ.hexToCoord(hex)
+          val hexCentroidBis = transformation.transform(hexCentroid)
+          val tazId = tazTreeMap.getTAZ(hexCentroidBis.getX, hexCentroidBis.getY).tazId
+          (hex, tazId)
+        }
+        .toMap
+        .seq
+    }
 
   def getAll: Iterable[HexIndex] = {
     tazToH3TAZMapping.keys


### PR DESCRIPTION
- Added logs how much time does it take to fill the box and to compute `tazToH3TAZMapping` 
- Compute `tazToH3TAZMapping` in parallel
- Extracted `transformation` to local val because internally it throws a lot of exception which slows down the loop

I'm currently working on Austin data and during the loading of simulation I saw it takes some time in H3TAZ. The main reason of course because the map contains 10kk nodes and bounding box area is pretty big. Here are the logs from H3TAZ to get some sense of the numbers of elements and the bounding box area
```
22:46:00.220 INFO  b.agentsim.infrastructure.taz.H3TAZ - fillBox for boundingBox QuadTreeBounds(-106.69448850456033,25.81901984758941,-93.3861787743846,36.69892793549934) with resolution 10 executed in 230483 ms
22:46:00.220 INFO  b.agentsim.infrastructure.taz.H3TAZ - fillBox for boundingBox QuadTreeBounds(-106.69448850456033,25.81901984758941,-93.3861787743846,36.69892793549934) with resolution 10 gives 88905072 elemets
22:48:34.770 INFO  b.agentsim.infrastructure.taz.H3TAZ - Constructed tazToH3TAZMapping executed in 154549 ms
```
I did not provide `beam.h3.resolution` so it is equal to 10 as default value. Maybe this number should be scenario specific?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2343)
<!-- Reviewable:end -->
