### PR TITLE
BugFix: a fix for java.util.NoSuchElementException: None.get

### DIFF
--- a/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
+++ b/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
@@ -160,9 +160,8 @@ class SupplementaryTripGenerator(
             false -> noTrip,
           )
 
-        tripMNL.sampleAlternative(tripChoice, r) match {
-          case Some(mnlSample) if mnlSample.alternativeType => destinationMNL.sampleAlternative(modeChoice, r)
-          case _                                            => None
+        tripMNL.sampleAlternative(tripChoice, r) collect {
+          case mnlSample if mnlSample.alternativeType => destinationMNL.sampleAlternative(modeChoice, r)
         }
     }
     chosenAlternativeOption match {

--- a/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
+++ b/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
@@ -160,12 +160,9 @@ class SupplementaryTripGenerator(
             false -> noTrip,
           )
 
-        val makeTrip: Boolean = tripMNL.sampleAlternative(tripChoice, r).get.alternativeType
-
-        if (makeTrip) {
-          destinationMNL.sampleAlternative(modeChoice, r)
-        } else {
-          None
+        tripMNL.sampleAlternative(tripChoice, r) match {
+          case Some(mnlSample) if mnlSample.alternativeType => destinationMNL.sampleAlternative(modeChoice, r)
+          case _                                            => None
         }
     }
     chosenAlternativeOption match {

--- a/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
+++ b/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
@@ -160,10 +160,12 @@ class SupplementaryTripGenerator(
             false -> noTrip,
           )
 
-        tripMNL.sampleAlternative(tripChoice, r) collect {
-          case mnlSample if mnlSample.alternativeType => destinationMNL.sampleAlternative(modeChoice, r)
+        tripMNL.sampleAlternative(tripChoice, r) match {
+          case Some(mnlSample) if mnlSample.alternativeType => destinationMNL.sampleAlternative(modeChoice, r)
+          case _                                            => None
         }
     }
+
     chosenAlternativeOption match {
       case Some(outcome) =>
         val chosenAlternative = outcome.alternativeType


### PR DESCRIPTION
to fix a fatal exception:

```
09:05:47.099 [main] INFO  beam.sim.BeamMobsim - Filling in secondary trips in plans
09:09:34.884 [main] ERROR o.m.c.controler.AbstractController - Mobsim did not complete normally! afterMobsimListeners will be called anyway.
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at beam.replanning.SupplementaryTripGenerator.generateSubtour(SupplementaryTripGenerator.scala:163)
	at beam.replanning.SupplementaryTripGenerator.$anonfun$generateNewPlans$1(SupplementaryTripGenerator.scala:82)
	at beam.replanning.SupplementaryTripGenerator.$anonfun$generateNewPlans$1$adapted(SupplementaryTripGenerator.scala:78)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2864)
<!-- Reviewable:end -->
