### PR TITLE
Remove shared teleportation vehicles for non-teleportation trips

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -643,7 +643,11 @@ class PersonAgent(
       )
       eventsManager.processEvent(teleportationEvent)
 
-      goto(ProcessingNextLegOrStartActivity) using data.copy(hasDeparted = true)
+      goto(ProcessingNextLegOrStartActivity) using data.copy(
+        hasDeparted = true,
+        currentVehicle = Vector.empty[Id[BeamVehicle]],
+        currentTourPersonalVehicle = None
+      )
 
   }
 


### PR DESCRIPTION
So that they don't end up throwing a none.get error when we ask for their manager here: https://github.com/LBNL-UCB-STI/beam/blob/012983f5d68d1c5a2ebbf2bf7992b48b7bc78bcd/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala#L1519

Stale vehicles staying in `data.availablePersonalStreetVehicles` might have something to do with the `Current tour vehicle is the same as the one being removed` error we've been seeing for a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3484)
<!-- Reviewable:end -->
