### PR TITLE
get tripId from trip.leg rather than activity in _experiencedBeamPlan

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -1487,9 +1487,10 @@ trait ChoosesMode {
         )
     }
 
-    val tripId = Option(
-      _experiencedBeamPlan.activities(data.personData.currentActivityIndex).getAttributes.getAttribute("trip_id")
-    ).getOrElse("").toString
+    val tripId = _experiencedBeamPlan.trips.lift(data.personData.currentActivityIndex + 1) match {
+      case Some(trip) => trip.leg.map(_.getAttributes.getAttribute("trip_id").toString).getOrElse("")
+      case None       => ""
+    }
 
     val modeChoiceEvent = new ModeChoiceEvent(
       tick,


### PR DESCRIPTION
Trip_id column hadn't been showing up in PILATES runs--I think it's because by default they are being stored in trips rather than activities in the beamPlan. This fix appears to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3508)
<!-- Reviewable:end -->
