### PR TITLE
We need to have JDK installed in order to get javac (java compiler)

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -13,9 +13,18 @@ System Requirements
 
 * At least 8GB RAM
 * Windows, Mac OSX, Linux
-* Java Runtime Environment or Java Development Kit 1.8
-* To verify your JRE: https://www.java.com/en/download/help/version_manual.xml
-* To download JRE 1.8 (AKA JRE 8): http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html
+* Java Development Kit 1.8. Oracle JDK 1.8: https://www.oracle.com/java/technologies/javase-jdk8-downloads.html. You can also use OpenJDK 8 JDK. For Ubuntu you can get it installed by running `sudo apt-get install openjdk-8-jdk`
+* Verify that you have both java runtime and java compiler:
+.. code-block:: bash
+
+    ubuntu@ip-172-31-14-187:~/git/beam$ java -version
+    openjdk version "1.8.0_252"
+    OpenJDK Runtime Environment (build 1.8.0_252-8u252-b09-1~18.04-b09)
+    OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
+    ubuntu@ip-172-31-14-187:~/git/beam$ javac -version
+    javac 1.8.0_252
+    ubuntu@ip-172-31-14-187:~/git/beam$              
+
 * We also recommend downloading the VIA vizualization app and obtaining a free or paid license: https://simunto.com/via/
 * Git and Git-LFS
 
@@ -24,8 +33,8 @@ Prerequisites :
 
 **Install Java**
 
-BEAM requires Java 1.8 JDK / JRE to be installed. If a different version of java is already installed on your system, please upgrade the version to 1.8.
-See this `link <https://www.java.com/en/download/help/version_manual.xml>`_ for steps to check the current version of your JRE.
+BEAM requires Java 1.8 JDK. If a different version of java is already installed on your system, please upgrade the version to 1.8.
+See this `link <https://www.oracle.com/java/technologies/javase-jdk8-downloads.html>`_ for steps to check the current version of your JDK.
 
 If java is not already installed on your system , please follow this `download manual <https://www.java.com/en/download/manual.jsp>`_ to install java on your system.
 


### PR DESCRIPTION
Env: Ubuntu 18.04, only JRE is installed (openjdk-8-jre-headless). Got an error during compilation of beam:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileScala'.
> java.io.IOException: Cannot run program "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac": error=2, No such file or directory
```

![image](https://user-images.githubusercontent.com/5107562/82084292-453db200-9715-11ea-973f-5c75c87db14c.png)

As we can see it needs `javac`, Java compiler. After installing JDK (`sudo apt-get install openjdk-8-jdk`) it worked:

![image](https://user-images.githubusercontent.com/5107562/82084561-ab2a3980-9715-11ea-8da3-d69392b52922.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2654)
<!-- Reviewable:end -->
