### PR TITLE
AgentSimToPhysSimPlanConverter: Use mean to compute average instead of collecting all speeds

### DIFF
--- a/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
+++ b/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
@@ -21,8 +21,8 @@ import beam.utils.FileUtils;
 import beam.utils.TravelTimeCalculatorHelper;
 import com.conveyal.r5.transit.TransportNetwork;
 import com.google.common.collect.Lists;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.events.Event;
@@ -88,7 +88,7 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
 
     private final PlotGraph plotGraph = new PlotGraph();
     Map<String, Boolean> caccVehiclesMap = new TreeMap<>();
-    private final Map<Integer, List<Double>> binSpeed = new HashMap<>();
+    private final Map<Integer, Mean> binSpeed = new HashMap<>();
 
     private TravelTime prevTravelTime = new FreeFlowTravelTime();
 
@@ -290,7 +290,8 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
                 if(travelTime > 0.0){
                     double speed = pte.legLength() / travelTime;
                     int bin = (int)departureTime / beamConfig.beam().physsim().linkStatsBinSize();
-                    binSpeed.merge(bin, Lists.newArrayList(speed), ListUtils::union);
+                    Mean mean = binSpeed.getOrDefault(bin, new Mean());
+                    mean.increment(speed);
                 }
             }
             // pt sampling
@@ -333,7 +334,7 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
         String path = controlerIO.getIterationFilename(iteration, "agentSimAverageSpeed.csv");
 
         List<String> rows = binSpeed.entrySet().stream().sorted(Map.Entry.comparingByKey())
-                .map(entry -> (entry.getKey()+1)+","+entry.getValue().stream().mapToDouble(x -> x).average().getAsDouble())
+                .map(entry -> (entry.getKey()+1)+","+entry.getValue().getResult())
                 .collect(Collectors.toList());
 
         FileUtils.writeToFile(path, Option.apply("timeBin,averageSpeed"), StringUtils.join(rows, "\n"), Option.empty());


### PR DESCRIPTION
It's a hot place currently:
![image](https://user-images.githubusercontent.com/5107562/80303744-4d709480-87dc-11ea-8a0d-5e1c5cfe7343.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2573)
<!-- Reviewable:end -->
