### PR TITLE
Fixed not storing physsim speed statistic

### DIFF
--- a/src/main/java/beam/analysis/physsim/PhyssimSpeedHandler.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimSpeedHandler.java
@@ -75,7 +75,7 @@ public class PhyssimSpeedHandler implements PersonArrivalEventHandler, PersonDep
                                         if(travelTime > 0.0) {
                                             double speed = distance / travelTime;
                                             int bin = (int) departureEvent.getTime() / binSize;
-                                            Mean mean = binSpeed.getOrDefault(bin, new Mean());
+                                            Mean mean = binSpeed.computeIfAbsent(bin, i -> new Mean());
                                             mean.increment(speed);
                                         }
                                         return;


### PR DESCRIPTION
Using compute instead of getOrDefault in order to store values to the map

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2692)
<!-- Reviewable:end -->
