### PR TITLE
Memory leak fix

### DIFF
--- a/src/main/java/beam/analysis/physsim/PhyssimCalcLinkStats.java
+++ b/src/main/java/beam/analysis/physsim/PhyssimCalcLinkStats.java
@@ -2,6 +2,7 @@ package beam.analysis.physsim;
 
 import beam.analysis.plots.GraphUtils;
 import beam.sim.BeamConfigChangesObservable;
+import beam.sim.BeamConfigChangesObserver;
 import beam.sim.config.BeamConfig;
 import beam.utils.BeamCalcLinkStats;
 import beam.utils.VolumesAnalyzerFixed;
@@ -26,7 +27,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
-public class PhyssimCalcLinkStats implements Observer {
+public class PhyssimCalcLinkStats implements BeamConfigChangesObserver {
 
     private Logger log = LoggerFactory.getLogger(PhyssimCalcLinkStats.class);
 
@@ -255,8 +256,7 @@ public class PhyssimCalcLinkStats implements Observer {
     }
 
     @Override
-    public void update(Observable observable, Object o) {
-        Tuple2 t = (Tuple2) o;
-        this.beamConfig = (BeamConfig) t._2;
+    public void update(BeamConfigChangesObservable observable, BeamConfig updatedBeamConfig) {
+        this.beamConfig = updatedBeamConfig;
     }
 }

--- a/src/main/java/beam/matsim/MatsimConfigUpdater.java
+++ b/src/main/java/beam/matsim/MatsimConfigUpdater.java
@@ -1,6 +1,7 @@
 package beam.matsim;
 
 import beam.sim.BeamConfigChangesObservable;
+import beam.sim.BeamConfigChangesObserver;
 import beam.sim.config.BeamConfig;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -12,7 +13,7 @@ import java.util.Observable;
 import java.util.Observer;
 
 @Singleton
-public class MatsimConfigUpdater implements Observer {
+public class MatsimConfigUpdater implements BeamConfigChangesObserver {
     private final ControlerConfigGroup controlerConfigGroup;
     private final LinkStatsConfigGroup linkStatsConfigGroup;
 
@@ -25,15 +26,8 @@ public class MatsimConfigUpdater implements Observer {
     }
 
     @Override
-    public void update(Observable observable, Object o) {
-        if (o instanceof Tuple2) {
-            Tuple2 t = (Tuple2) o;
-            if (t._2 instanceof BeamConfig) {
-                BeamConfig beamConfig = (BeamConfig) t._2;
-
-                controlerConfigGroup.setWritePlansInterval(beamConfig.beam().physsim().writePlansInterval());
-                linkStatsConfigGroup.setWriteLinkStatsInterval(beamConfig.matsim().modules().linkStats().writeLinkStatsInterval());
-            }
-        }
+    public void update(BeamConfigChangesObservable observable, BeamConfig updatedBeamConfig) {
+        controlerConfigGroup.setWritePlansInterval(updatedBeamConfig.beam().physsim().writePlansInterval());
+        linkStatsConfigGroup.setWriteLinkStatsInterval(updatedBeamConfig.matsim().modules().linkStats().writeLinkStatsInterval());
     }
 }

--- a/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
+++ b/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
@@ -15,6 +15,7 @@ import beam.physsim.cchRoutingAssignment.RoutingFrameworkWrapperImpl;
 import beam.router.BeamRouter;
 import beam.router.FreeFlowTravelTime;
 import beam.sim.BeamConfigChangesObservable;
+import beam.sim.BeamConfigChangesObserver;
 import beam.sim.BeamServices;
 import beam.sim.config.BeamConfig;
 import beam.sim.metrics.MetricsSupport;
@@ -65,7 +66,7 @@ import java.util.stream.Stream;
 /**
  * @author asif and rwaraich.
  */
-public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, MetricsSupport, IterationStatsProvider, Observer {
+public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, MetricsSupport, IterationStatsProvider, BeamConfigChangesObserver {
 
     public static final String CAR = "car";
     public static final String BUS = "bus";
@@ -482,8 +483,7 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
     }
 
     @Override
-    public void update(Observable observable, Object o) {
-        Tuple2 t = (Tuple2) o;
-        this.beamConfig = (BeamConfig) t._2;
+    public void update(BeamConfigChangesObservable observable, BeamConfig updatedBeamConfig) {
+        this.beamConfig = updatedBeamConfig;
     }
 }

--- a/src/main/java/beam/physsim/jdeqsim/cacc/roadCapacityAdjustmentFunctions/Hao2018CaccRoadCapacityAdjustmentFunction.java
+++ b/src/main/java/beam/physsim/jdeqsim/cacc/roadCapacityAdjustmentFunctions/Hao2018CaccRoadCapacityAdjustmentFunction.java
@@ -1,6 +1,7 @@
 package beam.physsim.jdeqsim.cacc.roadCapacityAdjustmentFunctions;
 
 import beam.sim.BeamConfigChangesObservable;
+import beam.sim.BeamConfigChangesObserver;
 import beam.sim.config.BeamConfig;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
@@ -36,7 +37,7 @@ in multi-lane freeway facilities." Transportation Research Part C: Emerging Tech
 
  */
 
-public class Hao2018CaccRoadCapacityAdjustmentFunction implements RoadCapacityAdjustmentFunction, Observer {
+public class Hao2018CaccRoadCapacityAdjustmentFunction implements RoadCapacityAdjustmentFunction, BeamConfigChangesObserver {
     private final static Logger log = LoggerFactory.getLogger(Hao2018CaccRoadCapacityAdjustmentFunction.class);
 
     private final double caccMinRoadCapacity;
@@ -172,13 +173,6 @@ public class Hao2018CaccRoadCapacityAdjustmentFunction implements RoadCapacityAd
         });
     }
 
-    @Override
-    public void update(Observable observable, Object o) {
-        Tuple2 t = (Tuple2) o;
-        BeamConfig beamConfig = (BeamConfig) t._2;
-        this.writeInterval = beamConfig.beam().physsim().jdeqsim().cacc().capacityPlansWriteInterval();
-    }
-
     private Optional<ICsvMapWriter> getCsvWriter(int iterationNumber) {
         try {
             String filePath = controllerIO.getIterationFilename(iterationNumber, "caccCapacityStats.csv.gz");
@@ -190,6 +184,11 @@ public class Hao2018CaccRoadCapacityAdjustmentFunction implements RoadCapacityAd
             log.error("Could not create CsvMapWriter", ex);
             return Optional.empty();
         }
+    }
+
+    @Override
+    public void update(BeamConfigChangesObservable observable, BeamConfig updatedBeamConfig) {
+        this.writeInterval = updatedBeamConfig.beam().physsim().jdeqsim().cacc().capacityPlansWriteInterval();
     }
 }
 

--- a/src/main/scala/beam/scoring/BeamScoringFunctionFactory.scala
+++ b/src/main/scala/beam/scoring/BeamScoringFunctionFactory.scala
@@ -1,7 +1,5 @@
 package beam.scoring
 
-import java.util.{Observable, Observer}
-
 import beam.agentsim.agents.PersonAgent
 import beam.agentsim.agents.choice.mode.ModeChoiceMultinomialLogit
 import beam.agentsim.events.{LeavingParkingEvent, ModeChoiceEvent, ReplanningEvent}
@@ -11,7 +9,7 @@ import beam.router.model.EmbodiedBeamTrip
 import beam.sim.config.BeamConfig
 import beam.sim.population.AttributesOfIndividual
 import beam.sim.population.PopulationAdjustment._
-import beam.sim.{BeamConfigChangesObservable, BeamServices, MapStringDouble, OutputDataDescription}
+import beam.sim.{BeamConfigChangesObservable, BeamConfigChangesObserver, BeamServices, MapStringDouble, OutputDataDescription}
 import beam.utils.{FileUtils, OutputDataDescriptor}
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
@@ -29,7 +27,7 @@ class BeamScoringFunctionFactory @Inject()(
   beamConfigChangesObservable: BeamConfigChangesObservable
 ) extends ScoringFunctionFactory
     with IterationEndsListener
-    with Observer
+    with BeamConfigChangesObserver
     with LazyLogging {
 
   beamConfigChangesObservable.addObserver(this)
@@ -263,12 +261,9 @@ class BeamScoringFunctionFactory @Inject()(
     }
   }
 
-  override def update(observable: Observable, o: Any): Unit = {
-    val t = o.asInstanceOf[(_, _)]
-    val beamConfig = t._2.asInstanceOf[BeamConfig]
-    this.beamConfig = beamConfig
+  override def update(observable: BeamConfigChangesObservable, updatedBeamConfig: BeamConfig): Unit = {
+    this.beamConfig = updatedBeamConfig
   }
-
 }
 
 /**

--- a/src/main/scala/beam/scoring/BeamScoringFunctionFactory.scala
+++ b/src/main/scala/beam/scoring/BeamScoringFunctionFactory.scala
@@ -9,7 +9,13 @@ import beam.router.model.EmbodiedBeamTrip
 import beam.sim.config.BeamConfig
 import beam.sim.population.AttributesOfIndividual
 import beam.sim.population.PopulationAdjustment._
-import beam.sim.{BeamConfigChangesObservable, BeamConfigChangesObserver, BeamServices, MapStringDouble, OutputDataDescription}
+import beam.sim.{
+  BeamConfigChangesObservable,
+  BeamConfigChangesObserver,
+  BeamServices,
+  MapStringDouble,
+  OutputDataDescription
+}
 import beam.utils.{FileUtils, OutputDataDescriptor}
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject

--- a/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
+++ b/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
@@ -13,7 +13,7 @@ import scala.ref.WeakReference
 @Singleton
 class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) {
 
-  class WeaklyObservable extends LazyLogging{
+  class WeaklyObservable extends LazyLogging {
     private var changed: Boolean = false
     private val observers: mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]] =
       new mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]]

--- a/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
+++ b/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
@@ -3,6 +3,7 @@ package beam.sim
 import beam.analysis.physsim.PhyssimCalcLinkStats
 import beam.sim.config.BeamConfig
 import beam.utils.BeamConfigUtils
+import com.typesafe.scalalogging.LazyLogging
 import javax.inject.{Inject, Singleton}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -12,8 +13,7 @@ import scala.ref.WeakReference
 @Singleton
 class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) {
 
-  class WeaklyObservable {
-    private val log = LoggerFactory.getLogger(classOf[WeaklyObservable])
+  class WeaklyObservable extends LazyLogging{
     private var changed: Boolean = false
     private val observers: mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]] =
       new mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]]
@@ -62,7 +62,7 @@ class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) {
           case None           =>
         }
 
-        log.debug(s"There are ${observers.size} observers and ${aliveObservers.size} of them alive.")
+        logger.debug(s"There are ${observers.size} observers and ${aliveObservers.size} of them alive.")
 
         clearChanged()
       }

--- a/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
+++ b/src/main/scala/beam/sim/BeamConfigChangesObservable.scala
@@ -1,11 +1,78 @@
 package beam.sim
 
+import java.util
+import java.util.{Observer, Vector}
+
 import beam.sim.config.BeamConfig
 import beam.utils.BeamConfigUtils
 import javax.inject.{Inject, Singleton}
 
+import scala.collection.mutable
+import scala.ref.WeakReference
+
 @Singleton
-class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) extends java.util.Observable {
+class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) {
+
+  class WeaklyObservable {
+    private var changed: Boolean = false
+    private val observers: mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]] =
+      new mutable.ListBuffer[WeakReference[BeamConfigChangesObserver]]
+
+    def setChanged(): Unit = {
+      synchronized(() => changed = true)
+    }
+
+    def addObserver(observer: BeamConfigChangesObserver): Unit = {
+      synchronized(() => {
+        val weakObserver = new WeakReference[BeamConfigChangesObserver](observer)
+        observers += weakObserver
+      })
+    }
+
+    protected def clearChanged(): Unit = {
+      changed = false
+    }
+
+    def notifyObservers(observable: BeamConfigChangesObservable, config: BeamConfig): Unit = {
+
+      val aliveObservers: mutable.ListBuffer[BeamConfigChangesObserver] =
+        new mutable.ListBuffer[BeamConfigChangesObserver]
+
+      /* from java.util.Observable:
+       *
+       * We don't want the Observer doing callbacks into
+       * arbitrary code while holding its own Monitor.
+       * The code where we extract each Observable from
+       * the Vector and store the state of the Observer
+       * needs synchronization, but notifying observers
+       * does not (should not).  The worst result of any
+       * potential race-condition here is that:
+       * 1) a newly-added Observer will miss a
+       *   notification in progress
+       * 2) a recently unregistered Observer will be
+       *   wrongly notified when it doesn't care
+       */
+      synchronized(() => {
+        if (!changed)
+          return
+
+        val links = observers.map(link => link.get)
+        observers.clear()
+        links.foreach {
+          case Some(observer) =>
+            aliveObservers += observer
+            observers += WeakReference(observer)
+          case None =>
+        }
+
+        clearChanged()
+      })
+
+      aliveObservers.foreach(_.update(observable, config))
+    }
+  }
+
+  val observable = new WeaklyObservable()
 
   var lastBeamConfig: BeamConfig = beamConfig
   BeamConfigChangesObservable.lastBeamConfigValue = beamConfig
@@ -22,13 +89,14 @@ class BeamConfigChangesObservable @Inject()(beamConfig: BeamConfig) extends java
   }
 
   def notifyChangeToSubscribers() {
-    setChanged()
+    observable.setChanged()
     val updatedBeamConfig = getUpdatedBeamConfig
     lastBeamConfig = updatedBeamConfig
     BeamConfigChangesObservable.lastBeamConfigValue = updatedBeamConfig
-    notifyObservers(this, updatedBeamConfig)
+    observable.notifyObservers(this, updatedBeamConfig)
   }
 
