### PR TITLE
Tool to sample Uber Movement data (speeds and travel times)

### DIFF
--- a/src/main/scala/beam/utils/map/EnvelopeToGpx.scala
+++ b/src/main/scala/beam/utils/map/EnvelopeToGpx.scala
@@ -64,8 +64,8 @@ object EnvelopeToGpx {
   def latitude(coord: Coord): Double = coord.getY
 
   def main(args: Array[String]): Unit = {
-    val en1 = new Envelope(-122.5447336, -122.3592068, 37.6989794, 37.843628)
+    val en: Envelope = new Envelope(-122.546046192, -122.330412968,37.655512625, 37.811362211)
     val envelopeToGpx = new EnvelopeToGpx
-    envelopeToGpx.render(en1, Some(new Coord(-123.180062255, 38.7728279981)), "ex1.gpx")
+    envelopeToGpx.render(en, None, "ex1.gpx")
   }
 }

--- a/src/main/scala/beam/utils/uber/movementdata/ConvertSpeedData.scala
+++ b/src/main/scala/beam/utils/uber/movementdata/ConvertSpeedData.scala
@@ -1,0 +1,146 @@
+package beam.utils.uber.movementdata
+
+import java.util.concurrent.TimeUnit
+import java.{lang, util}
+
+import beam.agentsim.infrastructure.geozone.WgsCoordinate
+import beam.utils.ProfilingUtils
+import beam.utils.csv.CsvWriter
+import beam.utils.uber.movementdata.SpeedReader.SpeedData
+import com.conveyal.osmlib.{Node, OSM}
+import com.vividsolutions.jts.geom.Envelope
+
+import scala.util.Random
+
+class ConvertSpeedData(
+  val pathToSpeedCsv: String,
+  val pathToOsm: String,
+  val boundingBox: Envelope,
+  val samplePerHour: Int,
+  val seed: Int
+) {
+  import ConvertSpeedData._
+
+  private val osm: OSM = ProfilingUtils.timed("Read osm file", x => println(x)) {
+    val temp = new OSM(null)
+    temp.readFromFile(pathToOsm)
+    temp
+  }
+  private val osmNodes: util.Map[lang.Long, Node] = osm.nodes
+
+  def write(): Unit = {
+    val sr = new SpeedReader(pathToSpeedCsv)
+    val (speeds, toClose) = sr.read(speedData => {
+      val startAndEndNodeExistInOSM = Option(osmNodes.get(speedData.startNodeId)).nonEmpty && Option(
+        osmNodes.get(speedData.endNodeId)
+      ).nonEmpty
+      val isRightDate = speedData.year == 2019 && speedData.month == 10 && speedData.day == 16
+      startAndEndNodeExistInOSM && isRightDate
+    })
+    try {
+      val matSpeeds = ProfilingUtils.timed("Read all the speeds", x => println(x)) {
+        speeds.toArray
+      }
+      println(s"matSpeeds: ${matSpeeds.length}")
+      val speedsWithinBoundingBox = matSpeeds.collect {
+        case speed if withinBoundingBox(speed) =>
+          speed
+      }
+      writeToCsv(speedsWithinBoundingBox, "SanFrancisco-Full_speeds.csv")
+      println(s"speedsWithinBoundingBox: ${speedsWithinBoundingBox.length}")
+
+      val rnd = new Random(seed)
+      val sampled = speedsWithinBoundingBox
+        .groupBy(x => x.hour)
+        .flatMap {
+          case (_, xs) =>
+            rnd.shuffle(xs.toList).take(samplePerHour)
+        }
+        .toArray
+        .sortBy(x => x.hour)
+      println(s"sampled: ${sampled.length}")
+
+      writeToCsv(sampled, s"SanFrancisco-Sampled_speeds_${samplePerHour}.csv")
+    } finally {
+      toClose.close()
+    }
+  }
+
+  private def writeToCsv(speedsWitinBoundingBox: Iterable[SpeedData], filePath: String): Unit = {
+    val headers = Array(
+      "year",
+      "month",
+      "day",
+      "hour",
+      "osm_way_id",
+      "osm_start_node_id",
+      "osm_end_node_id",
+      "speed_ms_mean",
+      "speed_ms_stddev",
+      "start_lat",
+      "start_lon",
+      "end_lat",
+      "end_lon",
+      "link"
+    )
+    val cswWriter = new CsvWriter(filePath, headers)
+    speedsWitinBoundingBox.foreach { speed =>
+      val startNode = osmNodes.get(speed.startNodeId)
+      val endNode = osmNodes.get(speed.endNodeId)
+      val startCoord = WgsCoordinate(startNode.getLat, startNode.getLon)
+      val endCoord = WgsCoordinate(endNode.getLat, endNode.getLon)
+      val googleLink = getLink(startCoord, endCoord, speed.hour)
+      cswWriter.write(
+        speed.year,
+        speed.month,
+        speed.day,
+        speed.hour,
+        speed.wayId,
+        speed.startNodeId,
+        speed.endNodeId,
+        speed.meanSpeedInMetersPerSecond,
+        speed.stdDevSpeed,
+        startCoord.latitude,
+        startCoord.longitude,
+        endCoord.latitude,
+        endCoord.longitude,
+        googleLink
+      )
+    }
+    cswWriter.close()
+  }
+
+  private def withinBoundingBox(speedData: SpeedData): Boolean = {
+    val startNode = osmNodes.get(speedData.startNodeId)
+    require(startNode != null, s"NodeId[startNodeId] ${speedData.startNodeId} does not exist in OSM")
+    val endNode = osmNodes.get(speedData.endNodeId)
+    require(endNode != null, s"NodeId[endNodeId] ${speedData.endNodeId} does not exist in OSM")
+    boundingBox.contains(startNode.getLat, startNode.getLon) && boundingBox.contains(endNode.getLat, endNode.getLon)
+  }
+}
+
+object ConvertSpeedData {
+
+  def getLink(startCoord: WgsCoordinate, endCoord: WgsCoordinate, hour: Byte): String = {
+    val mainPath =
+      s"https://www.google.com/maps/dir/${startCoord.latitude}%09${startCoord.longitude}/${endCoord.latitude}%09${endCoord.longitude}"
+    // We have chosen 2019-10-16 (Wednesday) as a day to get the routes from Google. It is 1571184000 in Unix time
+    val startOfTheDay: Long = 1571184000L
+    val timeEpochSeconds = startOfTheDay + TimeUnit.HOURS.toSeconds(hour)
+    val ending =
+      s"/data=!3m1!4b1!4m15!4m14!1m3!2m2!1d-97.7584165!2d30.3694661!1m3!2m2!1d-97.7295503!2d30.329807!2m4!2b1!6e0!7e2!8j${timeEpochSeconds}!3e0"
+    mainPath + ending
+  }
+
+  def main(args: Array[String]): Unit = {
+    val pathToSpeedCsv: String = "D:/Work/beam/Uber/SpeedData/movement-speeds-hourly-san-francisco-2019-10.csv"
+    val pathToOsm: String = "D:/Work/beam/Uber/SpeedData/norcal-latest.osm.pbf"
+
+    // Lat1, Lat2, Long1, Long2
+    // https://www.google.com/maps/d/drive?state=%7B%22ids%22%3A%5B%221JxxEvTayxiqi_GXe5-pzmNeV72wmjkkz%22%5D%2C%22action%22%3A%22open%22%2C%22userId%22%3A%22111892074776602978600%22%7D&usp=sharing
+    val boundingBox: Envelope = new Envelope(37.616703303, 37.887535417, -122.672606043, -122.186313573)
+    val stuff = new ConvertSpeedData(pathToSpeedCsv, pathToOsm, boundingBox, samplePerHour = 100, seed = 42)
+    stuff.write()
+  }
+
+}

