### PR TITLE
Optimize abstract skimmer

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/ChargingNetworkManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingNetworkManager.scala
@@ -64,7 +64,6 @@ class ChargingNetworkManager(
   private def currentTimeBin(tick: Int): Int = cnmConfig.timeStepInSeconds * (tick / cnmConfig.timeStepInSeconds).toInt
   private def nextTimeBin(tick: Int): Int = currentTimeBin(tick) + cnmConfig.timeStepInSeconds
 
-
   var timeSpentToPlanEnergyDispatchTrigger: Long = 0
   var nHandledPlanEnergyDispatchTrigger: Int = 0
 
@@ -144,7 +143,7 @@ class ChargingNetworkManager(
       val e = System.currentTimeMillis()
       nHandledPlanEnergyDispatchTrigger += 1
       timeSpentToPlanEnergyDispatchTrigger += e - s
-      
+
       sender ! CompletionNotice(triggerId, triggers.toIndexedSeq ++ nextStepPlanningTriggers)
 
     case TriggerWithId(ChargingTimeOutTrigger(tick, vehicleId, vehicleManager), triggerId) =>

--- a/src/main/scala/beam/agentsim/infrastructure/ChargingNetworkManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingNetworkManager.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.infrastructure
 
 import akka.actor.Status.Failure
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
 import beam.agentsim.Resource.ReleaseParkingStall
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.Id
 
 import java.util.concurrent.TimeUnit
 import scala.language.postfixOps
+import scala.concurrent.duration._
 
 /**
   * Created by haitamlaarabi
@@ -63,13 +64,37 @@ class ChargingNetworkManager(
   private def currentTimeBin(tick: Int): Int = cnmConfig.timeStepInSeconds * (tick / cnmConfig.timeStepInSeconds).toInt
   private def nextTimeBin(tick: Int): Int = currentTimeBin(tick) + cnmConfig.timeStepInSeconds
 
+
+  var timeSpentToPlanEnergyDispatchTrigger: Long = 0
+  var nHandledPlanEnergyDispatchTrigger: Int = 0
+
+  val maybeDebugReport: Option[Cancellable] = if (beamServices.beamConfig.beam.debug.debugEnabled) {
+    Some(context.system.scheduler.scheduleWithFixedDelay(10.seconds, 30.seconds, self, DebugReport)(context.dispatcher))
+  } else {
+    None
+  }
+
+  override def postStop: Unit = {
+    maybeDebugReport.foreach(_.cancel())
+    log.info(
+      s"timeSpentToPlanEnergyDispatchTrigger: ${timeSpentToPlanEnergyDispatchTrigger} ms, nHandledPlanEnergyDispatchTrigger: ${nHandledPlanEnergyDispatchTrigger}, AVG: ${timeSpentToPlanEnergyDispatchTrigger.toDouble / nHandledPlanEnergyDispatchTrigger}"
+    )
+    super.postStop()
+  }
+
   override def receive: Receive = {
+    case DebugReport =>
+      log.info(
+        s"timeSpentToPlanEnergyDispatchTrigger: ${timeSpentToPlanEnergyDispatchTrigger} ms, nHandledPlanEnergyDispatchTrigger: ${nHandledPlanEnergyDispatchTrigger}, AVG: ${timeSpentToPlanEnergyDispatchTrigger.toDouble / nHandledPlanEnergyDispatchTrigger}"
+      )
+
     case TriggerWithId(InitializeTrigger(_), triggerId) =>
       Future(scheduler ? ScheduleTrigger(PlanEnergyDispatchTrigger(0), self))
         .map(_ => CompletionNotice(triggerId, Vector()))
         .pipeTo(sender())
 
     case TriggerWithId(PlanEnergyDispatchTrigger(timeBin), triggerId) =>
+      val s = System.currentTimeMillis
       log.debug(s"Planning energy dispatch for vehicles currently connected to a charging point, at t=$timeBin")
       val estimatedLoad = requiredPowerInKWOverNextPlanningHorizon(timeBin)
       log.debug("Total Load estimated is {} at tick {}", estimatedLoad.values.sum, timeBin)
@@ -116,6 +141,10 @@ class ChargingNetworkManager(
         completeChargingAndTheDisconnectionOfAllConnectedVehiclesAtEndOfSimulation(timeBin, physicalBounds)
       }
 
+      val e = System.currentTimeMillis()
+      nHandledPlanEnergyDispatchTrigger += 1
+      timeSpentToPlanEnergyDispatchTrigger += e - s
+      
       sender ! CompletionNotice(triggerId, triggers.toIndexedSeq ++ nextStepPlanningTriggers)
 
     case TriggerWithId(ChargingTimeOutTrigger(tick, vehicleId, vehicleManager), triggerId) =>
@@ -355,6 +384,7 @@ class ChargingNetworkManager(
 }
 
 object ChargingNetworkManager {
+  object DebugReport
   case class ChargingZonesInquiry()
   case class PlanEnergyDispatchTrigger(tick: Int) extends Trigger
   case class ChargingTimeOutTrigger(tick: Int, vehicleId: Id[BeamVehicle], managerId: Id[VehicleManager])

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -2,6 +2,7 @@ package beam.router.skim.core
 
 import beam.agentsim.events.ScalaEvent
 import beam.router.skim.CsvSkimReader
+import beam.router.skim.core.TAZSkimmer.TAZSkimmerKey
 import beam.sim.BeamWarmStart
 import beam.sim.config.BeamConfig
 import beam.utils.{FileUtils, ProfilingUtils}
@@ -14,7 +15,9 @@ import org.matsim.core.events.handler.BasicEventHandler
 
 import java.io.BufferedWriter
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.reflect.io.File
 import scala.util.control.NonFatal
@@ -38,14 +41,21 @@ abstract class AbstractSkimmerEvent(eventTime: Double) extends Event(eventTime) 
 
 abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] var currentIterationInternal: Int = -1
-  private[core] val currentSkimInternal = mutable.HashMap.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
+  private[core] val currentSkimInternal = new ConcurrentHashMap[AbstractSkimmerKey, AbstractSkimmerInternal]()
   private[core] var aggregatedFromPastSkimsInternal = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
 
   def currentIteration: Int = currentIterationInternal
-  def currentSkim: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = currentSkimInternal.toMap
+
+  /**
+   *  This method creates a copy of `currentSkimInternal`, so careful when you use it often! Consider using `getCurrentSkimValue` in such scenario
+   *  or expose other method to access `currentSkimInternal`
+   */
+  def currentSkim: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = currentSkimInternal.asScala.toMap
+  def getCurrentSkimValue(key: AbstractSkimmerKey): Option[AbstractSkimmerInternal] = Option(currentSkimInternal.get(key))
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
+  def isEmpty: Boolean = currentSkimInternal.isEmpty
 }
 
 abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirectoryHierarchy)
