### PR TITLE
Gradle: Fix error when myAvailableRam/2 is not integer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -412,7 +412,7 @@ mainClassName = "beam.sim.RunBeam"
 
 
 def myAvailableRam = (System.getenv("MAXRAM") ?: (project.findProperty('maxRAM') ?: "140")).toString().replace("g", "").toInteger()
-
+def halfOfAvailableMem = (myAvailableRam / 2).toInteger()
 
 def getCurrentTimestamp = {
     DateTimeFormatter.ofPattern("MM-dd-yyyy_HH-mm-ss")
@@ -441,7 +441,7 @@ def jmx = ["-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.por
            "-Djava.net.preferIPv4Stack=true", "-Djava.rmi.server.hostname=127.0.0.1"]
 
 // UseParallelGC
-applicationDefaultJvmArgs = ["-Xmx${myAvailableRam}g", "-Xms${myAvailableRam/2}g",
+applicationDefaultJvmArgs = ["-Xmx${myAvailableRam}g", "-Xms${halfOfAvailableMem}g",
                              "-XX:+UseParallelGC", "-XX:+UseParallelOldGC", "-XX:MetaspaceSize=150M", "-Djava.awt.headless=true",
                              "-Dlogback.configurationFile=logback_prod.xml", "-Xss2048k"] + logGC + jmx
 


### PR DESCRIPTION
If `MAXRAM` parameter is odd number, then `./gradlew run` fails with:
```
$ ./gradlew run -PappArgs="['--config', 'test/input/texas/austin-prod-100k.conf']"
[-Xmx25g, -Xms12.5g, -XX:+UseParallelGC, -XX:+UseParallelOldGC, -XX:MetaspaceSize=150M, -Djava.awt.headless=true, -Dlogback.configurationFile=logback_prod.xml, -Xss2048k, -XX:+PrintGCDetails, -XX:+PrintGCDateStamps, -Xloggc:gc_03-22-2020_11-38-38.log, -Dcom.sun.management.jmxremote, -Dcom.sun.management.jmxremote.port=9005, -Dcom.sun.management.jmxremote.host=127.0.0.1, -Dcom.sun.management.jmxremote.local.only=true, -Dcom.sun.management.jmxremote.authenticate=false, -Dcom.sun.management.jmxremote.ssl=false, -Djava.net.preferIPv4Stack=true, -Djava.rmi.server.hostname=127.0.0.1]
:compileJava NO-SOURCE
:compileScala
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:processResources
:classes
:runError: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Invalid initial heap size: -Xms12.5g
 FAILED

FAILURE: Build failed with an exception.
```
This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2439)
<!-- Reviewable:end -->