--- a/src/main/scala/beam/utils/uber/movementdata/ConvertTravelTimeData.scala
+++ b/src/main/scala/beam/utils/uber/movementdata/ConvertTravelTimeData.scala
@@ -1,0 +1,121 @@
+package beam.utils.uber.movementdata
+
+import beam.agentsim.infrastructure.geozone.WgsCoordinate
+import beam.utils.GeoJsonReader
+import beam.utils.csv.CsvWriter
+import beam.utils.uber.movementdata.ConvertSpeedData.getLink
+import beam.utils.uber.movementdata.TravelTimeReader.TravelTime
+import com.vividsolutions.jts.geom.{Envelope, Geometry}
+import org.opengis.feature.Feature
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.util.Random
+
+class ConvertTravelTimeData(
+  val pathToGeoBoundaries: String,
+  val pathToTravelTimesCsv: String,
+  val boundingBox: Envelope,
+  val samplePerHour: Int,
+  val seed: Int
+) {
+  import ConvertTravelTimeData._
+
+  private val movIdToCenter: Map[Int, WgsCoordinate] = GeoJsonReader.read(pathToGeoBoundaries, mapper).toMap
+
+  def convert(): Unit = {
+    val (travelTimes, toClose) = new TravelTimeReader(pathToTravelTimesCsv).read(_ => true)
+    try {
+      val onlyWithinBoundingBox = travelTimes.collect { case travelTime if withinBoundingBox(travelTime) => travelTime }.toArray
+      writeToCsv(onlyWithinBoundingBox, "SanFrancisco-Full_travel-time.csv")
+      println(s"onlyWithinBoundingBox: ${onlyWithinBoundingBox.length}")
+
+      val rnd = new Random(seed)
+      val sampled = onlyWithinBoundingBox
+        .groupBy(x => x.hod)
+        .flatMap {
+          case (_, xs) =>
+            rnd.shuffle(xs.toList).take(samplePerHour)
+        }
+        .toArray
+        .sortBy(x => x.hod)
+      println(s"sampled: ${sampled.length}")
+      writeToCsv(sampled, s"SanFrancisco-Sampled_travel-time_${samplePerHour}.csv")
+    } finally {
+      toClose.close()
+    }
+  }
+
+  private def writeToCsv(travelTimes: Iterable[TravelTime], filePath: String): Unit = {
+    val headers = Array(
+      "sourceid",
+      "dstid",
+      "hod",
+      "mean_travel_time",
+      "standard_deviation_travel_time",
+      "start_lat",
+      "start_lon",
+      "end_lat",
+      "end_lon",
+      "link"
+    )
+    val cswWriter = new CsvWriter(filePath, headers)
+    travelTimes.foreach { travelTime =>
+      val srcCoord = movIdToCenter.getOrElse(
+        travelTime.sourceId,
+        throw new NoSuchElementException(s"sourceId ${travelTime.sourceId}")
+      )
+      val dstCoord =
+        movIdToCenter.getOrElse(travelTime.dstId, throw new NoSuchElementException(s"dstId ${travelTime.dstId}"))
+      val googleLink = getLink(srcCoord, dstCoord, travelTime.hod)
+      cswWriter.write(
+        travelTime.sourceId,
+        travelTime.dstId,
+        travelTime.hod,
+        travelTime.meanTravelTime,
+        travelTime.stdTravelTime,
+        srcCoord.latitude,
+        srcCoord.longitude,
+        dstCoord.latitude,
+        dstCoord.longitude,
+        googleLink
+      )
+    }
+    cswWriter.close()
+  }
+
+  private def withinBoundingBox(travelTime: TravelTime): Boolean = {
+    val srcCoord =
+      movIdToCenter.getOrElse(travelTime.sourceId, throw new NoSuchElementException(s"sourceId ${travelTime.sourceId}"))
+    val dstCoord =
+      movIdToCenter.getOrElse(travelTime.dstId, throw new NoSuchElementException(s"dstId ${travelTime.dstId}"))
+    boundingBox.contains(srcCoord.longitude, srcCoord.latitude) && boundingBox.contains(
+      dstCoord.longitude,
+      dstCoord.latitude
+    )
+  }
+
+}
+
+object ConvertTravelTimeData {
+
+  def mapper(feature: Feature): (Int, WgsCoordinate) = {
+    val centroid = feature.asInstanceOf[SimpleFeature].getDefaultGeometry.asInstanceOf[Geometry].getCentroid
+    val wgsCoord = WgsCoordinate(centroid.getY, centroid.getX)
+    val movId = feature.getProperty("MOVEMENT_ID").getValue.toString.toInt
+    (movId, wgsCoord)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val pathToGeoBoundaries: String = "D:/Work/beam/Uber/SpeedData/san_francisco_taz.json"
+    val pathToTravelTimesCsv: String =
+      "D:/Work/beam/Uber/SpeedData/san_francisco-taz-2019-4-OnlyWeekdays-HourlyAggregate.csv"
+
+    // https://www.google.com/maps/d/drive?state=%7B%22ids%22%3A%5B%221n-UDzL-FBZzyXBs7tSfYgb37GpJ93_Az%22%5D%2C%22action%22%3A%22open%22%2C%22userId%22%3A%22111892074776602978600%22%7D&usp=sharing
+    // Latitude values increase or decrease along the vertical axis, the Y axis, coordinate is between -90 and 90.
+    // Longitude changes value along the horizontal access, the X axis, coordinate is between -180 and 180.
+    // X = Longitude, Y = Latitude
+    val boundingBox: Envelope = new Envelope(-122.546046192, -122.330412968, 37.655512625, 37.811362211)
+    val c = new ConvertTravelTimeData(pathToGeoBoundaries, pathToTravelTimesCsv, boundingBox, 200, 42)
+    c.convert()
+  }
+}

