### PR TITLE
multiple secondary activities from home

### DIFF
--- a/src/main/scala/beam/replanning/AddSupplementaryTrips.scala
+++ b/src/main/scala/beam/replanning/AddSupplementaryTrips.scala
@@ -86,10 +86,11 @@ class AddSupplementaryTrips @Inject()(beamConfig: BeamConfig) extends PlansStrat
     }
     if (nonWorker) {
       listOfActivities.flatMap(
-        activity => activity.getType match {
-          case "Home" => addSubtourToActivity(activity)
-          case "Work" => List[Activity](activity)
-          case _ => List[Activity](activity)
+        activity =>
+          activity.getType match {
+            case "Home" => addSubtourToActivity(activity)
+            case "Work" => List[Activity](activity)
+            case _      => List[Activity](activity)
         }
       )
     } else {

--- a/src/main/scala/beam/replanning/AddSupplementaryTrips.scala
+++ b/src/main/scala/beam/replanning/AddSupplementaryTrips.scala
@@ -76,12 +76,24 @@ class AddSupplementaryTrips @Inject()(beamConfig: BeamConfig) extends PlansStrat
 
   private def definitelyAddSubtours(
     activity: Activity,
-    person: Person
+    person: Person,
+    nonWorker: Boolean = false
   ): List[Activity] = {
-    activity.getType match {
+    val listOfActivities = activity.getType match {
       case "Home" => addSubtourToActivity(activity)
       case "Work" => addSubtourToActivity(activity)
       case _      => List[Activity](activity)
+    }
+    if (nonWorker) {
+      listOfActivities.flatMap(
+        activity => activity.getType match {
+          case "Home" => addSubtourToActivity(activity)
+          case "Work" => List[Activity](activity)
+          case _ => List[Activity](activity)
+        }
+      )
+    } else {
+      listOfActivities
     }
   }
 
@@ -124,6 +136,7 @@ class AddSupplementaryTrips @Inject()(beamConfig: BeamConfig) extends PlansStrat
     newPlan.setType(plan.getType)
 
     val elements = plan.getPlanElements.asScala.collect { case activity: Activity => activity }
+    val nonWorker = (elements.length == 1)
     val newActivitiesToAdd = elements.zipWithIndex.map {
       case (planElement, idx) =>
         val prevEndTime = if (idx > 0) {
@@ -133,7 +146,7 @@ class AddSupplementaryTrips @Inject()(beamConfig: BeamConfig) extends PlansStrat
         }
         planElement.setMaximumDuration(planElement.getEndTime - prevEndTime)
         planElement.setStartTime(prevEndTime)
-        definitelyAddSubtours(planElement, person)
+        definitelyAddSubtours(planElement, person, nonWorker)
     }
     newActivitiesToAdd.flatten.foreach { x =>
       newPlan.addActivity(x)


### PR DESCRIPTION
Previously non-workers were limited to one secondary tour per day (it was one tour per mandatory activity). Added a fix allowing up to three secondary tours for non-workers. Could be generalized in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2915)
<!-- Reviewable:end -->