@@ -104,9 +114,9 @@ abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirec
     if (beamConfig.beam.routing.overrideNetworkTravelTimesUsingSkims) {
       logger.warn("skim aggregation is skipped as 'overrideNetworkTravelTimesUsingSkims' enabled")
     } else {
-      aggregatedFromPastSkimsInternal = (aggregatedFromPastSkimsInternal.keySet ++ currentSkimInternal.keySet).map {
+      aggregatedFromPastSkimsInternal = (aggregatedFromPastSkimsInternal.keySet ++ currentSkimInternal.asScala.keySet).map {
         key =>
-          key -> aggregateOverIterations(aggregatedFromPastSkimsInternal.get(key), currentSkimInternal.get(key))
+          key -> aggregateOverIterations(aggregatedFromPastSkimsInternal.get(key), Option(currentSkimInternal.get(key)))
       }.toMap
     }
     // write
@@ -118,10 +128,10 @@ abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirec
   override def handleEvent(event: Event): Unit = {
     event match {
       case e: AbstractSkimmerEvent if e.getEventType == eventType =>
-        currentSkimInternal.update(
-          e.getKey,
-          aggregateWithinIteration(currentSkimInternal.get(e.getKey), e.getSkimmerInternal)
-        )
+        currentSkimInternal.compute(e.getKey, (_, v) => {
+          val value = if (v == null) aggregateWithinIteration(None, e.getSkimmerInternal) else aggregateWithinIteration(Some(v), e.getSkimmerInternal)
+          value
+        })
       case _ =>
     }
   }

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -48,11 +48,13 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   def currentIteration: Int = currentIterationInternal
 
   /**
-   *  This method creates a copy of `currentSkimInternal`, so careful when you use it often! Consider using `getCurrentSkimValue` in such scenario
-   *  or expose other method to access `currentSkimInternal`
-   */
+    *  This method creates a copy of `currentSkimInternal`, so careful when you use it often! Consider using `getCurrentSkimValue` in such scenario
+    *  or expose other method to access `currentSkimInternal`
+    */
   def currentSkim: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = currentSkimInternal.asScala.toMap
-  def getCurrentSkimValue(key: AbstractSkimmerKey): Option[AbstractSkimmerInternal] = Option(currentSkimInternal.get(key))
+
+  def getCurrentSkimValue(key: AbstractSkimmerKey): Option[AbstractSkimmerInternal] =
+    Option(currentSkimInternal.get(key))
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
   def isEmpty: Boolean = currentSkimInternal.isEmpty
@@ -114,10 +116,10 @@ abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirec
     if (beamConfig.beam.routing.overrideNetworkTravelTimesUsingSkims) {
       logger.warn("skim aggregation is skipped as 'overrideNetworkTravelTimesUsingSkims' enabled")
     } else {
-      aggregatedFromPastSkimsInternal = (aggregatedFromPastSkimsInternal.keySet ++ currentSkimInternal.asScala.keySet).map {
-        key =>
+      aggregatedFromPastSkimsInternal =
+        (aggregatedFromPastSkimsInternal.keySet ++ currentSkimInternal.asScala.keySet).map { key =>
           key -> aggregateOverIterations(aggregatedFromPastSkimsInternal.get(key), Option(currentSkimInternal.get(key)))
-      }.toMap
+        }.toMap
     }
     // write
     writeToDisk(event)
@@ -128,10 +130,15 @@ abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirec
   override def handleEvent(event: Event): Unit = {
     event match {
       case e: AbstractSkimmerEvent if e.getEventType == eventType =>
-        currentSkimInternal.compute(e.getKey, (_, v) => {
-          val value = if (v == null) aggregateWithinIteration(None, e.getSkimmerInternal) else aggregateWithinIteration(Some(v), e.getSkimmerInternal)
-          value
-        })
+        currentSkimInternal.compute(
+          e.getKey,
+          (_, v) => {
+            val value =
+              if (v == null) aggregateWithinIteration(None, e.getSkimmerInternal)
+              else aggregateWithinIteration(Some(v), e.getSkimmerInternal)
+            value
+          }
+        )
       case _ =>
     }
   }

--- a/src/main/scala/beam/router/skim/core/DriveTimeSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/DriveTimeSkimmer.scala
@@ -57,12 +57,12 @@ class DriveTimeSkimmer @Inject()(
                 val key = PathCache(origin.tazId, destination.tazId, timeBin)
                 observedTravelTimes.get(key).foreach { timeObserved =>
                   val theSkimKey = DriveTimeSkimmerKey(origin.tazId, destination.tazId, timeBin * 3600)
-                  currentSkimInternal.get(theSkimKey).map(_.asInstanceOf[DriveTimeSkimmerInternal]).foreach {
+                  getCurrentSkimValue(theSkimKey).map(_.asInstanceOf[DriveTimeSkimmerInternal]).foreach {
                     theSkimInternal =>
                       series += ((theSkimInternal.observations, theSkimInternal.timeSimulated, timeObserved))
                       for (_ <- 1 to theSkimInternal.observations)
                         deltasOfObservedSimulatedTimes += theSkimInternal.timeSimulated - timeObserved
-                      currentSkimInternal.update(theSkimKey, theSkimInternal.copy(timeObserved = timeObserved))
+                      currentSkimInternal.put(theSkimKey, theSkimInternal.copy(timeObserved = timeObserved))
                   }
                 }
               }

--- a/src/main/scala/beam/router/skim/core/ODSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/ODSkimmer.scala
@@ -198,8 +198,9 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
             uniqueModes.foreach { mode =>
               uniqueTimeBins
                 .foreach { timeBin =>
-                  val internalSkimmer = getCurrentSkimValue(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
-                    .map(_.asInstanceOf[ODSkimmerInternal])
+                  val internalSkimmer =
+                    getCurrentSkimValue(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
+                      .map(_.asInstanceOf[ODSkimmerInternal])
                   val theSkim: ODSkimmer.Skim = internalSkimmer
                     .map(_.toSkimExternal)
                     .getOrElse {

--- a/src/main/scala/beam/router/skim/core/ODSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/ODSkimmer.scala
@@ -177,7 +177,7 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
       event.getServices.getIterationNumber,
       skimFileBaseName + "Full.csv.gz"
     )
-    val uniqueModes = currentSkimInternal.keys.map(key => key.asInstanceOf[ODSkimmerKey].mode).toList.distinct
+    val uniqueModes = currentSkim.keys.map(key => key.asInstanceOf[ODSkimmerKey].mode).toList.distinct
     val uniqueTimeBins = 0 to 23
 
     val dummyId = Id.create(
@@ -198,8 +198,7 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
             uniqueModes.foreach { mode =>
               uniqueTimeBins
                 .foreach { timeBin =>
-                  val internalSkimmer = currentSkimInternal
-                    .get(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
+                  val internalSkimmer = getCurrentSkimValue(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
                     .map(_.asInstanceOf[ODSkimmerInternal])
                   val theSkim: ODSkimmer.Skim = internalSkimmer
                     .map(_.toSkimExternal)
@@ -263,8 +262,7 @@ class ODSkimmer @Inject()(matsimServices: MatsimServices, beamScenario: BeamScen
   ): ExcerptData = {
     import scala.language.implicitConversions
     val individualSkims = hoursIncluded.map { timeBin =>
-      currentSkimInternal
-        .get(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
+      getCurrentSkimValue(ODSkimmerKey(timeBin, mode, origin.tazId, destination.tazId))
         .map(_.asInstanceOf[ODSkimmerInternal].toSkimExternal)
         .getOrElse {
           val adjustedDestCoord = if (origin.equals(destination)) {

--- a/src/main/scala/beam/router/skim/readonly/TAZSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TAZSkims.scala
@@ -8,10 +8,10 @@ import org.matsim.api.core.v01.Id
 
 case class TAZSkims(beamScenario: BeamScenario) extends AbstractSkimmerReadOnly {
 
-  def isPartialSkimEmpty: Boolean = currentSkim.isEmpty
+  def isPartialSkimEmpty: Boolean = isEmpty
 
   def getPartialSkim(time: Int, taz: Id[TAZ], hex: String, actor: String, key: String): Option[TAZSkimmerInternal] =
-    currentSkim.get(TAZSkimmerKey(time, taz, hex, actor, key)).asInstanceOf[Option[TAZSkimmerInternal]]
+    getCurrentSkimValue(TAZSkimmerKey(time, taz, hex, actor, key)).asInstanceOf[Option[TAZSkimmerInternal]]
 
   def getPartialSkim(time: Int, hex: String, actor: String, key: String): Option[TAZSkimmerInternal] =
     getPartialSkim(time, beamScenario.h3taz.getTAZ(hex), hex, actor, key)


### PR DESCRIPTION
Latest production run on smart-baseline scenario with twice lower population has bad performance for 0-th iteration. Decided to add some logs  and collect stats from profiler. Here what I saw:
![image](https://user-images.githubusercontent.com/5107562/109707457-c4c93e80-7bcc-11eb-941d-5c855ae2e915.png)

```
15:54:50.193 [ClusterSystem-akka.actor.default-dispatcher-90] INFO  b.a.scheduler.BeamAgentScheduler - Hour 59.5 completed. 73.3(GB)
15:55:02.950 [ClusterSystem-akka.actor.default-dispatcher-100] INFO  b.a.i.ChargingNetworkManager - timeSpentToPlanEnergyDispatchTrigger: 2624753 ms, nHandledPlanEnergyDispatchTrigger: 717, AVG: 3660.7433751743374
15:55:15.516 [ClusterSystem-akka.actor.default-dispatcher-65] INFO  b.a.scheduler.BeamAgentScheduler - Hour 60.0 completed. 91.3(GB)
15:55:15.517 [ClusterSystem-akka.actor.default-dispatcher-17] INFO  b.a.scheduler.BeamAgentScheduler - Stopping BeamAgentScheduler @ tick 216001. Iteration 0 executed in 3309 seconds
```
0-th iteration took 3309 seconds, but ChargingNetworkManager on it's own it spent 2624 seconds handling PlanEnergyDispatchTrigger message.
If I look to the profiler, I can see it spend a lot of time creating [copy of mutable hasmap](https://github.com/LBNL-UCB-STI/beam/blob/f570ce5c95e246e63e8d00d66f91dfa40c966c56/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala#L46):
![image](https://user-images.githubusercontent.com/5107562/109707397-b4b15f00-7bcc-11eb-8e8b-2141d2dbef16.png)

Link to the run results with logs: https://s3.us-east-2.amazonaws.com/beam-outputs/index.html#output/sfbay/sfbay-smartbase__2021-03-02_14-59-13_gpk/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3131)
<!-- Reviewable:end -->