--- a/src/main/scala/beam/utils/uber/movementdata/SpeedReader.scala
+++ b/src/main/scala/beam/utils/uber/movementdata/SpeedReader.scala
@@ -1,0 +1,61 @@
+package beam.utils.uber.movementdata
+
+import java.io.Closeable
+import java.time.ZonedDateTime
+
+import beam.utils.ProfilingUtils
+import beam.utils.csv.GenericCsvReader
+
+class SpeedReader(val pathToSpeedCsv: String) {
+  import SpeedReader._
+
+  def read(filter: SpeedData => Boolean): (Iterator[SpeedData], Closeable) = {
+    GenericCsvReader.readAs[SpeedData](pathToSpeedCsv, toSpeedData, filter)
+  }
+}
+
+object SpeedReader {
+  val mphToMs: Double = 0.44704
+
+  def toSpeedData(rec: java.util.Map[String, String]): SpeedData = {
+    SpeedData(
+      year = rec.get("year").toShort,
+      month = rec.get("month").toByte,
+      day = rec.get("day").toByte,
+      hour = rec.get("hour").toByte,
+      ts = ZonedDateTime.parse(rec.get("utc_timestamp")),
+      wayId = rec.get("osm_way_id").toLong,
+      startNodeId = rec.get("osm_start_node_id").toLong,
+      endNodeId = rec.get("osm_end_node_id").toLong,
+      meanSpeedInMetersPerSecond = rec.get("speed_mph_mean").toDouble * mphToMs,
+      stdDevSpeed = rec.get("speed_mph_stddev").toDouble * mphToMs,
+    )
+  }
+
+  case class SpeedData(
+    year: Short,
+    month: Byte,
+    day: Byte,
+    hour: Byte,
+    ts: ZonedDateTime,
+    wayId: Long,
+    startNodeId: Long,
+    endNodeId: Long,
+    meanSpeedInMetersPerSecond: Double,
+    stdDevSpeed: Double
+  )
+
+  def main(args: Array[String]): Unit = {
+    val path: String = "D:/Work/beam/Uber/SpeedData/1.csv"
+    val sr = new SpeedReader(path)
+    val (speeds, toClose) = sr.read(x => true)
+    try {
+      val matSpeeds = ProfilingUtils.timed("Read all the speeds", x => println(x)) {
+        speeds.toArray
+      }
+      println(s"matSpeeds: ${matSpeeds.length}")
+    } finally {
+      toClose.close()
+    }
+  }
+}

