### PR TITLE
Improvements in CarTripStatsFromPathTraversalEventHandler

### DIFF
--- a/src/main/scala/beam/analysis/cartraveltime/models.scala
+++ b/src/main/scala/beam/analysis/cartraveltime/models.scala
@@ -1,6 +1,7 @@
 package beam.analysis.cartraveltime
 
 import beam.utils.Statistics
+import org.matsim.api.core.v01.Coord
 
 sealed trait CarType {
   override def toString: String = this.getClass.getSimpleName.replace("$", "")
@@ -12,12 +13,14 @@ object CarType {
   object RideHail extends CarType
 }
 
-case class SingleRideStat(
+case class CarTripStat(
   vehicleId: String,
   travelTime: Double,
   distance: Double,
   freeFlowTravelTime: Double,
-  departureTime: Double
+  departureTime: Double,
+  startCoordWGS: Coord,
+  endCoordWGS: Coord
 ) {
   def speed: Double = if (travelTime == 0.0) Double.NaN else distance / travelTime
 
@@ -27,7 +30,7 @@ case class TravelTimeStatistics(stats: Statistics)
 
 object TravelTimeStatistics {
 
-  def apply(rideStats: Seq[SingleRideStat]): TravelTimeStatistics = {
+  def apply(rideStats: Seq[CarTripStat]): TravelTimeStatistics = {
     new TravelTimeStatistics(Statistics(rideStats.map(_.travelTime)))
   }
 }
@@ -36,7 +39,7 @@ case class SpeedStatistics(stats: Statistics)
 
 object SpeedStatistics {
 
-  def apply(rideStats: Seq[SingleRideStat]): SpeedStatistics = {
+  def apply(rideStats: Seq[CarTripStat]): SpeedStatistics = {
     new SpeedStatistics(Statistics(rideStats.map(_.speed)))
   }
 }
@@ -45,7 +48,7 @@ case class DistanceStatistics(stats: Statistics)
 
 object DistanceStatistics {
 
-  def apply(rideStats: Seq[SingleRideStat]): DistanceStatistics = {
+  def apply(rideStats: Seq[CarTripStat]): DistanceStatistics = {
     new DistanceStatistics(Statistics(rideStats.map(_.distance)))
   }
 }
@@ -54,7 +57,7 @@ case class FreeFlowTravelTimeStatistics(stats: Statistics)
 
 object FreeFlowTravelTimeStatistics {
 
-  def apply(rideStats: Seq[SingleRideStat]): FreeFlowTravelTimeStatistics = {
+  def apply(rideStats: Seq[CarTripStat]): FreeFlowTravelTimeStatistics = {
     new FreeFlowTravelTimeStatistics(Statistics(rideStats.map(_.freeFlowTravelTime)))
   }
 }
@@ -63,12 +66,12 @@ case class FreeFlowSpeedStatistics(stats: Statistics)
 
 object FreeFlowSpeedStatistics {
 
-  def apply(rideStats: Seq[SingleRideStat]): FreeFlowSpeedStatistics = {
+  def apply(rideStats: Seq[CarTripStat]): FreeFlowSpeedStatistics = {
     new FreeFlowSpeedStatistics(Statistics(rideStats.map(_.freeFlowSpeed)))
   }
 }
 
-case class IterationCarRideStats(
+case class IterationCarTripStats(
   iteration: Int,
   travelTime: TravelTimeStatistics,
   speed: SpeedStatistics,

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -9,7 +9,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import beam.agentsim.agents.modalbehaviors.ModeChoiceCalculator
 import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailIterationsStatsCollector}
-import beam.analysis.cartraveltime.CarRideStatsFromPathTraversalEventHandler
+import beam.analysis.cartraveltime.CarTripStatsFromPathTraversalEventHandler
 import beam.analysis.plots.modality.ModalityStyleStats
 import beam.analysis.plots.{GraphUtils, GraphsStatsAgentSimEventsListener}
 import beam.analysis.via.ExpectedMaxUtilityHeatMap
@@ -91,8 +91,8 @@ class BeamSim @Inject()(
 
   val rideHailUtilizationCollector: RideHailUtilizationCollector = new RideHailUtilizationCollector(beamServices)
 
-  val carTravelTimeFromPte: CarRideStatsFromPathTraversalEventHandler =
-    new CarRideStatsFromPathTraversalEventHandler(networkHelper, Some(beamServices.matsimServices.getControlerIO))
+  val carTravelTimeFromPte: CarTripStatsFromPathTraversalEventHandler =
+    new CarTripStatsFromPathTraversalEventHandler(networkHelper, Some(beamServices.matsimServices.getControlerIO))
 
   override def notifyStartup(event: StartupEvent): Unit = {
 

--- a/src/test/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandlerSpec.scala
+++ b/src/test/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandlerSpec.scala
@@ -4,11 +4,11 @@ import org.scalatest.Matchers._
 
 import scala.reflect.io.File
 
-class CarRideStatsFromPathTraversalEventHandlerSpec extends GenericEventsSpec {
+class CarTripStatsFromPathTraversalEventHandlerSpec extends GenericEventsSpec {
 
   "CarRideStatsFromPathTraversalEventHandlerSpec" must {
     "write speed statistics files" in {
-      val handler = new CarRideStatsFromPathTraversalEventHandler(
+      val handler = new CarTripStatsFromPathTraversalEventHandler(
         this.networkHelper,
         Some(beamServices.matsimServices.getControlerIO)
       )

--- a/src/test/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandlerSpec.scala
+++ b/src/test/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandlerSpec.scala
@@ -1,5 +1,6 @@
 package beam.analysis.cartraveltime
 import beam.agentsim.agents.GenericEventsSpec
+import org.scalatest.Assertion
 import org.scalatest.Matchers._
 
 import scala.reflect.io.File
@@ -21,10 +22,19 @@ class CarTripStatsFromPathTraversalEventHandlerSpec extends GenericEventsSpec {
       checkFileExistenceInRoot("CarTravelDistance.csv")
       checkFileExistenceInRoot("CarSpeed.csv")
       checkFileExistenceInRoot("FreeFlowCarSpeed.csv")
+
+      // If those start to fail, someone changed vehicle types for beamville or `CarTripStatsFromPathTraversalEventHandler` is changed
+      checkFileExistenceInIterFolder("ridehail.CarRideStats.csv.gz", 0)
+      checkFileExistenceInIterFolder("personal.CarRideStats.csv.gz", 0)
+      checkFileExistenceInIterFolder("cav.CarRideStats.csv.gz", 0)
     }
   }
 
-  private def checkFileExistenceInRoot(file: String) = {
+  private def checkFileExistenceInRoot(file: String): Assertion = {
     File(beamServices.matsimServices.getControlerIO.getOutputFilename(file)).isFile shouldEqual true
+  }
+
+  private def checkFileExistenceInIterFolder(file: String, iteration: Int): Assertion = {
+    File(beamServices.matsimServices.getControlerIO.getIterationFilename(iteration, file)).isFile shouldEqual true
   }
 }

--- a/src/test/scala/beam/sim/BeamWarmStartRunSpec.scala
+++ b/src/test/scala/beam/sim/BeamWarmStartRunSpec.scala
@@ -40,7 +40,7 @@ class BeamWarmStartRunSpec extends WordSpecLike with Matchers with BeamHelper wi
     val outputDirectoryHierarchy =
       new OutputDirectoryHierarchy(outputDir, OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles)
 
-    outputDirectoryHierarchy.getIterationFilename(iterationNumber, "CarRideStats.csv.gz")
+    outputDirectoryHierarchy.getIterationFilename(iterationNumber, "personal.CarRideStats.csv.gz")
   }
 
 }


### PR DESCRIPTION
- Added departure location (`start_x`, `start_y`) and arrival location (`end_x`, `end_y`) to `CarTripStat`
- Fixed bug in `writeCarTripStats` which was caused by using the same name of output file for all car types
- Renamed types to have less confusion with RideHail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2429)
<!-- Reviewable:end -->
