### PR TITLE
Grafana metrics enabled by default for production runs

### DIFF
--- a/docs/grafana.rst
+++ b/docs/grafana.rst
@@ -267,17 +267,6 @@ Metrics which contain a single number with a count of different types of ride ha
     beam-run-RH-ev-non-cav,
     beam-run-RH-non-ev-non-cav
 
-Ride hail EV (electric vehicle), CAV (connected and automated vehicle) metrics::
-
-    rh-ev-cav-count,
-    rh-ev-cav-distance,
-    rh-ev-nocav-count,
-    rh-ev-nocav-distance,
-    rh-noev-cav-count,
-    rh-noev-cav-distance,
-    rh-noev-nocav-count,
-    rh-noev-nocav-distance
-
 Various metrics for all vehicles/persons::
 
     parking,
@@ -294,6 +283,19 @@ Various metrics for ride hail
     ride-hail-trip-distance,
     ride-hail-inquiry-served (graph is not added to a grafana dashboard),
     ride-hail-allocation-reserved (graph is not added to a grafana dashboard)
+
+**Metrics which impact performance**
+
+Ride hail EV (electric vehicle), CAV (connected and automated vehicle) metrics::
+
+    rh-ev-cav-count,
+    rh-ev-cav-distance,
+    rh-ev-nocav-count,
+    rh-ev-nocav-distance,
+    rh-noev-cav-count,
+    rh-noev-cav-distance,
+    rh-noev-nocav-count,
+    rh-noev-nocav-distance
 
 New metrics
 ^^^^^^^^^^^^^^^^

--- a/gradle.deploy.properties
+++ b/gradle.deploy.properties
@@ -1,9 +1,9 @@
 runName=BEAM
 beamBranch=develop
 beamCommit=HEAD
-beamConfigs=test/input/sf-light/sf-light-25k.conf
+beamConfigs=test/input/sf-light/sf-light-1k.conf
 instanceType=t2.small
-runGrafana=false
+runGrafana=true
 
 #c5.9xlarge (36/141)    -> 5 instances -> $1.53 per Hour
 #m4.10xlarge (40/160)   -> 5 -> $2.00 per Hour

--- a/production/common/metrics.conf
+++ b/production/common/metrics.conf
@@ -42,9 +42,6 @@ beam.sim.metric.collector {
 
     beam-run-RH-ev-cav, beam-run-RH-non-ev-cav, beam-run-RH-ev-non-cav, beam-run-RH-non-ev-non-cav,
 
-    rh-ev-cav-count, rh-ev-cav-distance, rh-ev-nocav-count, rh-ev-nocav-distance,
-    rh-noev-cav-count, rh-noev-cav-distance, rh-noev-nocav-count, rh-noev-nocav-distance,
-
     parking, chargingPower, mode-choices, average-travel-time,
 
     ride-hail-waiting-time, ride-hail-waiting-time-map, ride-hail-trip-distance

--- a/production/common/metrics.conf
+++ b/production/common/metrics.conf
@@ -3,32 +3,50 @@
 ##################################################################
 beam.metrics.level = "off"
 
-kamon {
-  trace {
-    level = simple-trace
+beam.sim.metric.collector {
+  influxDbSimulationMetricCollector {
+    database = "beam"
+    connectionString = "http://localhost:8086"
   }
 
-  metric {
-    tick-interval = 2 seconds
-    filters {
-      trace.includes = [ "**" ]
-    }
-  }
+    ##################################################################
+    #
+    #   - writing a run name and an iteration number
+    #   - necessary for displaying all metrics
+    # beam-run, beam-iteration,
+    #
+    #   - writing a single number with a count of households, population size, charging stalls count e.t.c
+    # beam-run-households, beam-run-population-size, beam-run-private-fleet-size, beam-run-charging-depots-cnt,
+    # beam-run-charging-depots-stalls-cnt, beam-run-public-fast-charge-cnt, beam-run-public-fast-charge-stalls-cnt,
+    #
+    #   - writing a single number with a count of different RH vehicles
+    # beam-run-RH-ev-cav, beam-run-RH-non-ev-cav, beam-run-RH-ev-non-cav, beam-run-RH-non-ev-non-cav,
+    #
+    #   - RH EV CAV metrics for 8 graphs.
+    #   - 4 graphs for count of RH vehicles, 4 graphs for trip distances
+    # rh-ev-cav-count, rh-ev-cav-distance, rh-ev-nocav-count, rh-ev-nocav-distance,
+    # rh-noev-cav-count, rh-noev-cav-distance, rh-noev-nocav-count, rh-noev-nocav-distance,
+    #
+    #   - various graphs
+    # parking, chargingPower, mode-choices, average-travel-time,
+    #
+    #   - various graphs for RH
+    # ride-hail-inquiry-served, ride-hail-allocation-reserved, ride-hail-waiting-time, ride-hail-waiting-time-map, ride-hail-trip-distance
+    #
+    ##################################################################
+    metrics = """
+    beam-run, beam-iteration,
 
-  statsd {
-    hostname = 127.0.0.1
-    port = 8125
-  }
+    beam-run-households, beam-run-population-size, beam-run-private-fleet-size, beam-run-charging-depots-cnt,
+    beam-run-charging-depots-stalls-cnt, beam-run-public-fast-charge-cnt, beam-run-public-fast-charge-stalls-cnt,
 
-  influxdb {
-    hostname = 18.216.21.254
-    port = 8089
-    protocol = "udp"
-  }
+    beam-run-RH-ev-cav, beam-run-RH-non-ev-cav, beam-run-RH-ev-non-cav, beam-run-RH-non-ev-non-cav,
 
-  modules {
-    kamon-log-reporter.auto-start = no
-    kamon-statsd.auto-start = no
-    kamon-influxdb.auto-start = no
-  }
+    rh-ev-cav-count, rh-ev-cav-distance, rh-ev-nocav-count, rh-ev-nocav-distance,
+    rh-noev-cav-count, rh-noev-cav-distance, rh-noev-nocav-count, rh-noev-nocav-distance,
+
+    parking, chargingPower, mode-choices, average-travel-time,
+
+    ride-hail-waiting-time, ride-hail-waiting-time-map, ride-hail-trip-distance
+    """
 }


### PR DESCRIPTION
Grafana metrics are enabled by default for production configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2496)
<!-- Reviewable:end -->
