### PR TITLE
Move jfree usage to GraphUtils, part1

### DIFF
--- a/src/main/java/beam/analysis/physsim/PhyssimCalcLinkSpeedDistributionStats.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimCalcLinkSpeedDistributionStats.java
@@ -1,30 +1,22 @@
 package beam.analysis.physsim;
 
-import beam.analysis.plots.GraphsStatsAgentSimEventsListener;
-import beam.sim.OutputDataDescription;
+import beam.analysis.plots.GraphUtils;
 import beam.sim.config.BeamConfig;
-import beam.utils.OutputDataDescriptor;
-import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartUtilities;
+import com.google.common.base.Suppliers;
 import org.jfree.chart.JFreeChart;
-import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.category.DefaultCategoryDataset;
-import org.jfree.data.general.DatasetUtilities;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.util.TravelTime;
-import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
 import org.matsim.core.utils.misc.Time;
 
-import java.awt.*;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
-import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -63,26 +55,33 @@ public class PhyssimCalcLinkSpeedDistributionStats {
         //generate the graph input for the free flow speed distribution
         Map<Integer, Integer> processedSpeedDistributionData = generateInputDataForFreeFlowSpeedGraph(noOfBins,this.network);
         //generate  data matrix for the free flow speed distribution
-        double[][] speedDataMatrix = buildDataSetFromSpeedData(processedSpeedDistributionData);
+        Supplier<double[]> speedDataList = Suppliers.memoize(() -> buildDataSetFromSpeedData(processedSpeedDistributionData));
         //generate the graph input for the link efficiencies
-        Map<Double, Integer> processedSpeedDistributionAsPercentageData = generateInputDataForLinkEfficiencies(travelTime);
-        //generate category data set for free flow speed distribution
-        CategoryDataset dataSetForSpeed = DatasetUtilities.createCategoryDataset("Free Speed", "", speedDataMatrix);
-        //generate the category data set for link efficiencies
-        CategoryDataset dataSetForSpeedAsPercentage = generateLinkEfficienciesDataSet(processedSpeedDistributionAsPercentageData);
+        Supplier<Map<Double, Integer>> processedSpeedDistributionAsPercentageData = Suppliers.memoize(() ->
+                generateInputDataForLinkEfficiencies(travelTime));
+
         if (this.outputDirectoryHierarchy != null) {
             //If not running in test mode , write output to a csv file
             if (isNotTestMode()) {
                 //write data outputs to CSV
-                this.writeCSV(speedDataMatrix,outputDirectoryHierarchy.getIterationFilename(iteration, outputAsSpeedUnitFileName+".csv"),"freeSpeedInMetersPerSecond");
-                this.writeCSV(processedSpeedDistributionAsPercentageData,outputDirectoryHierarchy.getIterationFilename(iteration, outputAsPercentageFileName+".csv"),"linkEfficiencyInPercentage");
+                this.writeCSV(speedDataList.get(),outputDirectoryHierarchy.getIterationFilename(iteration, outputAsSpeedUnitFileName+".csv"),"freeSpeedInMetersPerSecond");
+                this.writeCSV(processedSpeedDistributionAsPercentageData.get(),outputDirectoryHierarchy.getIterationFilename(iteration, outputAsPercentageFileName+".csv"),"linkEfficiencyInPercentage");
             }
             //generate the required charts - frequency over speed (as m/s)
             if(beamConfig.beam().outputs().writeGraphs()) {
-                generateSpeedDistributionBarChart(dataSetForSpeed, iteration);
+                //generate category data set for free flow speed distribution
+                CategoryDataset dataSetForSpeedTest = generateSpeedDistributionDataSet(speedDataList.get());
+                generateSpeedDistributionBarChart(dataSetForSpeedTest, iteration);
+
+                //generate the category data set for link efficiencies
+                CategoryDataset dataSetForSpeedAsPercentage = generateLinkEfficienciesDataSet(processedSpeedDistributionAsPercentageData.get());
                 generateSpeedDistributionAsPercentageChart(dataSetForSpeedAsPercentage,iteration);
             }
         }
+    }
+
+    private CategoryDataset generateSpeedDistributionDataSet(double[] speedDataList) {
+        return GraphUtils.createCategoryDataset("", "", speedDataList);
     }
 
     private CategoryDataset generateLinkEfficienciesDataSet(Map<Double, Integer> generatedDataMap) {
@@ -104,17 +103,15 @@ public class PhyssimCalcLinkSpeedDistributionStats {
 
     /**
      * Helper method that writes the final data to a CSV file
-     * @param dataMatrix the input data required to generate the charts
+     * @param data the input data required to generate the charts
      * @param outputFilePath path to the CSV file
      * @param heading header string for the CSV file
      */
-    private void writeCSV(double[][] dataMatrix,String outputFilePath,String heading) {
-        try {
-            BufferedWriter bw = new BufferedWriter(new FileWriter(outputFilePath));
+    private void writeCSV(double[] data, String outputFilePath,String heading) {
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(outputFilePath))) {
             String completeHeading = heading + ",numberOfLinks\n";
             bw.write(completeHeading);
-            double[] data = dataMatrix[0];
-            IntStream.range(0,data.length)
+            IntStream.range(0, data.length)
                     .forEach( i -> {
                         try {
                             bw.write(i + "," + data[i] + "\n");
@@ -122,7 +119,6 @@ public class PhyssimCalcLinkSpeedDistributionStats {
                             e.printStackTrace();
                         }
                     });
-            bw.close();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -135,8 +131,7 @@ public class PhyssimCalcLinkSpeedDistributionStats {
      * @param heading header string for the CSV file
      */
     private void writeCSV(Map<Double, Integer> dataMap,String outputFilePath,String heading) {
-        try {
-            BufferedWriter bw = new BufferedWriter(new FileWriter(outputFilePath));
+        try(BufferedWriter bw = new BufferedWriter(new FileWriter(outputFilePath))) {
             String completeHeading = heading + ",linkEfficiencyRounded,numberOfLinks\n";
             bw.write(completeHeading);
             dataMap.forEach((k,v) -> {
@@ -146,7 +141,6 @@ public class PhyssimCalcLinkSpeedDistributionStats {
                     e.printStackTrace();
                 }
             });
-            bw.close();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -201,19 +195,16 @@ public class PhyssimCalcLinkSpeedDistributionStats {
     }
 
     /**
-     * Generate a 2d data matrix , used to generate category data set for stacked bar chart
+     * Generate a data, used to generate category data set for stacked bar chart
      * @param generatedDataMap input data generated as map
-     * @return 2d data matrix
+     * @return ordered data list
      */
-    private double[][] buildDataSetFromSpeedData(Map<Integer, Integer> generatedDataMap) {
-        Stream<Integer> keys = generatedDataMap.keySet()
-                .stream();
-        Integer max = keys.max(Comparator.comparing(Integer::valueOf)).orElse(0);
-        double[][] dataMatrix = new double[1][max+1];
-        for (int i = 1; i <= max; i++) {
-            dataMatrix[0][i-1] = generatedDataMap.getOrDefault(i,0);
-        }
-        return dataMatrix;
+    private double[] buildDataSetFromSpeedData(Map<Integer, Integer> generatedDataMap) {
+        int max = generatedDataMap.keySet().stream().max(Comparator.comparing(Integer::valueOf)).orElse(0);
+        double[] result = new double[max+1];
+        IntStream.rangeClosed(0, max).forEach(i -> result[i] = generatedDataMap.getOrDefault(i, 0));
+
+        return result;
     }
 
     /**
@@ -229,19 +220,13 @@ public class PhyssimCalcLinkSpeedDistributionStats {
         int width = 1000;
         int height = 600;
 
-        // Setting orientation for the plot
-        PlotOrientation orientation = PlotOrientation.VERTICAL;
-
         // Create the chart
-        final JFreeChart chart = ChartFactory
-                .createStackedBarChart(plotTitle, x_axis, y_axis, dataSet, orientation, false, true, true);
-        chart.setBackgroundPaint(new Color(255, 255, 255));
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, plotTitle, x_axis, y_axis, false);
 
         //Save the chart as image
         String graphImageFile = outputDirectoryHierarchy.getIterationFilename(iterationNumber, outputAsSpeedUnitFileName+".png");
         try {
-            ChartUtilities.saveChartAsPNG(new File(graphImageFile), chart, width,
-                    height);
+            GraphUtils.saveJFreeChartAsPNG(chart, graphImageFile, width, height);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -259,23 +244,16 @@ public class PhyssimCalcLinkSpeedDistributionStats {
         String y_axis = "Frequency";
         int width = 1000;
         int height = 800;
-        // Setting orientation for the plot
-        PlotOrientation orientation = PlotOrientation.VERTICAL;
 
         // Create the chart
-        final JFreeChart chart = ChartFactory
-                .createStackedBarChart(plotTitle, x_axis, y_axis, dataSet, orientation, false, true, true);
-        chart.setBackgroundPaint(new Color(255, 255, 255));
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, plotTitle, x_axis, y_axis, false);
 
         //Save the chart as image
         String graphImageFile = outputDirectoryHierarchy.getIterationFilename(iterationNumber, outputAsPercentageFileName+".png");
         try {
-            ChartUtilities.saveChartAsPNG(new File(graphImageFile), chart, width,
-                    height);
+            GraphUtils.saveJFreeChartAsPNG(chart, graphImageFile, width, height);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
-
-
 }

--- a/src/main/java/beam/analysis/physsim/PhyssimCalcLinkStats.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimCalcLinkStats.java
@@ -1,5 +1,6 @@
 package beam.analysis.physsim;
 
+import beam.analysis.plots.GraphUtils;
 import beam.sim.BeamConfigChangesObservable;
 import beam.sim.config.BeamConfig;
 import beam.utils.BeamCalcLinkStats;
@@ -16,13 +17,11 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.util.TravelTime;
-import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
 import org.matsim.core.utils.misc.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 import java.awt.*;
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.List;
@@ -80,7 +79,6 @@ public class PhyssimCalcLinkStats implements Observer {
     }
 
     public void notifyIterationEnds(int iteration, TravelTime travelTime) {
-
         linkStats.addData(volumes, travelTime);
         processData(iteration, travelTime);
         CategoryDataset dataset = buildAndGetGraphCategoryDataset();
@@ -92,7 +90,6 @@ public class PhyssimCalcLinkStats implements Observer {
                 createModesFrequencyGraph(dataset, iteration);
             }
         }
-
     }
 
     private boolean isNotTestMode() {
@@ -111,11 +108,7 @@ public class PhyssimCalcLinkStats implements Observer {
 
     private void processData(int iteration, TravelTime travelTime) {
         for (int idx = 0; idx < noOfBins; idx++) {
-
-
             for (Link link : this.network.getLinks().values()) {
-
-
                 double freeSpeed = link.getFreespeed(idx * binSize);
 
                 double linkLength = link.getLength();
@@ -171,10 +164,7 @@ public class PhyssimCalcLinkStats implements Observer {
     }
 
     private double[][] buildModesFrequencyDataset() {
-
         List<Double> relativeSpeedsCategoriesList = getSortedListRelativeSpeedCategoryList();
-
-
         double[][] dataset = new double[0][];
 
         Optional<Double> optionalMaxRelativeSpeedsCategories = relativeSpeedsCategoriesList.stream().max(Comparator.naturalOrder());
@@ -207,7 +197,6 @@ public class PhyssimCalcLinkStats implements Observer {
     }
 
     private void createModesFrequencyGraph(CategoryDataset dataset, int iterationNumber) {
-
         String plotTitle = "Relative Network Link Speeds";
         String xaxis = "Hour";
         String yaxis = "# of network links";
@@ -227,27 +216,19 @@ public class PhyssimCalcLinkStats implements Observer {
         CategoryPlot plot = chart.getCategoryPlot();
 
         LegendItemCollection legendItems = new LegendItemCollection();
-
-
         List<Double> relativeSpeedsCategoriesList = new ArrayList<>(relativeSpeedFrequenciesPerBin.keySet());
 
         int max = Collections.max(relativeSpeedsCategoriesList).intValue();
 
         for (int i = 0; i <= max ; i++) {
-
             legendItems.add(new LegendItem(String.valueOf(i), getColor(i)));
-
             plot.getRenderer().setSeriesPaint(i, getColor(i));
-
         }
         plot.setFixedLegendItems(legendItems);
 
-
         try {
-            ChartUtilities.saveChartAsPNG(new File(graphImageFile), chart, width,
-                    height);
+            GraphUtils.saveJFreeChartAsPNG(chart, graphImageFile, width, height);
         } catch (IOException e) {
-
             e.printStackTrace();
         }
     }
@@ -261,7 +242,6 @@ public class PhyssimCalcLinkStats implements Observer {
     }
 
     private Color getRandomColor() {
-
         Random rand = new Random();
 
         float r = rand.nextFloat();

--- a/src/main/java/beam/analysis/physsim/PhyssimSpeedHandler.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimSpeedHandler.java
@@ -4,8 +4,6 @@ import beam.analysis.plots.GraphUtils;
 import beam.analysis.plots.GraphsStatsAgentSimEventsListener;
 import beam.sim.config.BeamConfig;
 import beam.utils.FileUtils;
-import com.google.common.collect.Lists;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.jfree.chart.JFreeChart;
@@ -104,7 +102,6 @@ public class PhyssimSpeedHandler implements PersonArrivalEventHandler, PersonDep
     }
 
     public void notifyIterationEnds(int iteration) {
-
         writeIterationGraph(iteration);
         writeIterationCsv(iteration);
         personsDepartureTime.clear();
@@ -134,7 +131,6 @@ public class PhyssimSpeedHandler implements PersonArrivalEventHandler, PersonDep
                 graphTitle,
                 "hour",
                 "Average Speed [m/s]",
-                fileName+".png",
                 false
         );
         CategoryPlot plot = chart.getCategoryPlot();

--- a/src/main/java/beam/analysis/plots/BaseModeAnalysis.java
+++ b/src/main/java/beam/analysis/plots/BaseModeAnalysis.java
@@ -62,7 +62,7 @@ public abstract class BaseModeAnalysis<T extends Map<Integer, Map>> implements G
     }
 
     protected void createGraphInRootDirectory(CategoryDataset dataset, String graphTitleName, String fileName, String xAxisTitle, String yAxisTitle, Set<String> modes) throws IOException {
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitleName, xAxisTitle, yAxisTitle, fileName, true);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitleName, xAxisTitle, yAxisTitle, true);
         CategoryPlot plot = chart.getCategoryPlot();
         List<String> modesChosenList = new ArrayList<>(modes);
         Collections.sort(modesChosenList);

--- a/src/main/java/beam/analysis/plots/DeadHeadingAnalysis.java
+++ b/src/main/java/beam/analysis/plots/DeadHeadingAnalysis.java
@@ -602,7 +602,7 @@ public class DeadHeadingAnalysis implements GraphAnalysis, OutputDataDescriptor 
         String fileName = getFileName(graphName, "png");
         String graphTitle = getTitle(graphName);
         boolean legend = true;
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, graphTitle, xAxisTitle, yAxisTitle, fileName, legend);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, graphTitle, xAxisTitle, yAxisTitle, legend);
         CategoryPlot plot = chart.getCategoryPlot();
         List<String> legendItemList = getLegendItemList(graphName, dataSet.getRowCount(), getBucketSize());
         GraphUtils.plotLegendItems(plot, legendItemList, dataSet.getRowCount());

--- a/src/main/java/beam/analysis/plots/FuelUsageAnalysis.java
+++ b/src/main/java/beam/analysis/plots/FuelUsageAnalysis.java
@@ -142,7 +142,7 @@ public class FuelUsageAnalysis implements GraphAnalysis, IterationSummaryAnalysi
 
     private void createModesFuelageGraph(CategoryDataset dataset, int iterationNumber) throws IOException {
 
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, fileBaseName, true);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, true);
         CategoryPlot plot = chart.getCategoryPlot();
         List<String> modesFuelList = new ArrayList<>(modesFuel);
         Collections.sort(modesFuelList);

--- a/src/main/java/beam/analysis/plots/GraphSurgePricing.java
+++ b/src/main/java/beam/analysis/plots/GraphSurgePricing.java
@@ -2,8 +2,6 @@ package beam.analysis.plots;
 
 import beam.agentsim.agents.ridehail.RideHailSurgePricingManager;
 import beam.agentsim.agents.ridehail.SurgePriceBin;
-import beam.sim.OutputDataDescription;
-import beam.utils.OutputDataDescriptor;
 import com.google.inject.Inject;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
@@ -365,7 +363,7 @@ public class GraphSurgePricing implements ControlerListener, IterationEndsListen
         try {
             String fileName = graphImageFile;
 
-            final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisLabel, yAxisLabel, fileName, true);
+            final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisLabel, yAxisLabel, true);
             CategoryPlot plot = chart.getCategoryPlot();
             GraphUtils.plotLegendItems(plot, _categoriesKeys, dataset.getRowCount());
             GraphUtils.saveJFreeChartAsPNG(chart, fileName, GraphsStatsAgentSimEventsListener.GRAPH_WIDTH, GraphsStatsAgentSimEventsListener.GRAPH_HEIGHT);

--- a/src/main/java/beam/analysis/plots/GraphUtils.java
+++ b/src/main/java/beam/analysis/plots/GraphUtils.java
@@ -2,20 +2,12 @@ package beam.analysis.plots;
 
 import beam.analysis.plots.modality.RideHailDistanceRowModel;
 import org.jfree.chart.*;
-import org.jfree.chart.annotations.XYTextAnnotation;
-import org.jfree.chart.axis.AxisLocation;
-import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.CategoryPlot;
-import org.jfree.chart.plot.CombinedDomainXYPlot;
 import org.jfree.chart.plot.PlotOrientation;
-import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.chart.renderer.category.StandardBarPainter;
-import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
-import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.category.DefaultCategoryDataset;
-import org.jfree.data.general.DatasetUtilities;
 import org.jfree.data.xy.XYDataItem;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYSeries;
@@ -77,7 +69,7 @@ public class GraphUtils {
 
     }
 
-    public static JFreeChart createStackedBarChartWithDefaultSettings(CategoryDataset dataset, String graphTitle, String xAxisTitle, String yAxisTitle, String fileName, boolean legend) {
+    public static JFreeChart createStackedBarChartWithDefaultSettings(CategoryDataset dataset, String graphTitle, String xAxisTitle, String yAxisTitle, boolean legend) {
         PlotOrientation orientation = PlotOrientation.VERTICAL;
         final JFreeChart chart = ChartFactory.createStackedBarChart(
                 graphTitle, xAxisTitle, yAxisTitle,
@@ -95,12 +87,16 @@ public class GraphUtils {
         return chart;
     }
 
-    public static CategoryDataset createCategoryDatasetForIterationsData(String rowKeyPrefix,
-                                                        String columnKeyPrefix, double[][] data) {
+    public static CategoryDataset createCategoryDataset(String rowKeyPrefix, String columnKeyPrefix, double[] data) {
+        return createCategoryDataset(rowKeyPrefix, columnKeyPrefix, new double[][]{data});
+    }
+
+    public static CategoryDataset createCategoryDataset(
+            String rowKeyPrefix, String columnKeyPrefix, double[][] data) {
 
         DefaultCategoryDataset result = new DefaultCategoryDataset();
         for (int r = 0; r < data.length; r++) {
-            String rowKey = rowKeyPrefix + (r + 1);
+            String rowKey = rowKeyPrefix + r;
             for (int c = 0; c < data[r].length; c++) {
                 String columnKey = columnKeyPrefix + c;
                 result.addValue(new Double(data[r][c]), rowKey, columnKey);

--- a/src/main/java/beam/analysis/plots/PersonTravelTimeAnalysis.java
+++ b/src/main/java/beam/analysis/plots/PersonTravelTimeAnalysis.java
@@ -1,7 +1,6 @@
 package beam.analysis.plots;
 
 import beam.analysis.IterationSummaryAnalysis;
-import beam.sim.metrics.Metrics;
 import beam.sim.metrics.SimulationMetricCollector;
 import com.google.common.base.CaseFormat;
 import org.jfree.chart.JFreeChart;
@@ -14,7 +13,6 @@ import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.PersonArrivalEvent;
 import org.matsim.api.core.v01.events.PersonDepartureEvent;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.utils.collections.Tuple;
 import org.slf4j.Logger;
@@ -319,7 +317,7 @@ public class PersonTravelTimeAnalysis implements GraphAnalysis, IterationSummary
         String fileName = fileBaseName + CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, mode) + ".png";
         String graphTitle = "Average Travel Time [" + mode + "]";
 
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, fileName, false);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, false);
         CategoryPlot plot = chart.getCategoryPlot();
         GraphUtils.plotLegendItems(plot, dataset.getRowCount());
         String graphImageFile = GraphsStatsAgentSimEventsListener.CONTROLLER_IO.getIterationFilename(iterationNumber, fileName);
@@ -331,7 +329,7 @@ public class PersonTravelTimeAnalysis implements GraphAnalysis, IterationSummary
         personLastDepartureEvents.keySet().forEach(m -> defaultCategoryDataset.addValue((Number) personLastDepartureEvents.get(m).size(), 0, m));
         String graphTitle = "Non Arrived Agents at End of Simulation";
 
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(defaultCategoryDataset, graphTitle, "modes", "count", "NonArrivedAgentsAtTheEndOfSimulation.png", false);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(defaultCategoryDataset, graphTitle, "modes", "count", false);
         CategoryPlot plot = chart.getCategoryPlot();
         GraphUtils.plotLegendItems(plot, defaultCategoryDataset.getRowCount());
         String graphImageFile = GraphsStatsAgentSimEventsListener.CONTROLLER_IO.getIterationFilename(iterationNumber, "NonArrivedAgentsAtTheEndOfSimulation.png");

--- a/src/main/java/beam/analysis/plots/RealizedModeAnalysis.java
+++ b/src/main/java/beam/analysis/plots/RealizedModeAnalysis.java
@@ -13,8 +13,6 @@ import org.matsim.api.core.v01.events.Event;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.utils.collections.Tuple;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.*;
@@ -374,7 +372,7 @@ public class RealizedModeAnalysis extends BaseModeAnalysis {
 
     // generating graph in root directory for replanningCountModeChoice
     private void createRootReplaningModeChoiceCountGraph(CategoryDataset dataset, String fileName) throws IOException {
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, rootReplanningGraphTitle, "Iteration", "Number of events", fileName, false);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, rootReplanningGraphTitle, "Iteration", "Number of events", false);
         GraphUtils.saveJFreeChartAsPNG(chart, fileName, GraphsStatsAgentSimEventsListener.GRAPH_WIDTH, GraphsStatsAgentSimEventsListener.GRAPH_HEIGHT);
     }
 
@@ -383,7 +381,7 @@ public class RealizedModeAnalysis extends BaseModeAnalysis {
     }
 
     private void createReplanningCountModeChoiceGraph(CategoryDataset dataset, int iterationNumber) throws IOException {
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, replanningGraphTitle, xAxisTitle, yAxisTitleForReplanning, "replanningCountModeChoice", false);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, replanningGraphTitle, xAxisTitle, yAxisTitleForReplanning, false);
         String graphImageFile = GraphsStatsAgentSimEventsListener.CONTROLLER_IO.getIterationFilename(iterationNumber, "replanningCountModeChoice" + ".png");
         GraphUtils.saveJFreeChartAsPNG(chart, graphImageFile, GraphsStatsAgentSimEventsListener.GRAPH_WIDTH, GraphsStatsAgentSimEventsListener.GRAPH_HEIGHT);
     }

--- a/src/main/java/beam/analysis/plots/RideHailWaitingAnalysis.java
+++ b/src/main/java/beam/analysis/plots/RideHailWaitingAnalysis.java
@@ -428,7 +428,7 @@ public class RideHailWaitingAnalysis implements GraphAnalysis, IterationSummaryA
 
     private void createModesFrequencyGraph(CategoryDataset dataset, int iterationNumber) throws IOException {
 
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, fileName + ".png", true);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, true);
         CategoryPlot plot = chart.getCategoryPlot();
 
         // Legends
@@ -441,7 +441,7 @@ public class RideHailWaitingAnalysis implements GraphAnalysis, IterationSummaryA
     }
 
     private void createSingleStatsGraph(CategoryDataset dataset, int iterationNumber) throws IOException {
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, rideHailWaitingSingleStatsFileBaseName + ".png", false);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataset, graphTitle, xAxisTitle, yAxisTitle, false);
         GraphUtils.setColour(chart, 1);
         // Writing graph to image file
         String graphImageFile = GraphsStatsAgentSimEventsListener.CONTROLLER_IO.getIterationFilename(iterationNumber, rideHailWaitingSingleStatsFileBaseName + ".png");

--- a/src/main/java/beam/analysis/plots/modality/ModalityStyleStats.java
+++ b/src/main/java/beam/analysis/plots/modality/ModalityStyleStats.java
@@ -114,7 +114,7 @@ public class ModalityStyleStats {
             return;
         }
         List<String> classList = GraphsStatsAgentSimEventsListener.getSortedStringList(className);
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(categoryDataset, graphTile, xAxisTitle, yAxisTitle, fileName, true);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(categoryDataset, graphTile, xAxisTitle, yAxisTitle, true);
         CategoryPlot plot = chart.getCategoryPlot();
         GraphUtils.plotLegendItems(plot, classList, categoryDataset.getRowCount());
         String graphImageFile = GraphsStatsAgentSimEventsListener.CONTROLLER_IO.getOutputFilename(fileName);

--- a/src/main/java/beam/analysis/plots/passengerpertrip/CarPassengerPerTrip.java
+++ b/src/main/java/beam/analysis/plots/passengerpertrip/CarPassengerPerTrip.java
@@ -64,7 +64,6 @@ public class CarPassengerPerTrip implements IGraphPassengerPerTrip{
 
     @Override
     public CategoryDataset getCategoryDataSet() {
-
         matriXDataSet = new double[maxPassengers + 1][maxHour + 1];
 
         for (int numberOfpassengers = 0; numberOfpassengers < maxPassengers + 1; numberOfpassengers++) {

--- a/src/main/java/beam/analysis/plots/passengerpertrip/IGraphPassengerPerTrip.java
+++ b/src/main/java/beam/analysis/plots/passengerpertrip/IGraphPassengerPerTrip.java
@@ -38,7 +38,7 @@ public interface IGraphPassengerPerTrip {
         String fileName = getFileName("png");
         String graphTitle = getTitle();
         boolean legend = true;
-        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, graphTitle, xAxisTitle, yAxisTitle, fileName, legend);
+        final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(dataSet, graphTitle, xAxisTitle, yAxisTitle, legend);
         CategoryPlot plot = chart.getCategoryPlot();
         List<String> legendItemList = getLegendItemList(dataSet.getRowCount());
         GraphUtils.plotLegendItems(plot, legendItemList, dataSet.getRowCount());

--- a/src/main/java/beam/analysis/plots/passengerpertrip/TncPassengerPerTrip.java
+++ b/src/main/java/beam/analysis/plots/passengerpertrip/TncPassengerPerTrip.java
@@ -1,8 +1,8 @@
 package beam.analysis.plots.passengerpertrip;
 
 import beam.agentsim.events.PathTraversalEvent;
+import beam.analysis.plots.GraphUtils;
 import org.jfree.data.category.CategoryDataset;
-import org.jfree.data.general.DatasetUtilities;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.core.controler.events.IterationEndsEvent;
 
@@ -89,7 +89,6 @@ public class TncPassengerPerTrip implements IGraphPassengerPerTrip{
                 // Process the current event with num_passenger > 0 and remove any buffer of repositioning and deadheading events
                 updateNumPassengerInDeadHeadingsMap(hour, graphName, _num_passengers);
             } else {
-
                 Map<Integer, List<Event>> vehicleData = vehicleEventsCache.get(vehicle_id);
                 if (vehicleData == null) {
                     vehicleData = new HashMap<>();
@@ -108,10 +107,8 @@ public class TncPassengerPerTrip implements IGraphPassengerPerTrip{
         }
     }
 
-
     @Override
     public void process(IterationEndsEvent event) throws IOException {
-
         processDeadHeadingPassengerPerTripRemainingRepositionings();
         CategoryDataset dataSet = getCategoryDataSet();
         draw(dataSet, event.getIteration(), xAxisTitle, yAxisTitle);
@@ -120,17 +117,15 @@ public class TncPassengerPerTrip implements IGraphPassengerPerTrip{
 
     @Override
     public CategoryDataset getCategoryDataSet() {
-
-         matrixDataset = buildDeadHeadingDataSet(deadHeadingsMap.get(graphName), graphName);
-
-        return DatasetUtilities.createCategoryDataset("Mode ", "", matrixDataset);
+        matrixDataset = buildDeadHeadingDataSet(deadHeadingsMap.get(graphName));
+        return GraphUtils.createCategoryDataset("", "", matrixDataset);
     }
 
-    private double[][] buildDeadHeadingDataSet(Map<Integer, Map<Integer, Integer>> data, String graphName) {
+    private double[][] buildDeadHeadingDataSet(Map<Integer, Map<Integer, Integer>> data) {
         List<Integer> hours = new ArrayList<>(data.keySet());
         Collections.sort(hours);
         int maxHour = hours.get(hours.size() - 1);
-        Integer maxPassengers = TNC_MAX_PASSENGERS;
+        int maxPassengers = TNC_MAX_PASSENGERS;
 
         double[][] dataSet;
 
@@ -140,11 +135,9 @@ public class TncPassengerPerTrip implements IGraphPassengerPerTrip{
 
         for (int i = 1; i <= maxPassengers; i++) {
             dataSet[i] = getModeOccurrencePerHourAgainstMode(data, maxHour, i - 1);
-
         }
         return dataSet;
     }
-
 
     @Override
     public String getFileName(String extension) {
@@ -177,8 +170,6 @@ public class TncPassengerPerTrip implements IGraphPassengerPerTrip{
         }
         return modeOccurrencePerHour;
     }
-
-
 
     @Override
     public boolean isValidCase(String graphName, int numPassengers) {

--- a/src/main/scala/beam/analysis/DelayMetricAnalysis.scala
+++ b/src/main/scala/beam/analysis/DelayMetricAnalysis.scala
@@ -183,7 +183,6 @@ class DelayMetricAnalysis @Inject()(
       graphTitle,
       xAxisName,
       yAxisName,
-      fileName + ".png",
       true
     )
 
@@ -207,7 +206,6 @@ class DelayMetricAnalysis @Inject()(
       averageGraphTitle,
       xAxisName,
       yAxisAverageGraphName,
-      fileName,
       false
     )
     GraphUtils.saveJFreeChartAsPNG(
@@ -234,7 +232,6 @@ class DelayMetricAnalysis @Inject()(
       networkUtilizedGraphTitle,
       xAxisName_NetworkUtilized,
       yAxisName_NetworkUtilized,
-      graphImageFile,
       false
     )
 

--- a/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
+++ b/src/main/scala/beam/analysis/SimpleRideHailUtilization.scala
@@ -100,7 +100,6 @@ class SimpleRideHailUtilization extends IterationSummaryAnalysis with GraphAnaly
       graphTitleName,
       xAxisTitle,
       yAxisTitle,
-      fileName,
       legend
     )
     val plot: CategoryPlot = chart.getCategoryPlot

--- a/src/main/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandler.scala
+++ b/src/main/scala/beam/analysis/cartraveltime/CarTripStatsFromPathTraversalEventHandler.scala
@@ -278,7 +278,6 @@ class CarTripStatsFromPathTraversalEventHandler(
       graphTitle,
       "Iteration",
       "Average Travel Time [min]",
-      fileName,
       false
     )
     val plot = chart.getCategoryPlot
@@ -305,7 +304,6 @@ class CarTripStatsFromPathTraversalEventHandler(
       graphTitle,
       "hour",
       "Average Travel Time [min]",
-      fileName,
       false
     )
     val plot = chart.getCategoryPlot
@@ -337,7 +335,6 @@ class CarTripStatsFromPathTraversalEventHandler(
       graphTitle,
       "hour",
       "Average Speed [m/s]",
-      fileName,
       false
     )
     val plot = chart.getCategoryPlot

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -566,7 +566,6 @@ class BeamSim @Inject()(
       header,
       "iteration",
       header,
-      path,
       false
     )
 
@@ -632,5 +631,4 @@ class BeamSim @Inject()(
         }
       }
   }
-
 }


### PR DESCRIPTION
Move some jfree usage to GraphUtils.
Examples
1. Old version of `passengerPerTripRideHail.png` is
![0 passengerPerTripRideHail](https://user-images.githubusercontent.com/17457532/81958054-9d05eb80-9637-11ea-824d-5184cb288984.png)

Fixed version is
![0 passengerPerTripRideHail](https://user-images.githubusercontent.com/17457532/81956774-e9e8c280-9635-11ea-918b-7b3a41e7a4bc.png)

2. Old version of `physsimFreeFlowSpeedDistribution.png` is
![0 physsimFreeFlowSpeedDistribution](https://user-images.githubusercontent.com/17457532/81957014-3df3a700-9636-11ea-9a16-f7f51b3d2570.png)
Fixed version is
![0 physsimFreeFlowSpeedDistribution](https://user-images.githubusercontent.com/17457532/81957207-7abf9e00-9636-11ea-91b9-2b38c54dba16.png)
Pngs looks same, bug in csv file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2652)
<!-- Reviewable:end -->
