### PR TITLE
Add missing akka-router.conf for New York and Detroit

### DIFF
--- a/production/common/akka-router.conf
+++ b/production/common/akka-router.conf
@@ -1,0 +1,27 @@
+router-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 2
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 1.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 16
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 100
+}
+
+akka {
+  deployment {
+    /router/router-worker {
+      dispatcher = router-dispatcher
+    }
+  }
+}


### PR DESCRIPTION
New York and Detroit scenarios were extracted from `test/input` and so they included `akka-router.conf` which is missing for production configs. I adding it there with a minor change (removing `akka.log-dead-letters = 0` since it is already defined in `akka.conf`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3356)
<!-- Reviewable:end -->
