### PR TITLE
Docker: NERSC friendly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -620,6 +620,7 @@ task createDockerfile(type: Dockerfile, dependsOn: dockerSyncBuildContext) {
     instruction 'RUN pip3 install numpy pandas cython sklearn matplotlib mapclassify descartes geopandas contextily plotly collections-extended psutil requests'
     environmentVariable 'JAVA_OPTS', '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'
     workingDir("/app")
+    instruction 'RUN mkdir /app/output'
     // Beam dependencies, resources and compiled Java classes
     copyFile("libs", "libs")
     copyFile("resources", "resources")


### PR DESCRIPTION
Explicitly create /app/output for NERSC environment. Without this change when I try to run Beam in Docker in NERSC I get the following error:
```
abalaian@cori02:~> shifter -V /global/cscratch1/sd/abalaian/beam/output:/app/output --image=beammodel/beam:0.8.6 /app/entrypoint.sh --config /app/test/input/beamville/beam.conf
FAILED to create volume "to": /var/udiMount//app/output, cannot create mount points in that location
FAILED to setup user-requested mounts.
FAILED to setup image.
```

After [applying this change](https://hub.docker.com/layers/beammodel/beam/0.8.6.4-nersc/images/sha256-e6b8736d98b467d6cac527770696155cf6f16abc2f42d084210bc928b2e2a8fc?context=repo) it can successfully run it in NERSC:
```
abalaian@cori02:~> shifterimg pull beammodel/beam:0.8.6.4-nersc
2021-03-24T05:54:42 Pulling Image: docker:beammodel/beam:0.8.6.4-nersc, status: READY
abalaian@cori02:~> shifter --image=beammodel/beam:0.8.6.4-nersc /app/entrypoint.sh --config /app/test/input/beamville/beam.conf
OpenJDK 64-Bit Server VM warning: Unable to open cgroup memory limit file /sys/fs/cgroup/memory/memory.limit_in_bytes (No such file or directory)

  ________
  ___  __ )__________ _______ ___
  __  __  |  _ \  __ `/_  __ `__ \
  _  /_/ //  __/ /_/ /_  / / / / /
  /_____/ \___/\__,_/ /_/ /_/ /_/

 _____________________________________


Received 2 arguments: List(--config, /app/test/input/beamville/beam.conf)
Java version: 1.8.0_222
JVM args: List(-XX:+UnlockExperimentalVMOptions, -XX:+UseCGroupMemoryLimitForHeap)
Heap size: 1.9 GB
Heap max memory: 26.7 GB
Heap free memory: 1.8 GB
05:55:50.016 INFO  beam.sim.RunBeam$ -
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3149)
<!-- Reviewable:end -->
