### PR TITLE
AWS Deploy: Instance type should be string

### DIFF
--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -96,7 +96,7 @@ task deploy(type: AWSLambdaInvokeTask) {
   "storage_size": ${ext.getParameterValue('storageSize')},
   "batch": ${ext.getParameterValue('beamBatch')},
   "s3_publish": ${ext.getParameterValue('s3Backup') ?: true},
-  "instance_type": ${finalInstanceType},
+  "instance_type": "${finalInstanceType}",
   "region": "${ext.getParameterValue('region') ?: defaultRegion}",
   "shutdown_wait": "${ext.getParameterValue('shutdownWait')}",
   "shutdown_behaviour": "${ext.getParameterValue('shutdownBehaviour')}",
@@ -108,11 +108,11 @@ task deploy(type: AWSLambdaInvokeTask) {
   "min_memory": ${ext.getParameterValue('minMemory') ?: 0},
   "max_memory": ${ext.getParameterValue('maxMemory') ?: 0}
 }"""
+        payload = pload
         println payload
         println "Please note that if you set isSpot to true then it could take an excessive time period. In fact it could time out at 15 minutes and still complete later on. ALSO! volumes using spot instances must be MANUALLY deleted. This is done so you do not lose data in the case of a premature shutdown."
         functionName = "simulateBeam"
         invocationType = InvocationType.RequestResponse
-        payload = pload
     }
 
     doLast {


### PR DESCRIPTION
- instance_type is a string
- set `payload` before using it

Got an error during deploy:
```
:aws:deploy
{
  "title": "art/austin-prod-200k-plans-from-urbnasim_reasyuATgmail_com",
  "git_user_email": "reasyuATgmail_com",
  "deploy_type_tag": "null",
  "branch": "AK/#2624-merg-urbansim-with-austin",
  "commit": "d9644ad64a1432000602cd9c1ec8da8640152f00",
  "deploy_mode": "config",
  "configs": "test/input/texas/austin-prod-100k.conf",
  "experiments": "null",
  "execute_class": "beam.sim.RunBeam",
  "execute_args": "null",
  "max_ram": "300g",
  "storage_size": 256,
  "batch": false,
  "s3_publish": true,
  "instance_type": c5.9xlarge,
  "region": "us-east-2",
  "shutdown_wait": "15",
  "shutdown_behaviour": "terminate",
  "command": "deploy",
  "run_grafana" : false,
  "is_spot" : false,
  "min_cores": 0,
  "max_cores": 0,
  "min_memory": 0,
  "max_memory": 0
}
Please note that if you set isSpot to true then it could take an excessive time period. In fact it could time out at 15 minutes and still complete later on. ALSO! volumes using spot instances must be MANUALLY deleted. This is done so you do not lose data in the case of a premature shutdown.
:aws:deploy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':aws:deploy'.
> Could not parse request body into json: Unrecognized token 'c5': was expecting ('true', 'false' or 'null')
   at [Source: (byte[])"{
    "title": "art/austin-prod-200k-plans-from-urbnasim_reasyuATgmail_com",
    "git_user_email": "reasyuATgmail_com",
    "deploy_type_tag": "null",
    "branch": "AK/#2624-merg-urbansim-with-austin",
    "commit": "d9644ad64a1432000602cd9c1ec8da8640152f00",
    "deploy_mode": "config",
    "configs": "test/input/texas/austin-prod-100k.conf",
    "experiments": "null",
    "execute_class": "beam.sim.RunBeam",
    "execute_args": "null",
    "max_ram": "300g",
    "storage_size": 256,
    "batch": false,
    "s3_publish":"[truncated 268 bytes]; line: 16, column: 23] (Service: AWSLambda; Status Code: 400; Error Code: InvalidRequestContentException; Request ID: 35029b7e-3c1a-47bd-9892-e62121f21e11)

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2656)
<!-- Reviewable:end -->
