### PR TITLE
Fix AMI cleanup bug

### DIFF
--- a/AMI_Cleanup.py
+++ b/AMI_Cleanup.py
@@ -40,7 +40,7 @@ def backup_and_retrieve_config_and_delete_old_backup():
 
 def get_tagged_amis_along_with_most_recent(region):
     ec2 = get_ec2_for(region)
-    amis = ec2.describe_images(Owners=['self'])
+    amis = ec2.describe_images(Owners=['self'],Filters=[{'Name':'name','Values':['beam-automation-*']}])
     allAMIs = []
     newestAMI = None
     for ami in amis['Images']:


### PR DESCRIPTION
This was exposed when I had to create AMIs - and the script picked up one of the new ones as the newest...but it wasn't even a beam automation one. This wreaked minor havoc on the builds for a bit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3359)
<!-- Reviewable:end -->
