### PR TITLE
Force vehicle creation when plans require it

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -233,7 +233,7 @@ trait ChoosesMode {
               _,
               _,
               _,
-              None | Some(CAR | BIKE | DRIVE_TRANSIT | BIKE_TRANSIT),
+              plansModeOption @ (None | Some(CAR | BIKE | DRIVE_TRANSIT | BIKE_TRANSIT)),
               _,
               _,
               _,
@@ -267,11 +267,29 @@ trait ChoosesMode {
             _
           ) =>
         implicit val executionContext: ExecutionContext = context.system.dispatcher
-        requestAvailableVehicles(
-          vehicleFleets,
-          currentLocation,
-          _experiencedBeamPlan.activities(currentActivityIndex)
-        ) pipeTo self
+        plansModeOption match {
+          case Some(CAR | DRIVE_TRANSIT) =>
+            requestAvailableVehicles(
+              vehicleFleets,
+              currentLocation,
+              _experiencedBeamPlan.activities(currentActivityIndex),
+              Some(VehicleCategory.Car)
+            ) pipeTo self
+          case Some(BIKE | BIKE_TRANSIT) =>
+            requestAvailableVehicles(
+              vehicleFleets,
+              currentLocation,
+              _experiencedBeamPlan.activities(currentActivityIndex),
+              Some(VehicleCategory.Bike)
+            ) pipeTo self
+          case _ =>
+            requestAvailableVehicles(
+              vehicleFleets,
+              currentLocation,
+              _experiencedBeamPlan.activities(currentActivityIndex)
+            ) pipeTo self
+        }
+
       // Otherwise, send empty list to self
       case _ =>
         self ! MobilityStatusResponse(Vector(), getCurrentTriggerIdOrGenerate)


### PR DESCRIPTION
Fix problem where emergency vehicles weren't actually being generated. Here we make sure to tell the `emergencyHouseholdVehicleGenerator` when we're making a mobility request that _requires_ a personal vehicle be available because it is already determined in the plans.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3479)
<!-- Reviewable:end -->
