### PR TITLE
Bug: ODSkimmer writes full skim with incorrect order of columns

### DIFF
--- a/src/main/scala/beam/router/skim/ODSkimmer.scala
+++ b/src/main/scala/beam/router/skim/ODSkimmer.scala
@@ -191,9 +191,11 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
             uniqueModes.foreach { mode =>
               uniqueTimeBins
                 .foreach { timeBin =>
-                  val theSkim: ODSkimmer.Skim = currentSkim
+                  val internalSkimmer = currentSkim
                     .get(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
-                    .map(_.asInstanceOf[ODSkimmerInternal].toSkimExternal)
+                    .map(_.asInstanceOf[ODSkimmerInternal])
+                  val theSkim: ODSkimmer.Skim = internalSkimmer
+                    .map(_.toSkimExternal)
                     .getOrElse {
                       if (origin.equals(destination)) {
                         val newDestCoord = new Coord(
@@ -225,7 +227,9 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
                     }
 
                   writer.write(
-                    s"$timeBin,$mode,${origin.tazId},${destination.tazId},${theSkim.time},${theSkim.generalizedTime},${theSkim.cost},${theSkim.generalizedTime},${theSkim.distance},${theSkim.count},${theSkim.energy}\n"
+                    s"$timeBin,$mode,${origin.tazId},${destination.tazId},${theSkim.time},${theSkim.generalizedTime},${theSkim.cost},${theSkim.generalizedCost},${theSkim.distance},${theSkim.energy},${theSkim.count},${internalSkimmer
+                      .map(_.iterations)
+                      .getOrElse(0)}\n"
                   )
                 }
             }


### PR DESCRIPTION
- `generalizedTime` was written twice (the second time it should have been `generalizedCost`), fixed it. Now we write `generalizedCost`
- Fix the order of columns `count` and `energy`
- Added the value for `iterations` column

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/2984)
<!-- Reviewable:end -->
