### PR TITLE
generate free residential stall when needed

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
@@ -64,6 +64,7 @@ object ParkingStall {
       parkingType = ParkingType.Public
     )
   }
+
   /**
     * take a stall from the infinite parking zone, with a location at the request (e.g. traveler's home location).
     * This should only kick in when all other (potentially non-free, non-colocated) stalls in the search area are

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingStall.scala
@@ -64,4 +64,24 @@ object ParkingStall {
       parkingType = ParkingType.Public
     )
   }
+  /**
+    * take a stall from the infinite parking zone, with a location at the request (e.g. traveler's home location).
+    * This should only kick in when all other (potentially non-free, non-colocated) stalls in the search area are
+    * exhausted
+    *
+    * @param locationUTM request location (home)
+    *
+    * @return a stall that is free and located at the person's home.
+    */
+  def defaultResidentialStall(
+    locationUTM: Location
+  ): ParkingStall = ParkingStall(
+    tazId = TAZ.DefaultTAZId,
+    parkingZoneId = ParkingZone.DefaultParkingZoneId,
+    locationUTM = locationUTM,
+    costInDollars = 0.0,
+    chargingPointType = None,
+    pricingModel = Some { PricingModel.FlatFee(0) },
+    parkingType = ParkingType.Residential
+  )
 }

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -252,15 +252,24 @@ class ZonalParkingManager(
           case Some(result) =>
             result
           case None =>
-            // didn't find any stalls, so, as a last resort, create a very expensive stall
-            val boxAroundRequest = new Envelope(
-              inquiry.destinationUtm.getX + 2000,
-              inquiry.destinationUtm.getX - 2000,
-              inquiry.destinationUtm.getY + 2000,
-              inquiry.destinationUtm.getY - 2000
-            )
-            val newStall = ParkingStall.lastResortStall(boxAroundRequest, rand, tazId = emergencyTAZId)
-            ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
+            inquiry.activityType match {
+              case "init" =>
+                val newStall = ParkingStall.defaultResidentialStall(inquiry.destinationUtm)
+                ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
+              case "home" =>
+                val newStall = ParkingStall.defaultResidentialStall(inquiry.destinationUtm)
+                ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
+              case _ =>
+                // didn't find any stalls, so, as a last resort, create a very expensive stall
+                val boxAroundRequest = new Envelope(
+                  inquiry.destinationUtm.getX + 2000,
+                  inquiry.destinationUtm.getX - 2000,
+                  inquiry.destinationUtm.getY + 2000,
+                  inquiry.destinationUtm.getY - 2000
+                )
+                val newStall = ParkingStall.lastResortStall(boxAroundRequest, rand, tazId = emergencyTAZId)
+                ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
+            }
         }
 
       log.debug(

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -253,10 +253,7 @@ class ZonalParkingManager(
             result
           case None =>
             inquiry.activityType match {
-              case "init" =>
-                val newStall = ParkingStall.defaultResidentialStall(inquiry.destinationUtm)
-                ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
-              case "home" =>
+              case "init" | "home" =>
                 val newStall = ParkingStall.defaultResidentialStall(inquiry.destinationUtm)
                 ParkingZoneSearch.ParkingZoneSearchResult(newStall, ParkingZone.DefaultParkingZone)
               case _ =>


### PR DESCRIPTION
We're seeing the problem in NYC of really long walk trips, potentially to some extent caused by cars being initialized in emergency parking stalls really far away from home (so a really long walk trip still is favorable compared to a really long walk access trip to a car). We should assume that all cars have somewhere reasonably close by their household location to park.

First pass solution is to create a new version of an emergency parking stall that can only be created on vehicle initialization and for "home" activities. The new default residential stall is located at the request location and free, so no access time and cost. These stalls only are created when all other nearby spots are filled up, so hopefully it shouldn't artificially get rid of all parking scarcity.

Should fix #2882

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2883)
<!-- Reviewable:end -->
