### PR TITLE
Allow to choose the event manager for physsim

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -431,6 +431,11 @@ beam.physsim.duplicatePTE.departureTimeShiftMax = "int | 600"
 beam.physsim.skipPhysSim = false
 # values: JDEQSim, BPRSim, PARBPRSim, CCHRoutingAssignment
 beam.physsim.name = "JDEQSim"
+# values: Auto, Sequential, Parallel
+beam.physsim.eventManager.type = "Auto"
+# number of threads for parallel event manager,
+# 1 thread usually shows the best performance (async event handling)
+beam.physsim.eventManager.numberOfThreads = "int | 1"
 
 # JDEQSim
 beam.physsim.jdeqsim.agentSimPhysSimInterfaceDebugger.enabled = false

--- a/src/main/scala/beam/physsim/jdeqsim/ApproxPhysSim.scala
+++ b/src/main/scala/beam/physsim/jdeqsim/ApproxPhysSim.scala
@@ -3,7 +3,7 @@ package beam.physsim.jdeqsim
 import beam.router.r5.R5Parameters
 import beam.sim.config.BeamConfig
 import beam.sim.{BeamConfigChangesObservable, BeamServices}
-import beam.utils.Statistics
+import beam.utils.{ProfilingUtils, Statistics}
 import beam.utils.csv.CsvWriter
 import com.typesafe.scalalogging.StrictLogging
 import org.matsim.api.core.v01.Scenario
@@ -153,7 +153,9 @@ class ApproxPhysSim(
         agentSimIterationNumber
       )
       val simulationResult =
