### PR TITLE
change name to mitigate confusion of plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -556,7 +556,7 @@ tasks.withType(ScalaCompile) {
 }
 
 task fmt(dependsOn: scalafmtAll)
-task checkScalaFmt() {
+task verifyScalaFmtHasBeenRun() {
     doLast {
         try {
             def workingDir = new File("${project.projectDir}")


### PR DESCRIPTION
Resolves #2781 

This will NOT pass CI because we are removing the old name. I thought about aliasing it, but then you have the same problem as brought up in #2781 - so I think it'll be better to temporarily break branches until they merge this change. It's such a minor one anyway that it could be done manually if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2861)
<!-- Reviewable:end -->
