### PR TITLE
Added option to convert Physsim network to pbf directly

### DIFF
--- a/src/test/scala/beam/router/PhyssymXmlToOsmConverter.scala
+++ b/src/test/scala/beam/router/PhyssymXmlToOsmConverter.scala
@@ -68,7 +68,6 @@ object PhyssymXmlToOsmConverter extends StrictLogging {
               startElement.getAttributeByName(new QName("to")).getValue
             )
             wayInnerTags = buildLinkProps(startElement)
-            links += Way(wayId, source_destination._1, source_destination._2, wayInnerTags)
           case "attributes" if canProcessLink =>
             canProcessLinkAttributes = true
           case "attribute" if canProcessLinkAttributes && tagNameHasKind(startElement, "origid") =>
@@ -86,6 +85,7 @@ object PhyssymXmlToOsmConverter extends StrictLogging {
         endElement.getName.getLocalPart match {
           case "nodes"                  => canProcessNode = false
           case "link" if canProcessLink =>
+            links += Way(wayId, source_destination._1, source_destination._2, wayInnerTags)
           case "links" if canProcessLink =>
             canProcessLink = false
           case "attributes" if canProcessLinkAttributes => canProcessLinkAttributes = false

--- a/src/test/scala/beam/router/PhyssymXmlToOsmConverter.scala
+++ b/src/test/scala/beam/router/PhyssymXmlToOsmConverter.scala
@@ -78,7 +78,7 @@ object PhyssymXmlToOsmConverter extends StrictLogging {
       } else if (nextEvent.isEndElement) {
         val endElement = nextEvent.asEndElement()
         endElement.getName.getLocalPart match {
-          case "network" =>
+          case "network"                =>
           case "nodes"                  => canProcessNode = false
           case "node" if canProcessNode =>
           case "links" if canProcessLink =>
@@ -92,13 +92,15 @@ object PhyssymXmlToOsmConverter extends StrictLogging {
               isHighway = false
             }
           case somethingElse =>
-            logger.warn(s"Something not predicted. canProcessLinks: [$canProcessLink]; [canProcessLinkAttributes: [$canProcessLinkAttributes]; canProcessNode: [$canProcessNode]; somethingElse: [$somethingElse]")
+            logger.warn(
+              s"Something not predicted. canProcessLinks: [$canProcessLink]; [canProcessLinkAttributes: [$canProcessLinkAttributes]; canProcessNode: [$canProcessNode]; somethingElse: [$somethingElse]"
+            )
         }
       } else if (nextEvent.isCharacters) {
         val characters: Characters = nextEvent.asCharacters()
         val charactersValue = characters.getData
         if (!isBlank(charactersValue) && isHighway) {
-            wayInnerTags += "highway" -> charactersValue
+          wayInnerTags += "highway" -> charactersValue
         }
       }
     }


### PR DESCRIPTION
Closes #3153 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3159)
<!-- Reviewable:end -->

Changes:
- Fix bug: currently the Physym to OSM repeats the wayId. In the new version a unique wayId is extracted from linkId of Physsim network
- Allow to convert Physym network to PBF (in addition to OSM XML) 
- Small refactoring to improve log