### PR TITLE
CsvSkimReader: Minor improvements

### DIFF
--- a/src/main/scala/beam/router/skim/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/AbstractSkimmer.scala
@@ -3,24 +3,16 @@ package beam.router.skim
 import java.io.{BufferedWriter, File}
 
 import beam.agentsim.events.ScalaEvent
-import beam.agentsim.infrastructure.taz.TAZ
-import beam.router.Modes.BeamMode
-import beam.router.skim.ODSkimmer.{ODSkimmerInternal, ODSkimmerKey}
 import beam.sim.BeamServices
 import beam.sim.config.BeamConfig
 import beam.utils.{FileUtils, ProfilingUtils}
 import com.typesafe.scalalogging.LazyLogging
-import com.univocity.parsers.common.record.Record
-import com.univocity.parsers.csv.{CsvParser, CsvParserSettings}
-import org.matsim.api.core.v01.Id
 import org.matsim.api.core.v01.events.Event
 import org.matsim.core.controler.events.{IterationEndsEvent, IterationStartsEvent}
 import org.matsim.core.controler.listener.{IterationEndsListener, IterationStartsListener}
 import org.matsim.core.events.handler.BasicEventHandler
-import org.matsim.core.utils.io.IOUtils
 import org.supercsv.io.CsvMapReader
 import org.supercsv.prefs.CsvPreference
-import scala.collection.JavaConverters._
 
 import scala.collection.{immutable, mutable}
 import scala.util.control.NonFatal
