### PR TITLE
BeamCsvScenarioWriter compatible with ScenarioInfo classes

### DIFF
--- a/src/main/scala/beam/utils/csv/readers/BeamCsvScenarioReader.scala
+++ b/src/main/scala/beam/utils/csv/readers/BeamCsvScenarioReader.scala
@@ -96,7 +96,7 @@ object BeamCsvScenarioReader extends BeamScenarioReader with LazyLogging {
     val age = getIfNotNull(rec, "age").toInt
     val isFemale = getIfNotNull(rec, "isFemale", "false").toBoolean
     val rank = getIfNotNull(rec, "householdRank", "0").toInt
-    val excludedModes = Try(getIfNotNull(rec, "excludedModes")).getOrElse("")
+    val excludedModes = Try(getIfNotNull(rec, "excludedModes")).getOrElse("").split(",")
     val valueOfTime = NumberUtils.toDouble(Try(getIfNotNull(rec, "valueOfTime", "0")).getOrElse("0"), 0D)
     PersonInfo(
       personId = PersonId(personId),

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -24,6 +24,7 @@ import beam.utils.scenario.{HouseholdInfo, PersonInfo, VehicleInfo}
 object BeamCsvScenarioWriter {
 
   implicit class PopulationWriter(arr: Array[PersonInfo]) {
+
     def writeCsvPersonsFile(outputFileStr: String): Array[PersonInfo] = {
       PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
       arr
@@ -34,6 +35,7 @@ object BeamCsvScenarioWriter {
   }
 
   implicit class VehicleWriter(arr: Array[VehicleInfo]) {
+
     def writeCsvVehiclesFile(outputFileStr: String): Array[VehicleInfo] = {
       VehiclesCsvWriter(arr.toIterable).toCsv(arr.toIterator, outputFileStr)
       arr
@@ -44,6 +46,7 @@ object BeamCsvScenarioWriter {
   }
 
   implicit class HouseholdWriter(arr: Array[HouseholdInfo]) {
+
     def writeCsvHouseholdsFile(outputFileStr: String): Array[HouseholdInfo] = {
       PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
       arr

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -3,40 +3,53 @@ package beam.utils.csv.writers
 import scala.language.implicitConversions
 
 import beam.utils.scenario.{HouseholdInfo, PersonInfo, VehicleInfo}
-
+/*
+ * This file keeps symmetry with BeamCsvScenarioReader. Examples below:
+ *   import beam.utils.csv.readers.BeamCsvScenarioReader
+ *   import beam.utils.csv.writers.BeamCsvScenarioWriter._
+ *
+ *   val vehicles: Iterable[VehicleInfo] =
+ *     BeamCsvScenarioReader.readVehiclesFile("vehicles.csv")
+ *   vehicles.writeCsvVehiclesFile("vehicles_output.csv")
+ *
+ *   val households: Array[HouseholdInfo] =
+ *     BeamCsvScenarioReader.readHouseholdsFile("householdsFile.csv", vehicles)
+ *   vehicles.writeCsvVehiclesFile("households_output.csv")
+ *
+ *  val persons: Array[PersonInfo] =
+ *    BeamCsvScenarioReader.readPersonsFile("persons.csv")
+ *  persons.writeCsvPersonsFile("persons_out.csv")
+ */
 object BeamCsvScenarioWriter {
 
   implicit class PopulationWriter(arr: Array[PersonInfo]) {
-    def this(elements: Iterable[PersonInfo]) {
-      this(elements.toArray)
-    }
-
     def writeCsvPersonsFile(outputFileStr: String): Array[PersonInfo] = {
       PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
       arr
     }
   }
+  implicit def toPopulationWriter(elements: Iterable[PersonInfo]): PopulationWriter = {
+    new PopulationWriter(elements.toArray)
+  }
 
   implicit class VehicleWriter(arr: Array[VehicleInfo]) {
-    def this(elements: Iterable[VehicleInfo]) {
-      this(elements.toArray)
-    }
-
     def writeCsvVehiclesFile(outputFileStr: String): Array[VehicleInfo] = {
       VehiclesCsvWriter(arr.toIterable).toCsv(arr.toIterator, outputFileStr)
       arr
     }
   }
+  implicit def toVehicleWriter(elements: Iterable[VehicleInfo]): VehicleWriter = {
+    new VehicleWriter(elements.toArray)
+  }
 
   implicit class HouseholdWriter(arr: Array[HouseholdInfo]) {
-    def this(elements: Iterable[HouseholdInfo]) {
-      this(elements.toArray)
-    }
-
     def writeCsvHouseholdsFile(outputFileStr: String): Array[HouseholdInfo] = {
       PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
       arr
     }
+  }
+  implicit def toHouseholdWriter(elements: Iterable[HouseholdInfo]): HouseholdWriter = {
+    new HouseholdWriter(elements.toArray)
   }
 
 }

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -1,0 +1,43 @@
+package beam.utils.csv.writers
+
+import scala.language.implicitConversions
+
+import beam.utils.scenario.{HouseholdInfo, PersonInfo, VehicleInfo}
+import com.typesafe.scalalogging.LazyLogging
+
+object BeamCsvScenarioWriter extends LazyLogging {
+
+  implicit class PopulationWriter(arr: Array[PersonInfo]) {
+    def this(elements: Iterable[PersonInfo]) {
+      this(elements.toArray)
+    }
+
+    def writeCsvPersonsFile(outputFileStr: String): Array[PersonInfo] = {
+      PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
+      arr
+    }
+  }
+
+  implicit class VehicleWriter(arr: Array[VehicleInfo]) {
+    def this(elements: Iterable[VehicleInfo]) {
+      this(elements.toArray)
+    }
+
+    def writeCsvHouseholdsFile(outputFileStr: String): Array[VehicleInfo] = {
+      VehiclesCsvWriter(arr.toIterable).toCsv(arr.toIterator, outputFileStr)
+      arr
+    }
+  }
+
+  implicit class HouseholdWriter(arr: Array[HouseholdInfo]) {
+    def this(elements: Iterable[HouseholdInfo]) {
+      this(elements.toArray)
+    }
+
+    def writeCsvHouseholdsFile(outputFileStr: String): Array[HouseholdInfo] = {
+      PopulationCsvWriter.toCsv(arr.toIterator, outputFileStr)
+      arr
+    }
+  }
+
+}

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -3,6 +3,7 @@ package beam.utils.csv.writers
 import scala.language.implicitConversions
 
 import beam.utils.scenario.{HouseholdInfo, PersonInfo, VehicleInfo}
+
 /*
  * This file keeps symmetry with BeamCsvScenarioReader. Examples below:
  *   import beam.utils.csv.readers.BeamCsvScenarioReader

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -3,9 +3,8 @@ package beam.utils.csv.writers
 import scala.language.implicitConversions
 
 import beam.utils.scenario.{HouseholdInfo, PersonInfo, VehicleInfo}
-import com.typesafe.scalalogging.LazyLogging
 
-object BeamCsvScenarioWriter extends LazyLogging {
+object BeamCsvScenarioWriter {
 
   implicit class PopulationWriter(arr: Array[PersonInfo]) {
     def this(elements: Iterable[PersonInfo]) {

--- a/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/BeamCsvScenarioWriter.scala
@@ -23,7 +23,7 @@ object BeamCsvScenarioWriter extends LazyLogging {
       this(elements.toArray)
     }
 
-    def writeCsvHouseholdsFile(outputFileStr: String): Array[VehicleInfo] = {
+    def writeCsvVehiclesFile(outputFileStr: String): Array[VehicleInfo] = {
       VehiclesCsvWriter(arr.toIterable).toCsv(arr.toIterator, outputFileStr)
       arr
     }

--- a/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
@@ -4,8 +4,10 @@ import com.typesafe.scalalogging.StrictLogging
 import org.matsim.api.core.v01.Scenario
 import org.matsim.households.Household
 import org.matsim.utils.objectattributes.ObjectAttributes
-
 import scala.collection.JavaConverters._
+import scala.util.Try
+
+import beam.utils.scenario.{HouseholdId, HouseholdInfo}
 
 object HouseholdsCsvWriter extends ScenarioCsvWriter with StrictLogging {
 
@@ -28,15 +30,32 @@ object HouseholdsCsvWriter extends ScenarioCsvWriter with StrictLogging {
     val attributes: ObjectAttributes = scenario.getHouseholds.getHouseholdAttributes
 
     val households = scenario.getHouseholds.getHouseholds.asScala.values
-    households.toIterator.map { h: Household =>
+    val values = households.toIterator.map { h: Household =>
       val id = h.getId.toString
-      HouseholdEntry(
-        householdId = id,
-        incomeValue = h.getIncome.getIncome,
-        locationX = attributes.getAttribute(id, "homecoordx").toString,
-        locationY = attributes.getAttribute(id, "homecoordy").toString
-      ).toString
+      HouseholdInfo(
+        householdId = HouseholdId(id),
+        income = h.getIncome.getIncome,
+        locationX = Try(attributes.getAttribute(id, "homecoordx").toString.toDouble).getOrElse(0),
+        locationY = Try(attributes.getAttribute(id, "homecoordy").toString.toDouble).getOrElse(0),
+        cars = 0 // TODO: how to get this from scenario?
+      )
     }
+    contentIterator(values)
   }
 
+  override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {
+    elements.flatMap { item =>
+      item match {
+        case info: HouseholdInfo =>
+          val result = Seq(
+            info.householdId,
+            info.income,
+            info.locationX,
+            info.locationY
+          ).mkString("", FieldSeparator, LineSeparator)
+          Some(result)
+        case _ => None
+      }
+    }
+  }
 }

--- a/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
@@ -37,7 +37,7 @@ object HouseholdsCsvWriter extends ScenarioCsvWriter with StrictLogging {
         income = h.getIncome.getIncome,
         locationX = Try(attributes.getAttribute(id, "homecoordx").toString.toDouble).getOrElse(0),
         locationY = Try(attributes.getAttribute(id, "homecoordy").toString.toDouble).getOrElse(0),
-        // TODO: this information is not available in CSV file
+        // TODO: ISSUE 2961 - this information is not available in CSV file
         cars = h.getVehicleIds.size()
       )
     }

--- a/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/HouseholdsCsvWriter.scala
@@ -37,7 +37,8 @@ object HouseholdsCsvWriter extends ScenarioCsvWriter with StrictLogging {
         income = h.getIncome.getIncome,
         locationX = Try(attributes.getAttribute(id, "homecoordx").toString.toDouble).getOrElse(0),
         locationY = Try(attributes.getAttribute(id, "homecoordy").toString.toDouble).getOrElse(0),
-        cars = 0 // TODO: how to get this from scenario?
+        // TODO: this information is not available in CSV file
+        cars = h.getVehicleIds.size()
       )
     }
     contentIterator(values)

--- a/src/main/scala/beam/utils/csv/writers/NetworkCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/NetworkCsvWriter.scala
@@ -87,4 +87,6 @@ object NetworkCsvWriter extends ScenarioCsvWriter {
       }
   }
 
+  override def contentIterator[A](elements: Iterator[A]): Iterator[String] = ???
+
 }

--- a/src/main/scala/beam/utils/csv/writers/PlansCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/PlansCsvWriter.scala
@@ -170,29 +170,36 @@ object PlansCsvWriter extends ScenarioCsvWriter {
   }
 
   override def contentIterator(scenario: Scenario): Iterator[String] = {
-    val plans = getPlanInfo(scenario)
-    plans.toIterator.map { planInfo =>
-      PlanEntry(
-        personId = planInfo.personId.id,
-        planIndex = planInfo.planIndex,
-        planScore = planInfo.planScore,
-        planSelected = planInfo.planSelected,
-        planElementType = planInfo.planElementType,
-        planElementIndex = planInfo.planElementIndex,
-        activityType = planInfo.activityType.getOrElse(""),
-        activityLocationX = planInfo.activityLocationX.map(_.toString).getOrElse(""),
-        activityLocationY = planInfo.activityLocationY.map(_.toString).getOrElse(""),
-        activityEndTime = planInfo.activityEndTime.map(_.toString).getOrElse(""),
-        legMode = planInfo.legMode.getOrElse(""),
-        legDepartureTime = planInfo.legDepartureTime.getOrElse(""),
-        legTravelTime = planInfo.legTravelTime.getOrElse(""),
-        legRouteType = planInfo.legRouteType.getOrElse(""),
-        legRouteStartLink = planInfo.legRouteStartLink.getOrElse(""),
-        legRouteEndLink = planInfo.legRouteEndLink.getOrElse(""),
-        legRouteTravelTime = planInfo.legRouteTravelTime,
-        legRouteDistance = planInfo.legRouteDistance,
-        legRouteLinks = planInfo.legRouteLinks
-      ).toString
+    val plans: Iterable[PlanElement] = getPlanInfo(scenario)
+    contentIterator(plans.toIterator)
+  }
+
+  override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {
+    elements.flatMap {
+      case planInfo: PlanElement =>
+        val result = PlanEntry(
+          personId = planInfo.personId.id,
+          planIndex = planInfo.planIndex,
+          planScore = planInfo.planScore,
+          planSelected = planInfo.planSelected,
+          planElementType = planInfo.planElementType,
+          planElementIndex = planInfo.planElementIndex,
+          activityType = planInfo.activityType.getOrElse(""),
+          activityLocationX = planInfo.activityLocationX.map(_.toString).getOrElse(""),
+          activityLocationY = planInfo.activityLocationY.map(_.toString).getOrElse(""),
+          activityEndTime = planInfo.activityEndTime.map(_.toString).getOrElse(""),
+          legMode = planInfo.legMode.getOrElse(""),
+          legDepartureTime = planInfo.legDepartureTime.getOrElse(""),
+          legTravelTime = planInfo.legTravelTime.getOrElse(""),
+          legRouteType = planInfo.legRouteType.getOrElse(""),
+          legRouteStartLink = planInfo.legRouteStartLink.getOrElse(""),
+          legRouteEndLink = planInfo.legRouteEndLink.getOrElse(""),
+          legRouteTravelTime = planInfo.legRouteTravelTime,
+          legRouteDistance = planInfo.legRouteDistance,
+          legRouteLinks = planInfo.legRouteLinks
+        ).toString
+        Some(result)
+      case _ => None
     }
   }
 

--- a/src/main/scala/beam/utils/csv/writers/PlansCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/PlansCsvWriter.scala
@@ -1,11 +1,11 @@
 package beam.utils.csv.writers
 
+import scala.collection.JavaConverters._
+
 import beam.utils.scenario.{PersonId, PlanElement}
 import org.matsim.api.core.v01.Scenario
 import org.matsim.api.core.v01.population.{Activity, Leg, Plan, PlanElement => MatsimPlanElement}
 import org.matsim.core.population.routes.NetworkRoute
-
-import scala.collection.JavaConverters._
 
 object PlansCsvWriter extends ScenarioCsvWriter {
 
@@ -31,54 +31,8 @@ object PlansCsvWriter extends ScenarioCsvWriter {
     "legRouteLinks"
   )
 
-  private case class PlanEntry(
-    personId: String,
-    planIndex: Int,
-    planScore: Double,
-    planSelected: Boolean,
-    planElementType: String,
-    planElementIndex: Int,
-    activityType: String,
-    activityLocationX: String,
-    activityLocationY: String,
-    activityEndTime: String,
-    legMode: String,
-    legDepartureTime: String,
-    legTravelTime: String,
-    legRouteType: String,
-    legRouteStartLink: String,
-    legRouteEndLink: String,
-    legRouteTravelTime: Option[Double],
-    legRouteDistance: Option[Double],
-    legRouteLinks: Seq[String]
-  ) {
-    override def toString: String = {
-      Seq(
-        personId,
-        planIndex,
-        planScore,
-        planSelected,
-        planElementType,
-        planElementIndex,
-        activityType,
-        activityLocationX,
-        activityLocationY,
-        activityEndTime,
-        legMode,
-        legDepartureTime,
-        legTravelTime,
-        legRouteType,
-        legRouteStartLink,
-        legRouteEndLink,
-        legRouteTravelTime.map(_.toString).getOrElse(""),
-        legRouteDistance.map(_.toString).getOrElse(""),
-        legRouteLinks.mkString("|")
-      ).mkString("", FieldSeparator, LineSeparator)
-    }
-  }
-
-  private def getPlanInfo(scenario: Scenario): Iterable[PlanElement] = {
-    scenario.getPopulation.getPersons.asScala.flatMap {
+  private def getPlanInfo(scenario: Scenario): Iterator[PlanElement] = {
+    scenario.getPopulation.getPersons.asScala.iterator.flatMap {
       case (_, person) =>
         val selectedPlan = person.getSelectedPlan
         person.getPlans.asScala.zipWithIndex.flatMap {
@@ -170,37 +124,38 @@ object PlansCsvWriter extends ScenarioCsvWriter {
   }
 
   override def contentIterator(scenario: Scenario): Iterator[String] = {
-    val plans: Iterable[PlanElement] = getPlanInfo(scenario)
-    contentIterator(plans.toIterator)
+    contentIterator(getPlanInfo(scenario))
   }
 
   override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {
     elements.flatMap {
-      case planInfo: PlanElement =>
-        val result = PlanEntry(
-          personId = planInfo.personId.id,
-          planIndex = planInfo.planIndex,
-          planScore = planInfo.planScore,
-          planSelected = planInfo.planSelected,
-          planElementType = planInfo.planElementType,
-          planElementIndex = planInfo.planElementIndex,
-          activityType = planInfo.activityType.getOrElse(""),
-          activityLocationX = planInfo.activityLocationX.map(_.toString).getOrElse(""),
-          activityLocationY = planInfo.activityLocationY.map(_.toString).getOrElse(""),
-          activityEndTime = planInfo.activityEndTime.map(_.toString).getOrElse(""),
-          legMode = planInfo.legMode.getOrElse(""),
-          legDepartureTime = planInfo.legDepartureTime.getOrElse(""),
-          legTravelTime = planInfo.legTravelTime.getOrElse(""),
-          legRouteType = planInfo.legRouteType.getOrElse(""),
-          legRouteStartLink = planInfo.legRouteStartLink.getOrElse(""),
-          legRouteEndLink = planInfo.legRouteEndLink.getOrElse(""),
-          legRouteTravelTime = planInfo.legRouteTravelTime,
-          legRouteDistance = planInfo.legRouteDistance,
-          legRouteLinks = planInfo.legRouteLinks
-        ).toString
-        Some(result)
-      case _ => None
+      case planInfo: PlanElement => Some(toLine(planInfo))
+      case _                     => None
     }
+  }
+
+  private def toLine(planInfo: PlanElement): String = {
+    Seq(
+      planInfo.personId.id,
+      planInfo.planIndex,
+      planInfo.planScore,
+      planInfo.planSelected,
+      planInfo.planElementType,
+      planInfo.planElementIndex,
+      planInfo.activityType.getOrElse(""),
+      planInfo.activityLocationX.map(_.toString).getOrElse(""),
+      planInfo.activityLocationY.map(_.toString).getOrElse(""),
+      planInfo.activityEndTime.map(_.toString).getOrElse(""),
+      planInfo.legMode.getOrElse(""),
+      planInfo.legDepartureTime.getOrElse(""),
+      planInfo.legTravelTime.getOrElse(""),
+      planInfo.legRouteType.getOrElse(""),
+      planInfo.legRouteStartLink.getOrElse(""),
+      planInfo.legRouteEndLink.getOrElse(""),
+      planInfo.legRouteTravelTime,
+      planInfo.legRouteDistance,
+      planInfo.legRouteLinks
+    ).mkString("", FieldSeparator, LineSeparator)
   }
 
 }

--- a/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
@@ -73,10 +73,10 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
       val houseHoldId: String = personIdToHouseHoldId.get(personId).map(_.toString).getOrElse("")
 
       PersonInfo(
-        PersonId(personId.toString),
-        HouseholdId(houseHoldId),
-        Try(rank.toInt).getOrElse(0),
-        Try(personAge.toInt).getOrElse(0),
+        personId = PersonId(personId.toString),
+        householdId = HouseholdId(houseHoldId),
+        rank = Try(rank.toInt).getOrElse(0),
+        age = Try(personAge.toInt).getOrElse(0),
         isFemale = isFemale,
         valueOfTime = Try(valueOfTime.toString.toDouble).getOrElse(0),
         excludedModes = excludedModes

--- a/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
@@ -1,12 +1,16 @@
 package beam.utils.csv.writers
 
+import java.io.File
+
 import beam.sim.population.AttributesOfIndividual
 import org.matsim.api.core.v01.population.Person
 import org.matsim.api.core.v01.{Id, Scenario}
 import org.matsim.households.Household
 import org.matsim.utils.objectattributes.ObjectAttributes
-
 import scala.collection.JavaConverters._
+import scala.util.Try
+
+import beam.utils.scenario.{HouseholdId, PersonId, PersonInfo}
 
 object PopulationCsvWriter extends ScenarioCsvWriter {
 
@@ -36,41 +40,76 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
 
     val personAttributes: ObjectAttributes = scenario.getPopulation.getPersonAttributes
 
-    scenario.getPopulation.getPersons.values().asScala.toIterator.map { person =>
+    val values: Iterator[PersonInfo] = scenario.getPopulation.getPersons.values().asScala.toIterator.map { person =>
       val maybeAttribs: Option[AttributesOfIndividual] =
         Option(person.getCustomAttributes.get("beam-attributes")).map(_.asInstanceOf[AttributesOfIndividual])
 
-      // `personAttributes.getAttribute(...)` can return `null`
-      val excludedModes = Option(
+      val personId: Id[Person] = person.getId
+
+      val excludedModes: Seq[String] = Option(
         personAttributes
-          .getAttribute(person.getId.toString, "excluded-modes")
-      ).map { attrib =>
-          attrib.toString
-            .replaceAll(",", ArrayItemSeparator)
-            .split(ArrayItemSeparator)
-            .mkString(ArrayStartString, ArrayItemSeparator, ArrayEndString)
-        }
-        .getOrElse("")
+          .getAttribute(personId.toString, "excluded-modes")
+      ) match {
+        case None      => Seq.empty
+        case Some(att) => att.toString.split(",").toSeq
+      }
 
       val personAge = readAge(
         maybeAttribs.flatMap(_.age),
-        Option(personAttributes.getAttribute(person.getId.toString, "age")).map(_.toString.toInt)
+        Option(personAttributes.getAttribute(personId.toString, "age")).map(_.toString.toInt)
       ).map(_.toString).getOrElse("")
 
-      val isMale =
-        maybeAttribs.map(_.isMale).getOrElse(personAttributes.getAttribute(person.getId.toString, "sex") == "F")
-      val values = Seq(
-        person.getId.toString,
-        personAge,
-        !isMale,
-        personIdToHouseHoldId.get(person.getId).map(_.toString).getOrElse(""),
-        String.valueOf(personAttributes.getAttribute(person.getId.toString, "rank")),
-        excludedModes,
-        Option(personAttributes.getAttribute(person.getId.toString, "valueOfTime"))
-          .getOrElse(maybeAttribs.map(_.valueOfTime).getOrElse(8.0))
+      val isFemale = {
+        val isMale = maybeAttribs
+          .map(_.isMale)
+          .getOrElse(personAttributes.getAttribute(personId.toString, "sex") == "F")
+        !isMale
+      }
+      val valueOfTime = Option(personAttributes.getAttribute(personId.toString, "valueOfTime"))
+        .getOrElse(maybeAttribs.map(_.valueOfTime).getOrElse(8.0))
+
+      val rank = String.valueOf(personAttributes.getAttribute(personId.toString, "rank"))
+
+      val houseHoldId: String = personIdToHouseHoldId.get(personId).map(_.toString).getOrElse("")
+
+      PersonInfo(
+        PersonId(personId.toString),
+        HouseholdId(houseHoldId),
+        Try(rank.toInt).getOrElse(0),
+        Try(personAge.toInt).getOrElse(0),
+        isFemale = isFemale,
+        valueOfTime = Try(valueOfTime.toString.toDouble).getOrElse(0),
+        excludedModes = excludedModes
       )
-      values.mkString("", FieldSeparator, LineSeparator)
     }
+    contentIterator(values)
+  }
+
+  override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {
+    elements.flatMap {
+      case e: PersonInfo => Some(toLine(e))
+      case _             => None
+    }
+  }
+
+  private def toLine(personInfo: PersonInfo): String = {
+    val excludedModes = {
+      val excludedModesBeforeConvert = personInfo.excludedModes.mkString(",")
+      excludedModesBeforeConvert
+        .replaceAll(",", ArrayItemSeparator)
+        .split(ArrayItemSeparator)
+        .mkString(ArrayStartString, ArrayItemSeparator, ArrayEndString)
+    }
+    val values = Seq(
+      personInfo.personId,
+      personInfo.age,
+      personInfo.isFemale,
+      personInfo.householdId,
+      personInfo.rank,
+      excludedModes,
+      personInfo.valueOfTime
+    )
+    values.mkString("", FieldSeparator, LineSeparator)
   }
 
 }

--- a/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/PopulationCsvWriter.scala
@@ -40,10 +40,7 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
 
     val personAttributes: ObjectAttributes = scenario.getPopulation.getPersonAttributes
 
-    val values: Iterator[PersonInfo] = scenario.getPopulation.getPersons.values().asScala.toIterator.map { person =>
-      val maybeAttribs: Option[AttributesOfIndividual] =
-        Option(person.getCustomAttributes.get("beam-attributes")).map(_.asInstanceOf[AttributesOfIndividual])
-
+    scenario.getPopulation.getPersons.values().asScala.toIterator.map { person =>
       val personId: Id[Person] = person.getId
 
       val excludedModes: Seq[String] = Option(
@@ -53,6 +50,10 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
         case None      => Seq.empty
         case Some(att) => att.toString.split(",").toSeq
       }
+
+      val maybeAttribs: Option[AttributesOfIndividual] =
+        Option(person.getCustomAttributes.get("beam-attributes"))
+          .map(_.asInstanceOf[AttributesOfIndividual])
 
       val personAge = readAge(
         maybeAttribs.flatMap(_.age),
@@ -72,7 +73,7 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
 
       val houseHoldId: String = personIdToHouseHoldId.get(personId).map(_.toString).getOrElse("")
 
-      PersonInfo(
+      val info = PersonInfo(
         personId = PersonId(personId.toString),
         householdId = HouseholdId(houseHoldId),
         rank = Try(rank.toInt).getOrElse(0),
@@ -81,8 +82,8 @@ object PopulationCsvWriter extends ScenarioCsvWriter {
         valueOfTime = Try(valueOfTime.toString.toDouble).getOrElse(0),
         excludedModes = excludedModes
       )
+      toLine(info)
     }
-    contentIterator(values)
   }
 
   override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {

--- a/src/main/scala/beam/utils/csv/writers/ScenarioCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/ScenarioCsvWriter.scala
@@ -22,7 +22,7 @@ trait ScenarioCsvWriter {
 
   def toCsv(scenario: Scenario): Iterator[String] = header ++ contentIterator(scenario)
 
-  final def toCsv(scenario: Scenario, outputFile: String): File = {
+  def toCsv(scenario: Scenario, outputFile: String): File = {
     FileUtils.writeToFile(outputFile, toCsv(scenario))
     new File(outputFile)
   }

--- a/src/main/scala/beam/utils/csv/writers/ScenarioCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/ScenarioCsvWriter.scala
@@ -18,10 +18,17 @@ trait ScenarioCsvWriter {
 
   def contentIterator(scenario: Scenario): Iterator[String]
 
+  def contentIterator[A](elements: Iterator[A]): Iterator[String]
+
   def toCsv(scenario: Scenario): Iterator[String] = header ++ contentIterator(scenario)
 
-  def toCsv(scenario: Scenario, outputFile: String): File = {
+  final def toCsv(scenario: Scenario, outputFile: String): File = {
     FileUtils.writeToFile(outputFile, toCsv(scenario))
+    new File(outputFile)
+  }
+
+  final def toCsv[A](elements: Iterator[A], outputFile: String): File = {
+    FileUtils.writeToFile(outputFile, contentIterator(elements))
     new File(outputFile)
   }
 

--- a/src/main/scala/beam/utils/csv/writers/VehiclesCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/VehiclesCsvWriter.scala
@@ -4,43 +4,69 @@ import beam.sim.BeamServices
 import com.typesafe.scalalogging.StrictLogging
 import org.matsim.api.core.v01.{Id, Scenario}
 import org.matsim.households.Household
-import org.matsim.vehicles.Vehicle
-
+import org.matsim.vehicles.{Vehicle, VehicleType}
 import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
-class VehiclesCsvWriter(beamServices: BeamServices) extends ScenarioCsvWriter with StrictLogging {
+import beam.agentsim.agents.vehicles.BeamVehicle
+import beam.utils.scenario.VehicleInfo
+
+class VehiclesCsvWriter(idVehicleToVehicleTypeIdAsStr: Map[Id[BeamVehicle], String])
+    extends ScenarioCsvWriter
+    with StrictLogging {
 
   override protected val fields: Seq[String] = Seq("vehicleId", "vehicleTypeId", "householdId")
 
-  private case class VehicleEntry(vehicleId: String, vehicleTypeId: String, householdId: String) {
-    override def toString: String = {
-      Seq(vehicleId, vehicleTypeId, householdId).mkString("", FieldSeparator, LineSeparator)
-    }
-  }
-
-  private def vehicleType(vehicleId: Id[Vehicle]): String = {
-    beamServices.beamScenario.privateVehicles
-      .get(vehicleId)
-      .map(
-        v => v.beamVehicleType.id.toString.trim
-      )
-      .getOrElse("")
+  def vehicleType(vehicleId: Id[BeamVehicle]): String = {
+    idVehicleToVehicleTypeIdAsStr.getOrElse(vehicleId, "")
   }
 
   override def contentIterator(scenario: Scenario): Iterator[String] = {
     val households: mutable.Map[Id[Household], Household] = scenario.getHouseholds.getHouseholds.asScala
 
-    val allVehicles = households.values.flatMap { hh =>
+    val allVehicles: Iterable[VehicleInfo] = households.values.flatMap { hh =>
       hh.getVehicleIds.asScala.map { id: Id[Vehicle] =>
-        VehicleEntry(id.toString, vehicleType(id), hh.getId.toString).toString
+        VehicleInfo(id.toString, vehicleType(id), hh.getId.toString)
       }
     }
-    allVehicles.toIterator
+    contentIterator(allVehicles.toIterator)
+  }
+
+  override def contentIterator[A](elements: Iterator[A]): Iterator[String] = {
+    elements.flatMap { item =>
+      item match {
+        case vehicleInfo: VehicleInfo =>
+          val result = Seq(
+            vehicleInfo.vehicleId,
+            vehicleInfo.vehicleTypeId,
+            vehicleInfo.householdId
+          ).mkString("", FieldSeparator, LineSeparator)
+          Some(result)
+        case _ => None
+      }
+    }
   }
 
 }
 
 object VehiclesCsvWriter {
-  def apply(beamServices: BeamServices): VehiclesCsvWriter = new VehiclesCsvWriter(beamServices)
+
+  def apply(beamServices: BeamServices): VehiclesCsvWriter = {
+    val pVehicles: Map[Id[BeamVehicle], String] = beamServices.beamScenario.privateVehicles.map {
+      case (id: Id[BeamVehicle], vehicle: BeamVehicle) =>
+        id -> vehicle.beamVehicleType.id.toString.trim
+    }.toMap
+    new VehiclesCsvWriter(pVehicles)
+  }
+
+  def apply(elements: Iterable[VehicleInfo]): VehiclesCsvWriter = {
+    val pVehicles: Map[Id[BeamVehicle], String] = elements.map { vehicleInfo: VehicleInfo =>
+      val id = Id.create(vehicleInfo.vehicleId, classOf[BeamVehicle])
+      val vehicleTypeId = vehicleInfo.vehicleTypeId
+      id -> vehicleTypeId
+    }.toMap
+    new VehiclesCsvWriter(pVehicles)
+  }
+
 }

--- a/src/main/scala/beam/utils/csv/writers/VehiclesCsvWriter.scala
+++ b/src/main/scala/beam/utils/csv/writers/VehiclesCsvWriter.scala
@@ -24,7 +24,7 @@ class VehiclesCsvWriter(idVehicleToVehicleTypeIdAsStr: Map[Id[BeamVehicle], Stri
   override def contentIterator(scenario: Scenario): Iterator[String] = {
     val households: mutable.Map[Id[Household], Household] = scenario.getHouseholds.getHouseholds.asScala
 
-    val allVehicles: Iterator[VehicleInfo] = households.values.iterator.flatMap { hh =>
+    val allVehicles = households.values.iterator.flatMap { hh =>
       hh.getVehicleIds.asScala.map { id: Id[Vehicle] =>
         VehicleInfo(id.toString, vehicleType(id), hh.getId.toString)
       }

--- a/src/main/scala/beam/utils/data/synthpop/PumaLevelScenarioGenerator.scala
+++ b/src/main/scala/beam/utils/data/synthpop/PumaLevelScenarioGenerator.scala
@@ -225,7 +225,7 @@ class PumaLevelScenarioGenerator(
                             householdId = createdHousehold.householdId,
                             rank = 0,
                             age = person.age,
-                            excludedModes = "",
+                            excludedModes = Seq.empty,
                             isFemale = person.gender == Gender.Female,
                             valueOfTime = valueOfTime
                           )

--- a/src/main/scala/beam/utils/data/synthpop/ScenarioGenerator.scala
+++ b/src/main/scala/beam/utils/data/synthpop/ScenarioGenerator.scala
@@ -293,7 +293,7 @@ class SimpleScenarioGenerator(
                         householdId = createdHousehold.householdId,
                         rank = 0,
                         age = person.age,
-                        excludedModes = "",
+                        excludedModes = Seq.empty,
                         isFemale = person.gender == Gender.Female,
                         valueOfTime = valueOfTime
                       )

--- a/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
+++ b/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
@@ -2,15 +2,16 @@ package beam.utils.plan.sampling
 
 import java.util
 
+import scala.collection.JavaConverters
+
 import beam.router.Modes.BeamMode
 import beam.sim.BeamScenario
 import beam.sim.population.{AttributesOfIndividual, PopulationAdjustment}
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.lang3.StringUtils.isBlank
 import org.matsim.api.core.v01.population.{Person, Plan, Population}
 import org.matsim.core.population.algorithms.PermissibleModesCalculator
 import org.matsim.households.Household
-
-import scala.collection.JavaConverters
 
 /**
   * Several utility/convenience methods for mode availability. Note that the MATSim convention
@@ -36,16 +37,13 @@ object AvailableModeUtils extends LazyLogging {
     * @return List of excluded mode string
     */
   def getExcludedModesForPerson(population: Population, personId: String): Array[String] = {
-    Option(
+    val maybeExcludedModes = Option(
       population.getPersonAttributes.getAttribute(personId, PopulationAdjustment.EXCLUDED_MODES)
-    ).map(_.toString) match {
-      case Some(modes) =>
-        if (modes.isEmpty) {
-          Array.empty[String]
-        } else {
-          modes.split(",")
-        }
-      case None => Array.empty[String]
+    )
+    maybeExcludedModes match {
+      case Some(modes: Iterable[_])   => modes.map(_.toString).filterNot(v => isBlank(v)).toArray
+      case Some(modes: Array[String]) => modes.filterNot(v => isBlank(v))
+      case _                          => Array.empty[String]
     }
   }
 

--- a/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
+++ b/src/main/scala/beam/utils/plan/sampling/AvailableModeUtils.scala
@@ -40,9 +40,11 @@ object AvailableModeUtils extends LazyLogging {
     val maybeExcludedModes = Option(
       population.getPersonAttributes.getAttribute(personId, PopulationAdjustment.EXCLUDED_MODES)
     )
+    maybeExcludedModes.map(_.toString)
     maybeExcludedModes match {
-      case Some(modes: Iterable[_])   => modes.map(_.toString).filterNot(v => isBlank(v)).toArray
-      case Some(modes: Array[String]) => modes.filterNot(v => isBlank(v))
+      case Some(modes: Array[String]) => modes.filterNot(isBlank)
+      case Some(modes: Iterable[_])   => modes.flatMap(_.toString.split(",")).filterNot(isBlank).toArray
+      case Some(modes)                => modes.toString.split(",").filterNot(isBlank)
       case _                          => Array.empty[String]
     }
   }

--- a/src/main/scala/beam/utils/scenario/Models.scala
+++ b/src/main/scala/beam/utils/scenario/Models.scala
@@ -10,7 +10,8 @@ case class PersonInfo(
   rank: Int,
   age: Int,
   isFemale: Boolean,
-  valueOfTime: Double
+  valueOfTime: Double,
+  excludedModes: Seq[String] = Seq.empty
 )
 
 case class PlanElement(

--- a/src/main/scala/beam/utils/scenario/Models.scala
+++ b/src/main/scala/beam/utils/scenario/Models.scala
@@ -9,10 +9,9 @@ case class PersonInfo(
   householdId: HouseholdId,
   rank: Int,
   age: Int,
-  excludedModes: String,
   isFemale: Boolean,
   valueOfTime: Double,
-  excludedModes: Seq[String] = Seq.empty
+  excludedModes: Seq[String] = Seq.empty,
 )
 
 case class PlanElement(

--- a/src/main/scala/beam/utils/scenario/Models.scala
+++ b/src/main/scala/beam/utils/scenario/Models.scala
@@ -9,9 +9,9 @@ case class PersonInfo(
   householdId: HouseholdId,
   rank: Int,
   age: Int,
-  isFemale: Boolean,
-  valueOfTime: Double,
   excludedModes: Seq[String] = Seq.empty,
+  isFemale: Boolean,
+  valueOfTime: Double
 )
 
 case class PlanElement(

--- a/src/main/scala/beam/utils/scenario/generic/readers/PersonInfoReader.scala
+++ b/src/main/scala/beam/utils/scenario/generic/readers/PersonInfoReader.scala
@@ -27,7 +27,7 @@ object CsvPersonInfoReader extends PersonInfoReader {
     val age = getIfNotNull(rec, "age").toInt
     val isFemale = getIfNotNull(rec, "isFemale").toBoolean
     val rank = getIfNotNull(rec, "householdRank").toInt
-    val excludedModes = Try(getIfNotNull(rec, "excludedModes")).getOrElse("")
+    val excludedModes = Try(getIfNotNull(rec, "excludedModes")).getOrElse("").split(",")
     val valueOfTime = NumberUtils.toDouble(Try(getIfNotNull(rec, "valueOfTime")).getOrElse("0"), 0D)
     PersonInfo(
       personId = PersonId(personId),

--- a/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioSource.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/UrbanSimScenarioSource.scala
@@ -37,7 +37,7 @@ class UrbanSimScenarioSource(
         householdId = HouseholdId(person.householdId),
         rank = person.rank,
         age = person.age,
-        excludedModes = person.excludedModes,
+        excludedModes = person.excludedModes.split(","),
         isFemale = person.isFemale,
         valueOfTime = person.valueOfTime
       )

--- a/src/main/scala/beam/utils/scenario/urbansim/censusblock/merger/PersonMerger.scala
+++ b/src/main/scala/beam/utils/scenario/urbansim/censusblock/merger/PersonMerger.scala
@@ -12,12 +12,12 @@ class PersonMerger(inputHousehold: Map[String, InputHousehold]) extends Merger[I
     val income = PopulationAdjustment.incomeToValueOfTime(inputIncome).getOrElse(0d)
 
     PersonInfo(
-      PersonId(inputPersonInfo.personId),
-      HouseholdId(inputPersonInfo.householdId),
-      0,
-      inputPersonInfo.age,
-      inputPersonInfo.sex.isFemale,
-      income.toDouble
+      personId = PersonId(inputPersonInfo.personId),
+      householdId = HouseholdId(inputPersonInfo.householdId),
+      rank = 0,
+      age = inputPersonInfo.age,
+      isFemale = inputPersonInfo.sex.isFemale,
+      valueOfTime = income.toDouble
     )
   }
 }

--- a/src/test/scala/beam/utils/scenario/UrbanSimScenarioLoaderTest.scala
+++ b/src/test/scala/beam/utils/scenario/UrbanSimScenarioLoaderTest.scala
@@ -6,7 +6,7 @@ import beam.sim.config.BeamConfig
 import beam.utils.TestConfigUtils.testConfig
 import org.matsim.core.scenario.MutableScenario
 import org.mockito.Mockito.when
-import org.scalatest.{Assertion, AsyncWordSpec, BeforeAndAfterEach, Matchers}
+import org.scalatest.{AsyncWordSpec, BeforeAndAfterEach, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 class UrbanSimScenarioLoaderTest extends AsyncWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
@@ -142,7 +142,7 @@ class UrbanSimScenarioLoaderTest extends AsyncWordSpec with Matchers with Mockit
   private def assertCarNumbers(
     result: Iterable[(HouseholdInfo, Int)],
     householdId2ExpectedCarNumbers: (String, Int)*
-  ): Assertion = {
+  ) = {
     result.size shouldBe householdId2ExpectedCarNumbers.size
 
     result

--- a/src/test/scala/beam/utils/scenario/UrbanSimScenarioLoaderTest.scala
+++ b/src/test/scala/beam/utils/scenario/UrbanSimScenarioLoaderTest.scala
@@ -6,7 +6,7 @@ import beam.sim.config.BeamConfig
 import beam.utils.TestConfigUtils.testConfig
 import org.matsim.core.scenario.MutableScenario
 import org.mockito.Mockito.when
-import org.scalatest.{AsyncWordSpec, BeforeAndAfterEach, Matchers}
+import org.scalatest.{Assertion, AsyncWordSpec, BeforeAndAfterEach, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 class UrbanSimScenarioLoaderTest extends AsyncWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
@@ -129,12 +129,20 @@ class UrbanSimScenarioLoaderTest extends AsyncWordSpec with Matchers with Mockit
   private def household(cars: Int) = HouseholdInfo(HouseholdId(idIter.next().toString), cars, 123.0, 1.0, 1.0)
 
   private def person(householdId: HouseholdId) =
-    PersonInfo(PersonId(idIter.next().toString), householdId, 123, 30, false, 0.0)
+    PersonInfo(
+      personId = PersonId(idIter.next().toString),
+      householdId = householdId,
+      rank = 123,
+      age = 30,
+      isFemale = false,
+      excludedModes = Seq.empty,
+      valueOfTime = 0.0
+    )
 
   private def assertCarNumbers(
     result: Iterable[(HouseholdInfo, Int)],
     householdId2ExpectedCarNumbers: (String, Int)*
-  ) = {
+  ): Assertion = {
     result.size shouldBe householdId2ExpectedCarNumbers.size
 
     result


### PR DESCRIPTION
Resolves #2894 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2961)
<!-- Reviewable:end -->

Example of usage below:
```Scala
// Implicits supports conversion from Iterable and also Array
import beam.utils.csv.readers.BeamCsvScenarioReader
import beam.utils.csv.writers.BeamCsvScenarioWriter._

val vehicles: Iterable[VehicleInfo] =
  BeamCsvScenarioReader.readVehiclesFile("vehicles.csv")
vehicles.writeCsvVehiclesFile("vehicles_output.csv")

val households: Array[HouseholdInfo] =
  BeamCsvScenarioReader.readHouseholdsFile("householdsFile.csv", vehicles)
vehicles.writeCsvVehiclesFile("households_output.csv")

val persons: Array[PersonInfo] =
  BeamCsvScenarioReader.readPersonsFile("persons.csv")
persons.writeCsvPersonsFile("persons_out.csv")
```