### PR TITLE
add duration to walk egress leg after parking in mode choice

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -801,7 +801,7 @@ trait ChoosesMode {
                   parkingResponse.stall.locationUTM
                 )
                 val travelTime: Int = (dist / ZonalParkingManager.AveragePersonWalkingSpeed).toInt
-                leg.copy(beamLeg = leg.beamLeg.copy(duration = travelTime))
+                leg.copy(beamLeg = leg.beamLeg.scaleToNewDuration(travelTime))
               } else {
                 leg
               }

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -796,8 +796,6 @@ trait ChoosesMode {
               if (i == 2) {
                 leg.copy(cost = leg.cost + parkingResponse.stall.costInDollars)
               } else if (i == 3) {
-                val a = geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc)
-                val b = geo.utm2Wgs(parkingResponse.stall.locationUTM)
                 val dist = geo.distUTMInMeters(
                   geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc),
                   parkingResponse.stall.locationUTM

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -796,20 +796,13 @@ trait ChoosesMode {
               if (i == 2) {
                 leg.copy(cost = leg.cost + parkingResponse.stall.costInDollars)
               } else if (i == 3) {
+                val a = geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc)
                 val dist = geo.distUTMInMeters(
                   geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc),
                   parkingResponse.stall.locationUTM
                 )
                 val travelTime: Int = (dist / ZonalParkingManager.AveragePersonWalkingSpeed).toInt
-                EmbodiedBeamLeg.dummyLegAt(
-                  start = leg.beamLeg.startTime,
-                  vehicleId = leg.beamVehicleId,
-                  isLastLeg = true,
-                  location = leg.beamLeg.travelPath.endPoint.loc,
-                  mode = WALK,
-                  vehicleTypeId = body.beamVehicleType.id,
-                  duration = travelTime
-                )
+                leg.copy(beamLeg = leg.beamLeg.copy(duration = travelTime))
               } else {
                 leg
               }

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -797,6 +797,7 @@ trait ChoosesMode {
                 leg.copy(cost = leg.cost + parkingResponse.stall.costInDollars)
               } else if (i == 3) {
                 val a = geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc)
+                val b = geo.utm2Wgs(parkingResponse.stall.locationUTM)
                 val dist = geo.distUTMInMeters(
                   geo.wgs2Utm(leg.beamLeg.travelPath.endPoint.loc),
                   parkingResponse.stall.locationUTM

--- a/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithVehicleSharingSpec.scala
@@ -346,8 +346,8 @@ class PersonWithVehicleSharingSpec
                     linkIds = Vector(3, 4),
                     linkTravelTime = Vector(50, 50),
                     transitStops = None,
-                    startPoint = SpaceTime(0.01, 0.0, 28950),
-                    endPoint = SpaceTime(0.01, 0.01, 29000),
+                    startPoint = SpaceTime(-1.4887439, 0.0, 28950),
+                    endPoint = SpaceTime(-1.4887438, 0.01, 29000),
                     distanceInM = 1000D
                   )
                 ),
@@ -431,8 +431,8 @@ class PersonWithVehicleSharingSpec
                     linkIds = Vector(4, 3, 2, 1),
                     linkTravelTime = Vector(10, 10, 10, 10),
                     transitStops = None,
-                    startPoint = SpaceTime(0.01, 0.01, 61200),
-                    endPoint = SpaceTime(0.0, 0.0, 61230),
+                    startPoint = SpaceTime(-1.4887438, 0.0, 61200),
+                    endPoint = SpaceTime(-1.4887439, 0.0, 61230),
                     distanceInM = 1000D
                   )
                 ),


### PR DESCRIPTION
Seems to work in SF-light-1k. Before the fix, if we run a scenario with very limited parking we get 3727 car mode choices. With the fix, we now get 2160 car mode choices, implying that considering walk egress time makes the car mode less attractive. As reference, unlimited parking gives 4796 car mode choices, implying that before the fix some people were still being driven away from choosing the car mode because of the cost associated with the scarce parking (which checks out with expectations).

Should fix #2870

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2874)
<!-- Reviewable:end -->
