### PR TITLE
RideHailMatching: Per thread GeodeticCalculator

### DIFF
--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailMatching.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailMatching.scala
@@ -83,12 +83,14 @@ object RideHailMatching {
       s"${requests.size} requests and this schedule: ${schedule.map(_.toString).mkString("\n")}"
   }
 
+  val geodeticCalculatorPerThread: ThreadLocal[GeodeticCalculator] =
+    ThreadLocal.withInitial[GeodeticCalculator](() => new GeodeticCalculator(DefaultGeographicCRS.WGS84))
+
   def checkAngle(origin: Coord, dest1: Coord, dest2: Coord)(implicit services: BeamServices): Boolean = {
-    val crs = DefaultGeographicCRS.WGS84
+    val calc = geodeticCalculatorPerThread.get()
     val orgWgs = services.geo.utm2Wgs.transform(origin)
     val dst1Wgs = services.geo.utm2Wgs.transform(dest1)
     val dst2Wgs = services.geo.utm2Wgs.transform(dest2)
-    val calc = new GeodeticCalculator(crs)
     val gf = new GeometryFactory()
     val point1 = gf.createPoint(new Coordinate(orgWgs.getX, orgWgs.getY))
     calc.setStartingGeographicPoint(point1.getX, point1.getY)


### PR DESCRIPTION
## Summary
Optimized version increased AVG CPU utilization from 28.8% to 36% by removing thread contention. As a result of increased CPU utilization the total AgentSim time is reduced from 31908 seconds (08h:51m:48s) to 26156 seconds (07h:15m:56s), around 21% of improvement.

### AVG CPU utilization (left - before optimization, right - after optimization)
![image](https://user-images.githubusercontent.com/5107562/95989784-e95a8f00-0e54-11eb-894c-f18de85281a9.png)

### Thread contention (left - before optimization, right - after optimization)
![image](https://user-images.githubusercontent.com/5107562/95990064-3fc7cd80-0e55-11eb-9014-104f8b4a3a96.png)

## Links
- Before optimization: https://s3.us-east-2.amazonaws.com/beam-outputs/index.html#output/austin/austin-prod-full-after-opt-commits__2020-10-12_18-02-42_ebp/
- After optimization: https://s3.us-east-2.amazonaws.com/beam-outputs/index.html#output/austin/austin-prod-full-thread-local-geo-calc__2020-10-13_16-22-14_hud/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3043)
<!-- Reviewable:end -->
