### PR TITLE
Fixed using wrong beam config in the warm start related classes

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -141,7 +141,7 @@ trait BeamHelper extends LazyLogging {
           install(new ControlerDefaultCoreListenersModule)
 
           // Beam Inject below:
-          install(new ConfigModule(typesafeConfig))
+          install(new ConfigModule(typesafeConfig, beamConfig))
           install(new BeamAgentModule(beamConfig))
           install(new UtilsModule)
         }

--- a/src/main/scala/beam/sim/config/ConfigModule.scala
+++ b/src/main/scala/beam/sim/config/ConfigModule.scala
@@ -4,7 +4,7 @@ import com.google.inject._
 import com.typesafe.config.{Config => TypesafeConfig}
 import net.codingwell.scalaguice.ScalaModule
 
-class ConfigModule(val typesafeConfig: TypesafeConfig) extends AbstractModule with ScalaModule {
+class ConfigModule(val typesafeConfig: TypesafeConfig, beamConfig: BeamConfig) extends AbstractModule with ScalaModule {
 
   @Provides @Singleton
   def getTypesafeConfig: TypesafeConfig = {
@@ -12,8 +12,8 @@ class ConfigModule(val typesafeConfig: TypesafeConfig) extends AbstractModule wi
   }
 
   @Provides @Singleton
-  def beamConfig(typesafeConfig: TypesafeConfig): BeamConfig =
-    BeamConfig(typesafeConfig)
+  def beamConfig(): BeamConfig =
+    beamConfig
 
   override def configure(): Unit = {}
 


### PR DESCRIPTION
BeamConfig is modified by BeamWarmStart class. This PR injects this modified config into Guice instead of the original one so that we have a single config in the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2812)
<!-- Reviewable:end -->