-        jdeqSimRunner.simulate(currentIter, writeEvents = shouldWritePhysSimEvents && currentIter == nIterations)
+        ProfilingUtils.timed(s"Physsim simulation $agentSimIterationNumber.$currentIter", x => logger.info(x)) {
+          jdeqSimRunner.simulate(currentIter, writeEvents = shouldWritePhysSimEvents && currentIter == nIterations)
+        }
       carTravelTimeWriter.writeRow(
         Vector(
           currentIter,

--- a/src/main/scala/beam/physsim/jdeqsim/EventToHourFrequency.scala
+++ b/src/main/scala/beam/physsim/jdeqsim/EventToHourFrequency.scala
@@ -31,14 +31,7 @@ class EventToHourFrequency(val controlerIO: OutputDirectoryHierarchy)
     cnt += 1
     val hour = (event.getTime / 3600).toInt
     val className = event.getClass.getSimpleName
-    val hourFreq = eventToHourFreq.get(className) match {
-      case Some(value) =>
-        value
-      case None =>
-        val r = mutable.Map[Int, Int]()
-        eventToHourFreq.update(className, r)
-        r
-    }
+    val hourFreq = eventToHourFreq.getOrElseUpdate(className, mutable.Map[Int, Int]())
     val prev = hourFreq.getOrElse(hour, 0)
     hourFreq.update(hour, prev + 1)
   }

--- a/src/main/scala/beam/physsim/jdeqsim/PhysSim.scala
+++ b/src/main/scala/beam/physsim/jdeqsim/PhysSim.scala
@@ -3,7 +3,7 @@ package beam.physsim.jdeqsim
 import beam.router.r5.R5Parameters
 import beam.sim.config.BeamConfig
 import beam.sim.{BeamConfigChangesObservable, BeamServices}
-import beam.utils.Statistics
+import beam.utils.{ProfilingUtils, Statistics}
 import beam.utils.csv.CsvWriter
 import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
 import org.matsim.api.core.v01.Scenario
@@ -100,7 +100,9 @@ class PhysSim(
         agentSimIterationNumber
       )
       val simulationResult =
-        jdeqSimRunner.simulate(currentIter, writeEvents = shouldWritePhysSimEvents && currentIter == nIterations)
+        ProfilingUtils.timed(s"Physsim simulation $agentSimIterationNumber.$currentIter", x => logger.info(x)) {
+          jdeqSimRunner.simulate(currentIter, writeEvents = shouldWritePhysSimEvents && currentIter == nIterations)
+        }
       carTravelTimeWriter.writeRow(
         Vector(
           currentIter,

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2723,6 +2723,7 @@ object BeamConfig {
       bprsim: BeamConfig.Beam.Physsim.Bprsim,
       cchRoutingAssignment: BeamConfig.Beam.Physsim.CchRoutingAssignment,
       duplicatePTE: BeamConfig.Beam.Physsim.DuplicatePTE,
+      eventManager: BeamConfig.Beam.Physsim.EventManager,
       events: BeamConfig.Beam.Physsim.Events,
       eventsForFullVersionOfVia: scala.Boolean,
       eventsSampling: scala.Double,
@@ -2795,11 +2796,26 @@ object BeamConfig {
         def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Physsim.DuplicatePTE = {
           BeamConfig.Beam.Physsim.DuplicatePTE(
             departureTimeShiftMax =
-              if (c.hasPathOrNull("departureTimeShiftMax")) c.getInt("departureTimeShiftMax") else 0,
+              if (c.hasPathOrNull("departureTimeShiftMax")) c.getInt("departureTimeShiftMax") else 600,
             departureTimeShiftMin =
-              if (c.hasPathOrNull("departureTimeShiftMin")) c.getInt("departureTimeShiftMin") else 0,
+              if (c.hasPathOrNull("departureTimeShiftMin")) c.getInt("departureTimeShiftMin") else -600,
             fractionOfEventsToDuplicate =
               if (c.hasPathOrNull("fractionOfEventsToDuplicate")) c.getDouble("fractionOfEventsToDuplicate") else 0.0
+          )
+        }
+      }
+
+      case class EventManager(
+        numberOfThreads: scala.Int,
+        `type`: java.lang.String
+      )
+
+      object EventManager {
+
+        def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Physsim.EventManager = {
+          BeamConfig.Beam.Physsim.EventManager(
+            numberOfThreads = if (c.hasPathOrNull("numberOfThreads")) c.getInt("numberOfThreads") else 1,
+            `type` = if (c.hasPathOrNull("type")) c.getString("type") else "Auto"
           )
         }
       }
@@ -3468,6 +3484,10 @@ object BeamConfig {
           duplicatePTE = BeamConfig.Beam.Physsim.DuplicatePTE(
             if (c.hasPathOrNull("duplicatePTE")) c.getConfig("duplicatePTE")
             else com.typesafe.config.ConfigFactory.parseString("duplicatePTE{}")
+          ),
+          eventManager = BeamConfig.Beam.Physsim.EventManager(
+            if (c.hasPathOrNull("eventManager")) c.getConfig("eventManager")
+            else com.typesafe.config.ConfigFactory.parseString("eventManager{}")
           ),
           events = BeamConfig.Beam.Physsim.Events(
             if (c.hasPathOrNull("events")) c.getConfig("events")

--- a/test/input/sf-light/sf-light-25k-with-PTE-duplicates-1.conf
+++ b/test/input/sf-light/sf-light-25k-with-PTE-duplicates-1.conf
@@ -17,5 +17,5 @@ beam.physsim.duplicatePTE.departureTimeShiftMax = 600
 beam.physsim.skipPhysSim = false
 # values: JDEQSim, BPRSim, PARBPRSim, CCHRoutingAssignment
 beam.physsim.name = "PARBPRSim"
-beam.physsim.parbprsim.numberOfClusters = 32
+beam.physsim.parbprsim.numberOfClusters = 16
 beam.physsim.parbprsim.syncInterval = 600

--- a/test/input/sf-light/sf-light-25k-with-PTE-duplicates-2.conf
+++ b/test/input/sf-light/sf-light-25k-with-PTE-duplicates-2.conf
@@ -17,5 +17,5 @@ beam.physsim.duplicatePTE.departureTimeShiftMax = 600
 beam.physsim.skipPhysSim = false
 # values: JDEQSim, BPRSim, PARBPRSim, CCHRoutingAssignment
 beam.physsim.name = "PARBPRSim"
-beam.physsim.parbprsim.numberOfClusters = 32
+beam.physsim.parbprsim.numberOfClusters = 16
 beam.physsim.parbprsim.syncInterval = 600

--- a/test/input/sf-light/sf-light-25k-with-PTE-duplicates-3.conf
+++ b/test/input/sf-light/sf-light-25k-with-PTE-duplicates-3.conf
@@ -15,5 +15,5 @@ beam.physsim.duplicatePTE.departureTimeShiftMax = 600
 beam.physsim.skipPhysSim = false
 # values: JDEQSim, BPRSim, PARBPRSim, CCHRoutingAssignment
 beam.physsim.name = "PARBPRSim"
-beam.physsim.parbprsim.numberOfClusters = 32
+beam.physsim.parbprsim.numberOfClusters = 16
 beam.physsim.parbprsim.syncInterval = 600


### PR DESCRIPTION
Introduced new praram `beam.physsim.eventManager.type`, if set to Auto it chooses Sequential eventmanager for PARBPRsim and Parallel Event manager for the other physsim engines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3297)
<!-- Reviewable:end -->
