### PR TITLE
don't load previous plans as unselected

### DIFF
--- a/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
+++ b/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
@@ -71,12 +71,9 @@ object PreviousRunPlanMerger extends LazyLogging {
       personIdsToReplace.size
     )
     val shouldReplace = (plan: PlanElement) => personIdsToReplace.contains(plan.personId)
-    val (oldToBeReplaced, oldElements) = plans.partition(shouldReplace)
+    val (_, oldElementsToKeep) = plans.partition(shouldReplace)
     val elementsFromExistingPersonsToAdd = plansToMerge.filter(shouldReplace)
-    val shouldAdd = (plan: PlanElement) => personIdsToAdd.contains(plan.personId)
-    val elementsFromNewPersonsToAdd = plansToMerge.filter(shouldAdd)
-    val unselectedPlanElements = oldToBeReplaced.map(_.copy(planSelected = false))
-    oldElements ++ unselectedPlanElements ++ elementsFromExistingPersonsToAdd ++ elementsFromNewPersonsToAdd
+    oldElementsToKeep ++ elementsFromExistingPersonsToAdd
   }
 }
 


### PR DESCRIPTION
For some reason the previous unselected plans were being transformed into selected plans when being loaded, so people would end up with multiple sets of plans being selected and trying to complete two days' worth of trips, which causes chaos. Turning this off for now because it's not a super important feature

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3473)
<!-- Reviewable:end -->
