### PR TITLE
Fix GH alt route flaky test

### DIFF
--- a/src/test/scala/beam/router/GHRouterSpec.scala
+++ b/src/test/scala/beam/router/GHRouterSpec.scala
@@ -1,17 +1,29 @@
 package beam.router
 
 import akka.actor.ActorSystem
-import beam.sim.BeamHelper
-import beam.utils.ParquetReader
+import akka.pattern.ask
+import akka.testkit.TestActorRef
+import akka.util.Timeout
+import beam.agentsim.agents.vehicles.BeamVehicleType
+import beam.agentsim.agents.vehicles.VehicleProtocol.StreetVehicle
+import beam.agentsim.events.SpaceTime
+import beam.router.BeamRouter.{Location, RoutingRequest, RoutingResponse}
+import beam.router.Modes.BeamMode
+import beam.router.Modes.BeamMode._
+import beam.sim.population.{AttributesOfIndividual, HouseholdAttributes}
+import beam.sim.{BeamHelper, BeamScenario, BeamServices}
 import beam.utils.TestConfigUtils.testConfig
+import com.conveyal.r5.transit.TransportNetwork
 import com.typesafe.config.{Config, ConfigFactory}
+import org.matsim.api.core.v01.Id
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import java.io.File
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class GHRouterSpec extends AnyWordSpecLike with Matchers with BeamHelper {
+class GHRouterSpec extends AnyWordSpecLike with Matchers with BeamHelper with ScalaFutures {
 
   lazy val config: Config = ConfigFactory
     .parseString(
@@ -29,25 +41,80 @@ class GHRouterSpec extends AnyWordSpecLike with Matchers with BeamHelper {
     .withFallback(config)
     .resolve()
 
-  lazy implicit val system: ActorSystem = ActorSystem("GHRouterSpec", config)
-
   "Static GH" must {
     "run successfully" in {
       runBeamWithConfig(config)
     }
 
     "add alternative route for GraphHopper if enabled" in {
-      val (matsimConfig, _, _) = runBeamWithConfig(configAltRoutes)
-      val outputDir = matsimConfig.controler.getOutputDirectory
-      val routingResponse = new File(outputDir, "ITERS/it.0/0.routingResponse.parquet")
-      val (iterator, closable) = ParquetReader.read(routingResponse.toString)
-      val result = iterator.exists { record =>
-        val router = record.get("router").toString
-        val itineraryIndex = record.get("itineraryIndex").toString
-        router == "GH" && itineraryIndex == "2"
-      }
-      closable.close()
-      result shouldBe true
+      lazy implicit val system: ActorSystem = ActorSystem("GHRouterSpec", configAltRoutes)
+      val (_, _, beamScenario: BeamScenario, services: BeamServices, _) = prepareBeamService(configAltRoutes, None)
+      val transportNetwork = services.injector.getInstance(classOf[TransportNetwork])
+
+      val request = RoutingRequest(
+        originUTM = new Location(167138.0, 2234.0),
+        destinationUTM = new Location(166321.9, 1568.87),
+        departureTime = 36952,
+        withTransit = false,
+        personId = Some(Id.createPersonId(2)),
+        streetVehicles = Vector(
+          StreetVehicle(
+            Id.createVehicleId(2),
+            Id.create("beamVilleCar", classOf[BeamVehicleType]),
+            SpaceTime(167138.00001152378, 2233.9999999985166, 32482),
+            BeamMode.CAR,
+            true,
+            true
+          ),
+          StreetVehicle(
+            Id.createVehicleId("body-2"),
+            Id.create("BODY-TYPE-DEFAULT", classOf[BeamVehicleType]),
+            SpaceTime(167138.0, 2234.0, 36952),
+            WALK,
+            true,
+            false
+          )
+        ),
+        attributesOfIndividual = Some(
+          AttributesOfIndividual(
+            HouseholdAttributes("1", 50000.0, 3, 1, 0),
+            None,
+            true,
+            List(
+              CAR,
+              CAV,
+              WALK,
+              BIKE,
+              TRANSIT,
+              RIDE_HAIL,
+              RIDE_HAIL_POOLED,
+              RIDE_HAIL_TRANSIT,
+              DRIVE_TRANSIT,
+              WALK_TRANSIT,
+              BIKE_TRANSIT
+            ),
+            12.254901960784315,
+            Some(0),
+            Some(0.0)
+          )
+        ),
+        triggerId = 1
+      )
+      val worker =
+        TestActorRef(
+          RoutingWorker.props(
+            beamScenario,
+            transportNetwork,
+            services.networkHelper,
+            services.fareCalculator,
+            services.tollCalculator
+          )
+        )
+
+      implicit val timeout: Timeout = 1 minute
+      val future = (worker ? request).mapTo[RoutingResponse]
+      val response: RoutingResponse = future.futureValue
+      response.itineraries.count(_.router.contains("GH")) shouldBe 3
     }
 
   }

--- a/src/test/scala/beam/router/GHRouterSpec.scala
+++ b/src/test/scala/beam/router/GHRouterSpec.scala
@@ -62,23 +62,23 @@ class GHRouterSpec extends AnyWordSpecLike with Matchers with BeamHelper with Sc
             Id.create("beamVilleCar", classOf[BeamVehicleType]),
             SpaceTime(167138.00001152378, 2233.9999999985166, 32482),
             BeamMode.CAR,
-            true,
-            true
+            asDriver = true,
+            needsToCalculateCost = true
           ),
           StreetVehicle(
             Id.createVehicleId("body-2"),
             Id.create("BODY-TYPE-DEFAULT", classOf[BeamVehicleType]),
             SpaceTime(167138.0, 2234.0, 36952),
-            WALK,
-            true,
-            false
+            BeamMode.WALK,
+            asDriver = true,
+            needsToCalculateCost = false
           )
         ),
         attributesOfIndividual = Some(
           AttributesOfIndividual(
             HouseholdAttributes("1", 50000.0, 3, 1, 0),
-            None,
-            true,
+            modalityStyle = None,
+            isMale = true,
             List(
               CAR,
               CAV,

--- a/src/test/scala/beam/router/GHRouterSpec.scala
+++ b/src/test/scala/beam/router/GHRouterSpec.scala
@@ -30,7 +30,6 @@ class GHRouterSpec extends AnyWordSpecLike with Matchers with BeamHelper with Sc
       """
          |beam.actorSystemName = "GHRouterSpec"
          |beam.routing.carRouter="staticGH"
-         |beam.outputs.writeR5RoutesInterval = 1
       """.stripMargin
     )
     .withFallback(testConfig("test/input/beamville/beam.conf"))


### PR DESCRIPTION
Previous version was running full beamville simulation and verified that there were 2 alternative routes generated for GH. Unfortunately this was not fully deterministic, on CI in some rare cases last route was not generated, probably because RoutingRequest has different parameters. 

This new test uses one predefined RoutingRequest which is known to always return alternative route (if this config option is on) and sends it to RoutingWorker and check the resulting RoutingResponse

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3429)
<!-- Reviewable:end -->
