### PR TITLE
Try to open connection to InfluxDB

### DIFF
--- a/src/main/scala/beam/sim/metrics/SimulationMetricCollector.scala
+++ b/src/main/scala/beam/sim/metrics/SimulationMetricCollector.scala
@@ -228,9 +228,8 @@ class InfluxDbSimulationMetricCollector @Inject()(beamCfg: BeamConfig)
       Some(db)
     } catch {
       case NonFatal(t: Throwable) =>
-        logger.error(
-          s"Could not connect to InfluxDB at ${cfg.connectionString}, database: ${cfg.database}: ${t.getMessage}",
-          t
+        logger.warn(
+          s"Could not connect to InfluxDB at ${cfg.connectionString}, database: ${cfg.database}. Error: ${t.getMessage}"
         )
         None
     }

--- a/src/main/scala/beam/sim/metrics/SimulationMetricCollector.scala
+++ b/src/main/scala/beam/sim/metrics/SimulationMetricCollector.scala
@@ -223,6 +223,7 @@ class InfluxDbSimulationMetricCollector @Inject()(beamCfg: BeamConfig)
       val db = InfluxDBFactory.connect(cfg.connectionString)
       db.setDatabase(cfg.database)
       db.enableBatch(BatchOptions.DEFAULTS)
+      db.ping()
       logger.info(s"Connected to InfluxDB at ${cfg.connectionString}, database: ${cfg.database}")
       Some(db)
     } catch {


### PR DESCRIPTION
This will cause to see the following error in the logs in case if InfluxDB is not available:
```
22:15:53.495 ERROR b.s.m.InfluxDbSimulationMetricCollector - Could not connect to InfluxDB at http://localhost:8086, database: beam: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:8086
org.influxdb.InfluxDBIOException: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:8086
	at org.influxdb.impl.InfluxDBImpl.ping(InfluxDBImpl.java:395)
	at beam.sim.metrics.InfluxDbSimulationMetricCollector.liftedTree1$1(SimulationMetricCollector.scala:226)
	at beam.sim.metrics.InfluxDbSimulationMetricCollector.<init>(SimulationMetricCollector.scala:222)
	at beam.sim.metrics.InfluxDbSimulationMetricCollector$$FastClassByGuice$$ae09cc89.newInstance(<generated>)
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:56)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:205)
	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:199)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085)
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:199)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:180)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
	at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:232)
	at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:236)
	at org.matsim.core.controler.Injector.createInjector(Injector.java:73)
	at beam.sim.BeamHelper.buildInjector(BeamHelper.scala:543)
	at beam.sim.BeamHelper.buildInjector$(BeamHelper.scala:535)
	at beam.sim.RunBeam$.buildInjector(RunBeam.scala:5)
	at beam.sim.BeamHelper.runBeamWithConfig(BeamHelper.scala:485)
	at beam.sim.BeamHelper.runBeamWithConfig$(BeamHelper.scala:457)
	at beam.sim.RunBeam$.runBeamWithConfig(RunBeam.scala:5)
	at beam.sim.BeamHelper.runBeamUsing(BeamHelper.scala:339)
	at beam.sim.BeamHelper.runBeamUsing$(BeamHelper.scala:333)
	at beam.sim.RunBeam$.runBeamUsing(RunBeam.scala:5)
	at beam.sim.RunBeam$.main(RunBeam.scala:14)
	at beam.sim.RunBeam.main(RunBeam.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.CommandLineWrapper.main(CommandLineWrapper.java:66)
Caused by: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:8086
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265)
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183)
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224)
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108)
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88)
	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at org.influxdb.impl.BasicAuthInterceptor.intercept(BasicAuthInterceptor.java:22)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at org.influxdb.impl.GzipRequestInterceptor.intercept(GzipRequestInterceptor.java:42)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.java:152)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:221)
	at okhttp3.RealCall.execute(RealCall.java:81)
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:188)
	at org.influxdb.impl.InfluxDBImpl.ping(InfluxDBImpl.java:381)
	... 38 common frames omitted
Caused by: java.net.ConnectException: Connection refused: connect
	at java.net.DualStackPlainSocketImpl.waitForConnect(Native Method)
	at java.net.DualStackPlainSocketImpl.socketConnect(DualStackPlainSocketImpl.java:85)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.PlainSocketImpl.connect(PlainSocketImpl.java:172)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:606)
	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130)
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263)
	... 67 common frames omitted
```
Is it too much? @nikolayilyin what do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2462)
<!-- Reviewable:end -->
