### PR TITLE
Merge branch 'develop' into do/#2751-generalize-parallel-file-loading

### DIFF
--- a/src/main/scala/beam/router/skim/CsvSkimReader.scala
+++ b/src/main/scala/beam/router/skim/CsvSkimReader.scala
@@ -1,6 +1,6 @@
 package beam.router.skim
 
-import java.io.File
+import java.io.{BufferedReader, File}
 import java.util
 
 import com.typesafe.scalalogging.Logger
@@ -11,7 +11,6 @@ import org.matsim.core.utils.io.IOUtils
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.util.Try
-import scala.util.control.NonFatal
 
 /**
   * Skims csv reader.
@@ -28,35 +27,51 @@ class CsvSkimReader(
 ) {
 
   def readAggregatedSkims: immutable.Map[AbstractSkimmerKey, AbstractSkimmerInternal] = {
-    var res = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
-    val csvParser: CsvParser = getCsvParser
-    try {
-      if (new File(aggregatedSkimsFilePath).isFile) {
-        // Headers will be available only when parsing was started
-        lazy val headers = {
-          csvParser.getRecordMetadata.headers()
+    if (!new File(aggregatedSkimsFilePath).isFile) {
+      logger.info(s"warmStart skim NO PATH FOUND '$aggregatedSkimsFilePath'")
+      Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
+    } else {
+      Try {
+        IOUtils.getBufferedReader(aggregatedSkimsFilePath)
+      }.flatMap(tryReadSkims)
+        .recover {
+          case ex: Throwable =>
+            logger.warn(s"Could not load warmStart skim from '$aggregatedSkimsFilePath': ${ex.getMessage}")
+            Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
         }
-
-        val mapReader = csvParser.iterateRecords(IOUtils.getBufferedReader(aggregatedSkimsFilePath)).asScala
-        res = mapReader
-          .map(rec => {
-            val a = convertRecordToMap(rec, headers)
-            val newPair = fromCsv(a)
-            newPair
-          })
-          .toMap
-        logger.info(s"warmStart skim successfully loaded from path '${aggregatedSkimsFilePath}'")
-      } else {
-        logger.info(s"warmStart skim NO PATH FOUND '${aggregatedSkimsFilePath}'")
-      }
-    } catch {
-      case NonFatal(ex) =>
-        logger.info(s"Could not load warmStart skim from '${aggregatedSkimsFilePath}': ${ex.getMessage}")
-    } finally {
-      // In any case stop parser
-      Try(csvParser.stopParsing())
+        .get
     }
-    res
+
+  }
+
+  def readSkims(reader: BufferedReader): Map[AbstractSkimmerKey, AbstractSkimmerInternal] = {
+    tryReadSkims(reader).recover {
+      case ex: Throwable =>
+        logger.warn(s"Could not load warmStart skim from '$aggregatedSkimsFilePath'", ex)
+        Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
+    }.get
+  }
+
+  private def tryReadSkims(reader: BufferedReader): Try[Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = {
+    val csvParser: CsvParser = getCsvParser
+    val result: Try[Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = Try {
+      // Headers will be available only when parsing was started
+      lazy val headers = {
+        csvParser.getRecordMetadata.headers()
+      }
+      val mapReader = csvParser.iterateRecords(reader).asScala
+      val res = mapReader
+        .map(rec => {
+          val a = convertRecordToMap(rec, headers)
+          val newPair = fromCsv(a)
+          newPair
+        })
+        .toMap
+      logger.info(s"warmStart skim successfully loaded from path '$aggregatedSkimsFilePath'")
+      res
+    }
+    Try(csvParser.stopParsing())
+    result
   }
 
   private def convertRecordToMap(rec: Record, header: Array[String]): scala.collection.Map[String, String] = {

--- a/src/main/scala/scripts/SplitCsvSkims.scala
+++ b/src/main/scala/scripts/SplitCsvSkims.scala
@@ -3,9 +3,11 @@ package scripts
 import java.nio.file.Paths
 
 import beam.sim.BeamWarmStart
+import beam.utils.FileUtils
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.core.utils.io.IOUtils
 
+import scala.annotation.tailrec
 import scala.reflect.io.File
 
 object SplitCsvSkims extends App with LazyLogging {
@@ -17,42 +19,25 @@ object SplitCsvSkims extends App with LazyLogging {
   def process(csvFilePath: String, outputDirectory: String, numberOfParts: Int): Unit = {
     File(outputDirectory).createDirectory()
 
-    val filePartSuffix = BeamWarmStart.fileNameSubstringToDetectIfReadSkimsInParallelMode
-    val bufferWritersMap = (1 to numberOfParts)
-      .map(
-        i =>
-          i.toLong -> IOUtils.getBufferedWriter(
-            Paths.get(outputDirectory, File(csvFilePath).name.replace(".csv.gz", s"$filePartSuffix$i.csv.gz")).toString
-        )
-      )
-      .toMap
-
     val reader = IOUtils.getBufferedReader(csvFilePath)
     val headers = reader.readLine()
 
-    bufferWritersMap.foreach {
-      case (_, bw) =>
-        bw.write(headers)
-    }
+    val filePartSuffix = BeamWarmStart.fileNameSubstringToDetectIfReadSkimsInParallelMode
+    val pattern = File(csvFilePath).name.replace(".csv", filePartSuffix + "$i.csv")
+    FileUtils.parWrite(Paths.get(outputDirectory), pattern, numberOfParts) { (_, _, writer) =>
+      writer.write(headers)
 
-    var counter = 0L
-    reader
-      .lines()
-      .forEach(line => {
-        val part = (counter % numberOfParts) + 1
-        bufferWritersMap.get(part) match {
-          case Some(bw) =>
-            bw.newLine()
-            bw.write(line)
-          case None => throw new IllegalStateException(s"Buffer writer for part $part was not found")
+      @tailrec
+      def recur(): Unit = {
+        val line = reader.readLine()
+        if (line != null) {
+          writer.newLine()
+          writer.write(line)
+          recur()
         }
-        counter += 1
-      })
+      }
 
-    bufferWritersMap.foreach {
-      case (_, bw) =>
-        bw.flush()
-        bw.close()
+      recur()
     }
   }
 

--- a/src/test/scala/beam/utils/FileUtilsSpec.scala
+++ b/src/test/scala/beam/utils/FileUtilsSpec.scala
@@ -1,0 +1,86 @@
+package beam.utils
+
+import java.io.BufferedReader
+import java.nio.file.Paths
+
+import com.univocity.parsers.csv.{CsvParser, CsvParserSettings}
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.collection.JavaConverters._
+
+/**
+  *
+  * @author Dmitry Openkov
+  */
+class FileUtilsSpec extends WordSpecLike with Matchers {
+  val skimPath = Paths.get(getClass.getResource("/files/multi-part-od-skims").toURI)
+
+  "FileUtils" must {
+    "read files in parallel into a map" in {
+      val result = FileUtils.parRead(skimPath, "od_for_test_part*.csv.gz") { (path, reader) =>
+        val numPattern = "\\d+".r
+        val partNumber = numPattern.findFirstIn(path.getFileName.toString).get.toInt
+        val records: scala.List[_root_.com.univocity.parsers.common.record.Record] = parseCSV(reader)
+        partNumber -> records
+      }
+      result.size should be(3)
+      result.keys should contain allOf (1, 2, 3)
+      result(1).size should be(3)
+      result(1).head.getInt("hour") should be(0)
+      result(2).size should be(3)
+      result(2).head.getInt("hour") should be(1)
+      result(3).size should be(3)
+      result(3).head.getInt("hour") should be(2)
+    }
+
+    "read files in parallel into a flat iterable" in {
+      val result = FileUtils
+        .flatParRead(skimPath, "od_for_test_part*.csv.gz") { (path, reader) =>
+          val records: scala.List[_root_.com.univocity.parsers.common.record.Record] = parseCSV(reader)
+          records
+        }
+        .toList
+        .sortBy(_.getInt("hour"))
+      result.map(_.getInt("hour")) should be((0 to 8).toList)
+    }
+
+    "write data to files in parallel" in {
+      val data = Array.ofDim[String](111)
+      for (i <- 0 until data.length) {
+        data(i) = i + (",CAR,101241,101241,153,153.0,0.128873295,0.468873295," +
+        "1175.0,0.0,0,0,CAR,101241,101241,153,153.0,0.128873295,0.468873295,1175.0,0.0,0,0CAR,101241,101241,153," +
+        "153.0,0.128873295,0.468873295,1175.0,0.0,0,0")
+      }
+      val numberOfParts = 4
+      FileUtils.usingTemporaryDirectory { tmpDir =>
+        FileUtils.parWrite(tmpDir, "part$i.csv.gz", numberOfParts) { (i, _, writer) =>
+          val n = data.length / numberOfParts
+          val from = (i - 1) * n
+          val until = if (i < numberOfParts) from + n else data.length
+          val mySlice = data.view(from, until)
+          writer.write("a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,x,y,z,a1,a2,a3,a4,a5,a6,a7,a8,a9")
+          mySlice.foreach { x =>
+            writer.newLine()
+            writer.write(x)
+          }
+        }
+        val records = FileUtils
+          .flatParRead(tmpDir, "part*.csv.gz") { (path, reader) =>
+            parseCSV(reader)
+          }
+          .toList
+        records.size should be(111)
+      }
+    }
+  }
+
+  private def parseCSV(reader: BufferedReader) = {
+    val settings = new CsvParserSettings()
+    settings.setHeaderExtractionEnabled(true)
+    settings.detectFormatAutomatically()
+    val csvParser = new CsvParser(settings)
+    val records = csvParser.iterateRecords(reader).asScala.toList
+    csvParser.stopParsing()
+    records
+  }
+}


### PR DESCRIPTION
Performance testing for writing files in parallel gives SplitCSVSkims got 2 times faster (4 threads). Writing data from memory to disk is 1.5 times faster (4 threads).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2771)
<!-- Reviewable:end -->