+  def addObserver(observer: BeamConfigChangesObserver): Unit = observable.addObserver(observer)
 }
 
 object BeamConfigChangesObservable {
@@ -42,5 +110,4 @@ object BeamConfigChangesObservable {
   def clear(): Unit = {
     System.clearProperty(configFileLocationString)
   }
-
 }

--- a/src/main/scala/beam/sim/BeamConfigChangesObserver.scala
+++ b/src/main/scala/beam/sim/BeamConfigChangesObserver.scala
@@ -1,0 +1,7 @@
+package beam.sim
+
+import beam.sim.config.BeamConfig
+
+trait BeamConfigChangesObserver {
+  def update(observable: BeamConfigChangesObservable, updatedBeamConfig: BeamConfig): Unit
+}

--- a/src/main/scala/beam/sim/config/BeamConfigHolder.scala
+++ b/src/main/scala/beam/sim/config/BeamConfigHolder.scala
@@ -1,19 +1,18 @@
 package beam.sim.config
 import java.util.{Observable, Observer}
 
-import beam.sim.BeamConfigChangesObservable
+import beam.sim.{BeamConfigChangesObservable, BeamConfigChangesObserver}
 import javax.inject.Inject
 
 class BeamConfigHolder @Inject()(
   beamConfigChangesObservable: BeamConfigChangesObservable,
   config: BeamConfig
-) extends Observer {
+) extends BeamConfigChangesObserver {
 
   var beamConfig: BeamConfig = config
   beamConfigChangesObservable.addObserver(this)
 
-  override def update(o: Observable, arg: Any): Unit = {
-    val (_, updatedBeamConfig) = arg.asInstanceOf[(_, BeamConfig)]
+  override def update(observable: BeamConfigChangesObservable, updatedBeamConfig: BeamConfig): Unit = {
     this.beamConfig = updatedBeamConfig
   }
 }


### PR DESCRIPTION
There used to be memory leaks because PhyssimCalcLinkStats is recreated every iteration and resubscribed for BeamConfig changes through BeamConfigChangesObservable.
The BeamConfigChangesObservable have had a link to all subscribers together with all old instances of PhyssimCalcLinkStats.

Now BeamConfigChangesObservable using a WeakReference to store all subscribers. This should solve the problem not only for now but for future uses too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2698)
<!-- Reviewable:end -->
