### PR TITLE
Use now for ride hail reservation time

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -839,22 +839,21 @@ class PersonAgent(
       val legSegment = nextLeg :: tailOfCurrentTrip.takeWhile(
         leg => leg.beamVehicleId == nextLeg.beamVehicleId
       )
-      val departAt = legSegment.head.beamLeg.startTime
 
       rideHailManager ! RideHailRequest(
         ReserveRide,
         PersonIdWithActorRef(id, self),
         beamServices.geo.wgs2Utm(nextLeg.beamLeg.travelPath.startPoint.loc),
-        departAt,
+        _currentTick.get,
         beamServices.geo.wgs2Utm(legSegment.last.beamLeg.travelPath.endPoint.loc),
         nextLeg.isPooledTrip
       )
 
       eventsManager.processEvent(
         new ReserveRideHailEvent(
-          _currentTick.getOrElse(departAt).toDouble,
+          _currentTick.get.toDouble,
           id,
-          departAt,
+          _currentTick.get,
           nextLeg.beamLeg.travelPath.startPoint.loc,
           legSegment.last.beamLeg.travelPath.endPoint.loc
         )


### PR DESCRIPTION
During trip planning (in ChoosesMode) we build a trip with legs that looks like e.g. WALK,RIDE_HAIL,WALK. When we do this we make the start time of the WALK leg be “now” and start time of the RIDE_HAIL be set to the pickup time, which therefore allows our mode choice alg to include wait time in the option.

So far so good. 

But then when we execute the trip we are taking the dummy WALK leg which takes 0 seconds and we are sending a reservation request to RHM with the start time of the RIDE_HAIL leg as the requested departure time. So this is a problem because the RHM takes requested departure time on faith and won’t dispatch a vehicle more quickly even if it were possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2532)
<!-- Reviewable:end -->
