### PR TITLE
tell people to use develop branch

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -95,9 +95,9 @@ Fetch the remote branches and tags::
 
     git fetch
 
-Now checkout the latest stable version of BEAM, v0.7.0::
+Now checkout the develop branch::
 
-   git checkout v0.7.0
+   git checkout develop
 
 
 Run the gradle command to compile BEAM, this will also downloaded all required dependencies automatically::


### PR DESCRIPTION
in the getting started guide -- 0.7.0 is really obsolete now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3269)
<!-- Reviewable:end -->
