### PR TITLE
Issue-3495 add a configurable seed for population sampling

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -966,6 +966,7 @@ trait BeamHelper extends LazyLogging {
       Kamon.init(config.withFallback(ConfigFactory.load()))
     }
 
+    logger.info("Agentsim random seed for population scaling is set to {}.", beamConfig.beam.agentsim.randomSeed)
     logger.info("Starting beam on branch {} at commit {}.", BashUtils.getBranch, BashUtils.getCommitHash)
 
     logger.info(

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2162,8 +2162,9 @@ object BeamConfig {
 
       def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Agentsim = {
         BeamConfig.Beam.Agentsim(
-          randomSeed = if (c.hasPathOrNull("randomSeed"))
-            c.getInt("randomSeed")
+          randomSeed =
+            if (c.hasPathOrNull("randomSeed"))
+              c.getInt("randomSeed")
             else new Random().nextInt(),
           agentSampleSizeAsFractionOfPopulation =
             if (c.hasPathOrNull("agentSampleSizeAsFractionOfPopulation"))

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2,6 +2,8 @@
 
 package beam.sim.config
 
+import scala.util.Random
+
 case class BeamConfig(
   beam: BeamConfig.Beam,
   matsim: BeamConfig.Matsim
@@ -37,6 +39,7 @@ object BeamConfig {
   object Beam {
 
     case class Agentsim(
+      randomSeed: scala.Int,
       agentSampleSizeAsFractionOfPopulation: scala.Double,
       agents: BeamConfig.Beam.Agentsim.Agents,
       chargingNetworkManager: BeamConfig.Beam.Agentsim.ChargingNetworkManager,
@@ -2159,6 +2162,9 @@ object BeamConfig {
 
       def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Agentsim = {
         BeamConfig.Beam.Agentsim(
+          randomSeed = if (c.hasPathOrNull("randomSeed"))
+            c.getInt("randomSeed")
+            else new Random().nextInt(),
           agentSampleSizeAsFractionOfPopulation =
             if (c.hasPathOrNull("agentSampleSizeAsFractionOfPopulation"))
               c.getDouble("agentSampleSizeAsFractionOfPopulation")

--- a/src/main/scala/beam/sim/population/PopulationScaling.scala
+++ b/src/main/scala/beam/sim/population/PopulationScaling.scala
@@ -126,7 +126,7 @@ class PopulationScaling extends LazyLogging {
     val numAgents = math.round(
       beamConfig.beam.agentsim.agentSampleSizeAsFractionOfPopulation * scenario.getPopulation.getPersons.size()
     )
-    val rand = new Random(beamServices.beamConfig.matsim.modules.global.randomSeed)
+    val rand = new Random(beamServices.beamConfig.beam.agentsim.randomSeed)
     val notSelectedHouseholdIds = mutable.Set[Id[Household]]()
     val notSelectedVehicleIds = mutable.Set[Id[Vehicle]]()
     val notSelectedPersonIds = mutable.Set[Id[Person]]()

--- a/src/test/scala/beam/sim/population/PopulationSamplingSpec.scala
+++ b/src/test/scala/beam/sim/population/PopulationSamplingSpec.scala
@@ -15,7 +15,7 @@ import java.nio.file.Files
 class PopulationSamplingSpec extends AnyWordSpecLike with Matchers with BeamHelper with IntegrationSpecCommon {
 
   private def getObjectsForPopulationSampling(
-    seed:Integer = 0
+    seed: Integer = 0
   ): (MutableScenario, BeamScenario, BeamConfig, BeamServices, String) = {
     if (seed.equals(0)) {
       return prepareObjectsForPopulationSampling(getConfigWithRandomSeed)
@@ -41,9 +41,7 @@ class PopulationSamplingSpec extends AnyWordSpecLike with Matchers with BeamHelp
           "beam.agentsim.agentSampleSizeAsFractionOfPopulation",
           ConfigValueFactory.fromAnyRef(0.5)
         )
-        .withValue(
-          "beam.agentsim.randomSeed",
-          ConfigValueFactory.fromAnyRef(seed))
+        .withValue("beam.agentsim.randomSeed", ConfigValueFactory.fromAnyRef(seed))
         .resolve()
     )
   }
@@ -75,13 +73,27 @@ class PopulationSamplingSpec extends AnyWordSpecLike with Matchers with BeamHelp
       val samplingDataOne = getObjectsForPopulationSampling(1441)
       val samplingDataTwo = getObjectsForPopulationSampling(1441)
       val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
-      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
+      PopulationScaling.samplePopulation(
+        samplingDataOne._1,
+        samplingDataOne._2,
+        samplingDataOne._3,
+        samplingDataOne._4,
+        samplingDataOne._5
+      )
 
       agentsBeforeSamplingOneSize should be <= 50
-      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingOne =
+        samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
 
-      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
-      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      PopulationScaling.samplePopulation(
+        samplingDataTwo._1,
+        samplingDataTwo._2,
+        samplingDataTwo._3,
+        samplingDataTwo._4,
+        samplingDataTwo._5
+      )
+      val agentsAfterSamplingTwo =
+        samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
 
       agentsAfterSamplingOne shouldBe agentsAfterSamplingTwo
     }
@@ -90,25 +102,54 @@ class PopulationSamplingSpec extends AnyWordSpecLike with Matchers with BeamHelp
       val samplingDataOne = getObjectsForPopulationSampling()
       val samplingDataTwo = getObjectsForPopulationSampling()
       val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
-      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
-      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
+      PopulationScaling.samplePopulation(
+        samplingDataOne._1,
+        samplingDataOne._2,
+        samplingDataOne._3,
+        samplingDataOne._4,
+        samplingDataOne._5
+      )
+      PopulationScaling.samplePopulation(
+        samplingDataTwo._1,
+        samplingDataTwo._2,
+        samplingDataTwo._3,
+        samplingDataTwo._4,
+        samplingDataTwo._5
+      )
 
       agentsBeforeSamplingOneSize should be <= 50
-      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
-      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingOne =
+        samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingTwo =
+        samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
 
       agentsAfterSamplingOne should not equal agentsAfterSamplingTwo
     }
+
     "sample different agents for different randomSeeds" in {
       val samplingDataOne = getObjectsForPopulationSampling(1441)
       val samplingDataTwo = getObjectsForPopulationSampling(23)
       val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
-      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
-      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
+      PopulationScaling.samplePopulation(
+        samplingDataOne._1,
+        samplingDataOne._2,
+        samplingDataOne._3,
+        samplingDataOne._4,
+        samplingDataOne._5
+      )
+      PopulationScaling.samplePopulation(
+        samplingDataTwo._1,
+        samplingDataTwo._2,
+        samplingDataTwo._3,
+        samplingDataTwo._4,
+        samplingDataTwo._5
+      )
 
       agentsBeforeSamplingOneSize should be <= 50
-      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
-      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingOne =
+        samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingTwo =
+        samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
 
       agentsAfterSamplingOne should not equal agentsAfterSamplingTwo
     }

--- a/src/test/scala/beam/sim/population/PopulationSamplingSpec.scala
+++ b/src/test/scala/beam/sim/population/PopulationSamplingSpec.scala
@@ -1,0 +1,116 @@
+package beam.sim.population
+
+import beam.integration.IntegrationSpecCommon
+import beam.sim.config.{BeamConfig, MatSimBeamConfigBuilder}
+import beam.sim.{BeamHelper, BeamScenario, BeamServices}
+import beam.utils.FileUtils
+import com.typesafe.config.ConfigValueFactory
+import org.matsim.core.scenario.{MutableScenario, ScenarioUtils}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.nio.file.Files
+
+class PopulationSamplingSpec extends AnyWordSpecLike with Matchers with BeamHelper with IntegrationSpecCommon {
+
+  private def getObjectsForPopulationSampling(
+    seed:Integer = 0
+  ): (MutableScenario, BeamScenario, BeamConfig, BeamServices, String) = {
+    if (seed.equals(0)) {
+      return prepareObjectsForPopulationSampling(getConfigWithRandomSeed)
+    }
+    prepareObjectsForPopulationSampling(getConfigWithSeed(seed))
+  }
+
+  private def getConfigWithRandomSeed: BeamConfig = {
+    BeamConfig(
+      baseConfig
+        .withValue(
+          "beam.agentsim.agentSampleSizeAsFractionOfPopulation",
+          ConfigValueFactory.fromAnyRef(0.5)
+        )
+        .resolve()
+    )
+  }
+
+  private def getConfigWithSeed(seed: Integer): BeamConfig = {
+    BeamConfig(
+      baseConfig
+        .withValue(
+          "beam.agentsim.agentSampleSizeAsFractionOfPopulation",
+          ConfigValueFactory.fromAnyRef(0.5)
+        )
+        .withValue(
+          "beam.agentsim.randomSeed",
+          ConfigValueFactory.fromAnyRef(seed))
+        .resolve()
+    )
+  }
+
+  private def prepareObjectsForPopulationSampling(
+    config: BeamConfig
+  ): (MutableScenario, BeamScenario, BeamConfig, BeamServices, String) = {
+    val beamScenario = loadScenario(config)
+    val configBuilder = new MatSimBeamConfigBuilder(baseConfig)
+    val matsimConfig = configBuilder.buildMatSimConf()
+    matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+    FileUtils.setConfigOutputFile(config, matsimConfig)
+
+    val scenario = ScenarioUtils.loadScenario(matsimConfig).asInstanceOf[MutableScenario]
+    scenario.setNetwork(beamScenario.network)
+
+    val injector = org.matsim.core.controler.Injector.createInjector(
+      scenario.getConfig,
+      module(baseConfig, config, scenario, beamScenario)
+    )
+
+    val beamServices: BeamServices = injector.getInstance(classOf[BeamServices])
+    val temporaryOutputDirectory = Files.createTempDirectory("dummyOutputDirectory").toString
+    (scenario, beamScenario, config, beamServices, temporaryOutputDirectory)
+  }
+
+  "PopulationSampling" must {
+    "sample the same agents for the same randomSeed value" in {
+      val samplingDataOne = getObjectsForPopulationSampling(1441)
+      val samplingDataTwo = getObjectsForPopulationSampling(1441)
+      val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
+      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
+
+      agentsBeforeSamplingOneSize should be <= 50
+      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+
+      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
+      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+
+      agentsAfterSamplingOne shouldBe agentsAfterSamplingTwo
+    }
+
+    "sample different agents if randomSeed is not set" in {
+      val samplingDataOne = getObjectsForPopulationSampling()
+      val samplingDataTwo = getObjectsForPopulationSampling()
+      val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
+      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
+      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
+
+      agentsBeforeSamplingOneSize should be <= 50
+      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+
+      agentsAfterSamplingOne should not equal agentsAfterSamplingTwo
+    }
+    "sample different agents for different randomSeeds" in {
+      val samplingDataOne = getObjectsForPopulationSampling(1441)
+      val samplingDataTwo = getObjectsForPopulationSampling(23)
+      val agentsBeforeSamplingOneSize = samplingDataOne._1.getPopulation.getPersons.keySet().size()
+      PopulationScaling.samplePopulation(samplingDataOne._1, samplingDataOne._2, samplingDataOne._3, samplingDataOne._4, samplingDataOne._5)
+      PopulationScaling.samplePopulation(samplingDataTwo._1, samplingDataTwo._2, samplingDataTwo._3, samplingDataTwo._4, samplingDataTwo._5)
+
+      agentsBeforeSamplingOneSize should be <= 50
+      val agentsAfterSamplingOne = samplingDataOne._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+      val agentsAfterSamplingTwo = samplingDataTwo._1.getPopulation.getPersons.keySet().stream().map(a => a.leftSide).toArray
+
+      agentsAfterSamplingOne should not equal agentsAfterSamplingTwo
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/LBNL-UCB-STI/beam/issues/3495
> 
> We need to add a configurable [seed](https://en.wikipedia.org/wiki/Random_seed) for population down sampling.
> It is needed for reproducing the same agents sampling. It should be a separate parameter.
> So there are 2 cases:
> 
> if the parameter is set - the same seed is used and the input agents are the same in every run.
> if the parameter is not set - this seed should be randomized and logged in `beamLog.out`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3496)
<!-- Reviewable:end -->