--- a/src/main/scala/beam/utils/uber/movementdata/TravelTimeReader.scala
+++ b/src/main/scala/beam/utils/uber/movementdata/TravelTimeReader.scala
@@ -1,0 +1,30 @@
+package beam.utils.uber.movementdata
+
+import java.io.Closeable
+
+import beam.utils.csv.GenericCsvReader
+
+class TravelTimeReader(val pathToSpeedCsv: String) {
+
+  import TravelTimeReader._
+
+  def read(filter: TravelTime => Boolean): (Iterator[TravelTime], Closeable) = {
+    GenericCsvReader.readAs[TravelTime](pathToSpeedCsv, toTravelTime, filter)
+  }
+}
+
+object TravelTimeReader {
+
+  case class TravelTime(sourceId: Int, dstId: Int, hod: Byte, meanTravelTime: Double, stdTravelTime: Double)
+
+  def toTravelTime(rec: java.util.Map[String, String]): TravelTime = {
+    TravelTime(
+      sourceId = rec.get("sourceid").toInt,
+      dstId = rec.get("dstid").toInt,
+      hod = rec.get("hod").toByte,
+      meanTravelTime = rec.get("mean_travel_time").toDouble,
+      stdTravelTime = rec.get("standard_deviation_travel_time").toDouble
+    )
+  }
+
+}


### PR DESCRIPTION
- Added `SpeedReader` and `TravelTimeReader` for Uber Movement data
- Added `ConvertSpeedData` to read and sample speed data
- Added `ConvertTravelTimeData` to read and sample travel time data

If we sample 100 for every hour in this area of San Fransico:
![image](https://user-images.githubusercontent.com/5107562/84403813-52749080-ac30-11ea-9c5b-80284627e846.png)

We would get the following graph:
![image](https://user-images.githubusercontent.com/5107562/84403766-44267480-ac30-11ea-81ec-0aa4cefeb02a.png)

This shows that Google travel times are in the reasonable range.

