### PR TITLE
GoogleSpeedApi: specify exact iteration number for different kind of google speed requests

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -686,6 +686,8 @@ beam.calibration.google.travelTimes.iterationInterval = "int | 5"
 beam.calibration.google.travelTimes.tolls = "boolean | true"
 beam.calibration.google.travelTimes.queryDate = "2020-10-14"
 beam.calibration.google.travelTimes.offPeakEnabled = "boolean | false"
+beam.calibration.google.travelTimes.exactRequestRegularIterationNumber = "int | -1"
+beam.calibration.google.travelTimes.exactRequestOffPeakIterationNumber = "int | -1"
 
 beam.calibration.studyArea.enabled = "boolean | false"
 beam.calibration.studyArea.lat = "double | 0"

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -1724,6 +1724,8 @@ object BeamConfig {
       object Google {
         case class TravelTimes(
           enable: scala.Boolean,
+          exactOffPeakRequestIterationNumber: scala.Int,
+          exactRegularRequestIterationNumber: scala.Int,
           iterationInterval: scala.Int,
           minDistanceInMeters: scala.Double,
           numDataPointsOver24Hours: scala.Int,
@@ -1737,6 +1739,14 @@ object BeamConfig {
           def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Calibration.Google.TravelTimes = {
             BeamConfig.Beam.Calibration.Google.TravelTimes(
               enable = c.hasPathOrNull("enable") && c.getBoolean("enable"),
+              exactOffPeakRequestIterationNumber =
+                if (c.hasPathOrNull("exactRequestOffPeakIterationNumber"))
+                  c.getInt("exactRequestOffPeakIterationNumber")
+                else -1,
+              exactRegularRequestIterationNumber =
+                if (c.hasPathOrNull("exactRequestRegularIterationNumber"))
+                  c.getInt("exactRequestRegularIterationNumber")
+                else -1,
               iterationInterval = if (c.hasPathOrNull("iterationInterval")) c.getInt("iterationInterval") else 5,
               minDistanceInMeters =
                 if (c.hasPathOrNull("minDistanceInMeters")) c.getDouble("minDistanceInMeters") else 5000,


### PR DESCRIPTION
because requests cost money and we want to do very specific '3am' requests at iteration 0 and requests for regular route time at last iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2898)
<!-- Reviewable:end -->
