### PR TITLE
fix log4j issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,9 @@ if (project.hasProperty('env')) {
 
 allprojects {
     repositories {
+        mavenCentral().content {
+            excludeModule("javax.media", "jai_core")
+        }
         maven { url "https://repo.osgeo.org/repository/release/" }
         maven { url "https://download.osgeo.org/webdav/geotools" }
         // maven { url "http://maven.icm.edu.pl/artifactory/repo/" }
@@ -107,7 +110,6 @@ allprojects {
         maven { url "https://people.apache.org/repo/m1-ibiblio-rsync-repository/org.apache.axis2/" }
         maven { url "https://maven.geo-solutions.it" }
         mavenLocal()
-        mavenCentral()
         maven {
             url "http://nexus.onebusaway.org/content/groups/public/"
             allowInsecureProtocol = true


### PR DESCRIPTION
Fixes #3413
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3415)
<!-- Reviewable:end -->

The cause of the issue was renaming log4-1.2.17 to log4j-1.2.17.norce.jar in geoserver repo, but pom file still points to log4j-1.2.17. So it resolves the dependency but it has a missing jar. The solution I came with is to search first in Maven Central repo where log4j resolves correctly. Maven Central has its own problem with missing jar file for jai_core, so it is excluded from there.

Note that log4j 1.2.17 doesn't have Log4Shell vulnerability which only affects log4j 2