@@ -69,7 +61,7 @@ abstract class AbstractSkimmer(beamServices: BeamServices, config: BeamConfig.Be
   protected lazy val currentSkim = mutable.Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
   private lazy val eventType = skimName + "-event"
 
-  protected def fromCsv(line: immutable.Map[String, String]): (AbstractSkimmerKey, AbstractSkimmerInternal)
+  protected def fromCsv(line: scala.collection.Map[String, String]): (AbstractSkimmerKey, AbstractSkimmerInternal)
   protected def aggregateOverIterations(
     prevIteration: Option[AbstractSkimmerInternal],
     currIteration: Option[AbstractSkimmerInternal]
@@ -113,7 +105,7 @@ abstract class AbstractSkimmer(beamServices: BeamServices, config: BeamConfig.Be
     }
   }
 
-  protected def writeToDisk(event: IterationEndsEvent) = {
+  protected def writeToDisk(event: IterationEndsEvent): Unit = {
     if (beamConfig.beam.router.skim.writeSkimsInterval > 0 && event.getIteration % beamConfig.beam.router.skim.writeSkimsInterval == 0)
       ProfilingUtils.timed(s"beam.router.skim.writeSkimsInterval on iteration ${event.getIteration}", logger.info(_)) {
         val filePath =
@@ -167,7 +159,7 @@ abstract class AbstractSkimmer(beamServices: BeamServices, config: BeamConfig.Be
     res.toMap
   }
 
-  private def writeSkim(skim: immutable.Map[AbstractSkimmerKey, AbstractSkimmerInternal], filePath: String) = {
+  private def writeSkim(skim: immutable.Map[AbstractSkimmerKey, AbstractSkimmerInternal], filePath: String): Unit = {
     var writer: BufferedWriter = null
     try {
       writer = org.matsim.core.utils.io.IOUtils.getBufferedWriter(filePath)

--- a/src/main/scala/beam/router/skim/CsvSkimReader.scala
+++ b/src/main/scala/beam/router/skim/CsvSkimReader.scala
@@ -3,13 +3,14 @@ package beam.router.skim
 import java.io.File
 import java.util
 
-import com.typesafe.scalalogging.{Logger}
+import com.typesafe.scalalogging.Logger
 import com.univocity.parsers.common.record.Record
 import com.univocity.parsers.csv.{CsvParser, CsvParserSettings}
 import org.matsim.core.utils.io.IOUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -21,18 +22,18 @@ import scala.util.control.NonFatal
   */
 class CsvSkimReader(
   val aggregatedSkimsFilePath: String,
-  fromCsv: Map[String, String] => (AbstractSkimmerKey, AbstractSkimmerInternal),
+  fromCsv: scala.collection.Map[String, String] => (AbstractSkimmerKey, AbstractSkimmerInternal),
   logger: Logger
 ) {
 
-  val header: Array[String] = initHeader
+  val header: Array[String] = initHeader()
 
   def readAggregatedSkims: immutable.Map[AbstractSkimmerKey, AbstractSkimmerInternal] = {
     var res = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
     val csvParser: CsvParser = getCsvParser
     try {
       if (new File(aggregatedSkimsFilePath).isFile) {
-        var mapReader = csvParser.iterateRecords(IOUtils.getBufferedReader(aggregatedSkimsFilePath)).asScala
+        val mapReader = csvParser.iterateRecords(IOUtils.getBufferedReader(aggregatedSkimsFilePath)).asScala
         res = mapReader
           .map(rec => {
             val a = convertRecordToMap(rec, header)
@@ -47,20 +48,36 @@ class CsvSkimReader(
     } catch {
       case NonFatal(ex) =>
         logger.info(s"Could not load warmStart skim from '${aggregatedSkimsFilePath}': ${ex.getMessage}")
+    } finally {
+      // In any case stop parser
+      Try(csvParser.stopParsing())
     }
     res
   }
 
   private def initHeader(): Array[String] = {
     val csvParser = getCsvParser
-    csvParser.beginParsing(IOUtils.getBufferedReader(aggregatedSkimsFilePath))
-    csvParser.getRecordMetadata.headers()
+    try {
+      val rdr = IOUtils.getBufferedReader(aggregatedSkimsFilePath)
+      try {
+        csvParser.beginParsing(rdr)
+        csvParser.getRecordMetadata.headers()
+      } finally {
+        Try(rdr.close())
+      }
+    } catch {
+      case NonFatal(ex) =>
+        logger.info(s"Could not read headers '${aggregatedSkimsFilePath}': ${ex.getMessage}", ex)
+        Array.empty
+    } finally {
+      Try(csvParser.stopParsing())
+    }
   }
 
-  private def convertRecordToMap(rec: Record, header: Array[String]): immutable.Map[String, String] = {
-    var res = new util.HashMap[String, String]()
+  private def convertRecordToMap(rec: Record, header: Array[String]): scala.collection.Map[String, String] = {
+    val res = new util.HashMap[String, String]()
     rec.fillFieldMap(res, header: _*)
-    res.asScala.toMap
+    res.asScala
   }
 
   private def getCsvParser: CsvParser = {

--- a/src/main/scala/beam/router/skim/DriveTimeSkimmer.scala
+++ b/src/main/scala/beam/router/skim/DriveTimeSkimmer.scala
@@ -14,8 +14,8 @@ import scala.collection.mutable
 
 class DriveTimeSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Router.Skim)
     extends AbstractSkimmer(beamServices, config) {
-  import SkimsUtils._
   import DriveTimeSkimmer._
+  import SkimsUtils._
   import beamServices._
 
   val maxDistanceFromBeamTaz: Double = 500.0 // 500 meters
@@ -70,7 +70,9 @@ class DriveTimeSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Route
     super.notifyIterationEnds(event)
   }
 
-  override protected def fromCsv(line: Map[String, String]): (AbstractSkimmerKey, AbstractSkimmerInternal) = {
+  override protected def fromCsv(
+    line: scala.collection.Map[String, String]
+  ): (AbstractSkimmerKey, AbstractSkimmerInternal) = {
     (
       DriveTimeSkimmerKey(
         fromTAZId = Id.create(line("fromTAZId"), classOf[TAZ]),

--- a/src/main/scala/beam/router/skim/ODSkimmer.scala
+++ b/src/main/scala/beam/router/skim/ODSkimmer.scala
@@ -12,7 +12,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.controler.events.IterationEndsEvent
 
-import scala.collection.immutable
 import scala.util.control.NonFatal
 
 class ODSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Router.Skim)
@@ -43,7 +42,7 @@ class ODSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Router.Skim)
   }
 
   override def fromCsv(
-    row: immutable.Map[String, String]
+    row: scala.collection.Map[String, String]
   ): (AbstractSkimmerKey, AbstractSkimmerInternal) = {
     ODSkimmer.fromCsv(row)
   }
@@ -312,7 +311,7 @@ object ODSkimmer extends LazyLogging {
   }
 
   def fromCsv(
-    row: immutable.Map[String, String]
+    row: scala.collection.Map[String, String]
   ): (AbstractSkimmerKey, AbstractSkimmerInternal) = {
     (
       ODSkimmerKey(

--- a/src/main/scala/beam/router/skim/TAZSkimmer.scala
+++ b/src/main/scala/beam/router/skim/TAZSkimmer.scala
@@ -5,8 +5,6 @@ import beam.sim.config.BeamConfig
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Id
 
-import scala.collection.immutable
-
 class TAZSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Router.Skim)
     extends AbstractSkimmer(beamServices, config) {
   import TAZSkimmer._
@@ -19,7 +17,7 @@ class TAZSkimmer(beamServices: BeamServices, config: BeamConfig.Beam.Router.Skim
     "time,taz,hex,actor,key,value,observations,iterations"
 
   override def fromCsv(
-    line: immutable.Map[String, String]
+    line: scala.collection.Map[String, String]
   ): (AbstractSkimmerKey, AbstractSkimmerInternal) = {
     (
       TAZSkimmerKey(


### PR DESCRIPTION
- Reduce memory pressure by using `scala.collection.Map`
- Stop parsing in `initHeaders` and `readAggregatedSkims` in any case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2684)
<!-- Reviewable:end -->
