### PR TITLE
Fix file not found error when do deployToNersc

### DIFF
--- a/nersc/build.gradle
+++ b/nersc/build.gradle
@@ -30,7 +30,7 @@ remotes {
 import org.apache.tools.ant.filters.ReplaceTokens
 
 task deployToNersc {
-        def propsFileName = "../gradle.deploy.properties"
+        def propsFileName = "${project.rootDir}/gradle.deploy.properties"
         if (project.hasProperty('propsFile')) {
             propsFileName = project.findProperty('propsFile')
         }
@@ -60,7 +60,7 @@ task deployToNersc {
 
     doFirst {
         copy {
-            from('src/main/bash/shifter_job.sh') {
+            from("${project.rootDir}/nersc/src/main/bash/shifter_job.sh") {
                 filter(ReplaceTokens, tokens: ['jobName': runName.toString(), 'userEmail': git_user_email.toString()])
             }
             into "${project.rootDir}/build/generated/scripts"
@@ -71,7 +71,7 @@ task deployToNersc {
 
         ssh.run {
             session(remotes.nerscLoginNode) {
-                put from: 'nersc/src/main/bash/run_beam_on_nersc.sh', into: "run_beam.sh"
+                put from: "${project.rootDir}/nersc/src/main/bash/run_beam_on_nersc.sh", into: "run_beam.sh"
                 put from: "${project.rootDir}/build/generated/scripts/shifter_job.sh", into: "shifter_job.sh"
                 execute "chmod +x run_beam.sh shifter_job.sh"
                 execute "./run_beam.sh \

--- a/src/main/scala/beam/utils/plan/PlansBuilder.scala
+++ b/src/main/scala/beam/utils/plan/PlansBuilder.scala
@@ -22,7 +22,7 @@ import org.matsim.vehicles.{Vehicle, VehicleUtils, VehicleWriterV1, Vehicles}
 import java.io.{BufferedWriter, File, FileWriter}
 import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
-import scala.collection.{JavaConverters, immutable}
+import scala.collection.{immutable, JavaConverters}
 import scala.util.Random
 
 object PlansBuilder {


### PR DESCRIPTION
In some environments gradle looks for relative paths relative to the gradle daemon working directory. This PR fixes this by using project.rootDir property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3312)
<!-- Reviewable:end -->
