### PR TITLE
snap coordinates and log errors in csv

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -31,6 +31,7 @@ beam.agentsim.lastIteration = "int | 0"
 beam.agentsim.endTime = "30:00:00"
 beam.agentsim.scheduleMonitorTask.initialDelay = 1
 beam.agentsim.scheduleMonitorTask.interval = 30
+beam.agentsim.snapLocationAndRemoveInvalidInputs = "boolean | false"
 
 beam.agentsim.agents.bodyType = "BODY-TYPE-DEFAULT"
 

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -201,7 +201,7 @@ object FreightReader {
           rand,
           tazMap,
           beamConfig.beam.agentsim.snapLocationAndRemoveInvalidInputs,
-          Some(snapLocationHelper),
+          snapLocationHelper,
           outputDirMaybe
         )
       case s =>

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -203,6 +203,7 @@ object FreightReader {
           geoUtils,
           rand,
           tazMap,
+          beamConfig.beam.agentsim.snapLocationAndRemoveInvalidInputs,
           Some(snapLocationHelper),
           outputDirMaybe
         )

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -12,6 +12,7 @@ import beam.sim.BeamServices
 import beam.sim.common.GeoUtils
 import beam.sim.config.BeamConfig
 import beam.sim.config.BeamConfig.Beam.Agentsim.Agents.Freight
+import beam.utils.SnapCoordinateUtils.SnapLocationHelper
 import com.conveyal.r5.streets.StreetLayer
 import org.matsim.api.core.v01.population._
 import org.matsim.api.core.v01.{Coord, Id}
@@ -185,10 +186,16 @@ object FreightReader {
     beamConfig: BeamConfig,
     geoUtils: GeoUtils,
     streetLayer: StreetLayer,
-    tazMap: TAZTreeMap
+    tazMap: TAZTreeMap,
+    outputDirMaybe: Option[String]
   ): FreightReader = {
     val rand: Random = new Random(beamConfig.matsim.modules.global.randomSeed)
     val config = beamConfig.beam.agentsim.agents.freight
+    val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+      geoUtils,
+      streetLayer,
+      beamConfig.beam.routing.r5.linkRadiusMeters
+    )
     beamConfig.beam.agentsim.agents.freight.reader match {
       case "Generic" =>
         new GenericFreightReader(
@@ -196,16 +203,22 @@ object FreightReader {
           geoUtils,
           rand,
           tazMap,
-          Some(ClosestUTMPointOnMap(streetLayer, beamConfig.beam.routing.r5.linkRadiusMeters))
+          snapLocationHelper,
+          outputDirMaybe
         )
       case s =>
         throw new RuntimeException(s"Unknown freight reader $s")
     }
   }
 
-  def apply(beamConfig: BeamConfig, geoUtils: GeoUtils, streetLayer: StreetLayer): FreightReader = {
+  def apply(
+    beamConfig: BeamConfig,
+    geoUtils: GeoUtils,
+    streetLayer: StreetLayer,
+    outputDirMaybe: Option[String]
+  ): FreightReader = {
     val tazMap = TAZTreeMap.getTazTreeMap(beamConfig.beam.agentsim.taz.filePath)
-    apply(beamConfig, geoUtils, streetLayer, tazMap)
+    apply(beamConfig, geoUtils, streetLayer, tazMap, outputDirMaybe)
   }
 
   def apply(beamServices: BeamServices): FreightReader =
@@ -213,21 +226,7 @@ object FreightReader {
       beamServices.beamConfig,
       beamServices.geo,
       beamServices.beamScenario.transportNetwork.streetLayer,
-      beamServices.beamScenario.tazTreeMap
+      beamServices.beamScenario.tazTreeMap,
+      None
     )
-
-  case class ClosestUTMPointOnMap(streetLayer: StreetLayer, r5LinkRadiusMeters: Double) {
-
-    def find(wsgCoord: Coord, geoUtils: GeoUtils): Option[Coord] = {
-      //val wsgCoord = geoUtils.utm2Wgs(utmCoord)
-      val theSplit = geoUtils.getR5Split(streetLayer, wsgCoord, r5LinkRadiusMeters)
-      if (theSplit == null) {
-        None
-      } else {
-        val wgsPointOnMap = geoUtils.splitToCoord(theSplit)
-        val utmCoord = geoUtils.wgs2Utm(wgsPointOnMap)
-        Some(utmCoord)
-      }
-    }
-  }
 }

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -203,7 +203,7 @@ object FreightReader {
           geoUtils,
           rand,
           tazMap,
-          snapLocationHelper,
+          Some(snapLocationHelper),
           outputDirMaybe
         )
       case s =>

--- a/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
@@ -360,7 +360,7 @@ class GenericFreightReader(
   }
 
   private def getDistributedTazLocation(taz: TAZ): Coord =
-    convertedLocation(TAZTreeMap.randomLocationInTAZ(taz, rnd))
+    convertedLocation(TAZTreeMap.randomLocationInTAZ(taz, rnd, Some(snapLocationHelper)))
 
   private def extractCoordOrTaz(strX: String, strY: String, strZone: String): (Option[Id[TAZ]], ClosestUTMPoint) = {
     if (isBlank(strX) || isBlank(strY)) {

--- a/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
@@ -27,8 +27,8 @@ class GenericFreightReader(
   val geoUtils: GeoUtils,
   rnd: Random,
   tazTree: TAZTreeMap,
-  val snapLocationHelper: SnapLocationHelper,
-  val outputDirMaybe: Option[String]
+  val snapLocationHelperMaybe: Option[SnapLocationHelper] = None,
+  val outputDirMaybe: Option[String] = None
 ) extends LazyLogging
     with FreightReader {
 
@@ -360,7 +360,7 @@ class GenericFreightReader(
   }
 
   private def getDistributedTazLocation(taz: TAZ): Coord =
-    convertedLocation(TAZTreeMap.randomLocationInTAZ(taz, rnd, Some(snapLocationHelper)))
+    convertedLocation(TAZTreeMap.randomLocationInTAZ(taz, rnd, snapLocationHelperMaybe))
 
   private def extractCoordOrTaz(strX: String, strY: String, strZone: String): (Option[Id[TAZ]], ClosestUTMPoint) = {
     if (isBlank(strX) || isBlank(strY)) {
@@ -368,7 +368,8 @@ class GenericFreightReader(
       (Some(taz.tazId), Left(getDistributedTazLocation(taz)))
     } else {
       val wasInWgs = config.convertWgs2Utm
-      (None, Right(snapLocationHelper.computeResult(location(strX.toDouble, strY.toDouble), wasInWgs)))
+      val loc = location(strX.toDouble, strY.toDouble)
+      (None, Right(snapLocationHelperMaybe.map(_.computeResult(loc, wasInWgs)).getOrElse(Result.Succeed(loc))))
     }
   }
 

--- a/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
@@ -7,7 +7,7 @@ import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.sim.common.GeoUtils
 import beam.sim.config.BeamConfig.Beam.Agentsim.Agents.Freight
 import beam.utils.SnapCoordinateUtils
-import beam.utils.SnapCoordinateUtils.{Category, Error, ErrorInfo, Result, SnapLocationHelper}
+import beam.utils.SnapCoordinateUtils.{Category, CsvFile, Error, ErrorInfo, Result, SnapLocationHelper}
 import beam.utils.csv.GenericCsvReader
 import beam.utils.matsim_conversion.MatsimPlanConversion.IdOps
 import com.typesafe.scalalogging.LazyLogging
@@ -114,7 +114,7 @@ class GenericFreightReader(
 
     outputDirMaybe.foreach { path =>
       if (errors.isEmpty) logger.info("No 'snap location' error to report for freight tours.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationFreightTourErrors.csv.gz", errors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.FreightTours}", errors)
     }
 
     maybeTours.flatten
@@ -202,7 +202,7 @@ class GenericFreightReader(
 
     outputDirMaybe.foreach { path =>
       if (errors.isEmpty) logger.info("No 'snap location' error to report for freight payload plans.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationFreightPayloadPlanErrors.csv.gz", errors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.FreightPayloadPlans}", errors)
     }
 
     maybePlans.flatten
@@ -341,11 +341,13 @@ class GenericFreightReader(
 
     outputDirMaybe.foreach { path =>
       if (errors.isEmpty) logger.info("No 'snap location' error to report for freight carriers.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationFreightCarrierErrors.csv.gz", errors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.FreightCarriers}", errors)
     }
 
+    val removedCarrierIds = errors.map(_.id)
     val carriersWithFleet = maybeCarrierRows.flatten
       .groupBy(_.carrierId)
+      .filterNot { case (carrierId, _) => removedCarrierIds.contains(carrierId.toString) }
       .map { case (carrierId, carrierRows) =>
         createCarrier(carrierId, carrierRows)
       }

--- a/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
@@ -70,23 +70,12 @@ class GenericFreightReader(
                 maxTourDurationInSec
               )
             )
-          case (_, Left(Error.OutOfBoundingBoxError)) =>
+          case (_, Left(error)) =>
             errors.append(
               ErrorInfo(
                 tourId.toString,
                 Category.FreightTour,
-                Error.OutOfBoundingBoxError,
-                departureLocationX.toDouble,
-                departureLocationY.toDouble
-              )
-            )
-            None
-          case (_, Left(Error.R5SplitNullError)) =>
-            errors.append(
-              ErrorInfo(
-                tourId.toString,
-                Category.FreightTour,
-                Error.R5SplitNullError,
+                error,
                 departureLocationX.toDouble,
                 departureLocationY.toDouble
               )
@@ -152,23 +141,12 @@ class GenericFreightReader(
                 operationDurationInSec
               )
             )
-          case (_, Left(Error.OutOfBoundingBoxError)) =>
+          case (_, Left(error)) =>
             errors.append(
               ErrorInfo(
                 payloadId.toString,
                 Category.FreightPayloadPlan,
-                Error.OutOfBoundingBoxError,
-                locationX.toDouble,
-                locationY.toDouble
-              )
-            )
-            None
-          case (_, Left(Error.R5SplitNullError)) =>
-            errors.append(
-              ErrorInfo(
-                payloadId.toString,
-                Category.FreightPayloadPlan,
-                Error.R5SplitNullError,
+                error,
                 locationX.toDouble,
                 locationY.toDouble
               )
@@ -296,23 +274,12 @@ class GenericFreightReader(
         ) match {
           case (warehouseZoneMaybe, Right(coord)) =>
             Some(FreightCarrierRow(carrierId, tourId, vehicleId, vehicleTypeId, warehouseZoneMaybe, coord))
-          case (_, Left(Error.OutOfBoundingBoxError)) =>
+          case (_, Left(error)) =>
             errors.append(
               ErrorInfo(
                 carrierId.toString,
                 Category.FreightCarrier,
-                Error.OutOfBoundingBoxError,
-                warehouseX.toDouble,
-                warehouseY.toDouble
-              )
-            )
-            None
-          case (_, Left(Error.R5SplitNullError)) =>
-            errors.append(
-              ErrorInfo(
-                carrierId.toString,
-                Category.FreightCarrier,
-                Error.R5SplitNullError,
+                error,
                 warehouseX.toDouble,
                 warehouseY.toDouble
               )

--- a/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/GenericFreightReader.scala
@@ -367,7 +367,8 @@ class GenericFreightReader(
       val taz = getTaz(strZone)
       (Some(taz.tazId), Left(getDistributedTazLocation(taz)))
     } else {
-      (None, Right(snapLocationHelper.computeResult(location(strX.toDouble, strY.toDouble))))
+      val wasInWgs = config.convertWgs2Utm
+      (None, Right(snapLocationHelper.computeResult(location(strX.toDouble, strY.toDouble), wasInWgs)))
     }
   }
 

--- a/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
+++ b/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
@@ -8,6 +8,7 @@ import beam.router.Modes.BeamMode
 import beam.router.Modes.BeamMode.{CAR, CAV, RIDE_HAIL, RIDE_HAIL_POOLED, WALK, WALK_TRANSIT}
 import beam.sim.BeamServices
 import beam.sim.population.AttributesOfIndividual
+import beam.utils.SnapCoordinateUtils.SnapLocationHelper
 import org.matsim.api.core.v01.population.{Activity, Person, Plan}
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.population.PopulationUtils
@@ -22,7 +23,8 @@ class SupplementaryTripGenerator(
   val attributesOfIndividual: AttributesOfIndividual,
   val destinationChoiceModel: DestinationChoiceModel,
   val beamServices: BeamServices,
-  val personId: Id[Person]
+  val personId: Id[Person],
+  val snapLocationHelper: SnapLocationHelper
 ) {
   val r: Random.type = scala.util.Random
   val personSpecificSeed: Long = personId.hashCode().toLong
@@ -199,7 +201,7 @@ class SupplementaryTripGenerator(
         val newActivity =
           PopulationUtils.createActivityFromCoord(
             newActivityType,
-            TAZTreeMap.randomLocationInTAZ(chosenAlternative.taz)
+            TAZTreeMap.randomLocationInTAZ(chosenAlternative.taz, snapLocationHelperMaybe = Some(snapLocationHelper))
           )
         val activityBeforeNewActivity =
           PopulationUtils.createActivityFromCoord(prevActivity.getType, prevActivity.getCoord)
@@ -244,7 +246,8 @@ class SupplementaryTripGenerator(
         Map[SupplementaryTripAlternative, Map[SupplementaryTripAlternative, Map[DestinationParameters, Double]]]()
       } else {
         TAZs.map { taz =>
-          val destinationCoord: Coord = TAZTreeMap.randomLocationInTAZ(taz)
+          val destinationCoord: Coord =
+            TAZTreeMap.randomLocationInTAZ(taz, snapLocationHelperMaybe = Some(snapLocationHelper))
           val additionalActivity = PopulationUtils.createActivityFromCoord(newActivityType, destinationCoord)
           additionalActivity.setStartTime(startTime)
           additionalActivity.setEndTime(endTime)

--- a/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
+++ b/src/main/scala/beam/replanning/SupplementaryTripGenerator.scala
@@ -24,7 +24,7 @@ class SupplementaryTripGenerator(
   val destinationChoiceModel: DestinationChoiceModel,
   val beamServices: BeamServices,
   val personId: Id[Person],
-  val snapLocationHelper: SnapLocationHelper
+  val snapLocationHelperMaybe: Option[SnapLocationHelper] = None
 ) {
   val r: Random.type = scala.util.Random
   val personSpecificSeed: Long = personId.hashCode().toLong
@@ -201,7 +201,7 @@ class SupplementaryTripGenerator(
         val newActivity =
           PopulationUtils.createActivityFromCoord(
             newActivityType,
-            TAZTreeMap.randomLocationInTAZ(chosenAlternative.taz, snapLocationHelperMaybe = Some(snapLocationHelper))
+            TAZTreeMap.randomLocationInTAZ(chosenAlternative.taz, snapLocationHelperMaybe = snapLocationHelperMaybe)
           )
         val activityBeforeNewActivity =
           PopulationUtils.createActivityFromCoord(prevActivity.getType, prevActivity.getCoord)
@@ -247,7 +247,7 @@ class SupplementaryTripGenerator(
       } else {
         TAZs.map { taz =>
           val destinationCoord: Coord =
-            TAZTreeMap.randomLocationInTAZ(taz, snapLocationHelperMaybe = Some(snapLocationHelper))
+            TAZTreeMap.randomLocationInTAZ(taz, snapLocationHelperMaybe = snapLocationHelperMaybe)
           val additionalActivity = PopulationUtils.createActivityFromCoord(newActivityType, destinationCoord)
           additionalActivity.setStartTime(startTime)
           additionalActivity.setEndTime(endTime)

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -800,10 +800,9 @@ trait BeamHelper extends LazyLogging {
     matsimConfig: MatsimConfig
   ): (MutableScenario, BeamScenario, Boolean) = {
     val scenarioConfig = beamConfig.beam.exchange.scenario
-
     val src = scenarioConfig.source.toLowerCase
-
     val fileFormat = scenarioConfig.fileFormat
+    val outputDir = matsimConfig.controler().getOutputDirectory
 
     val (scenario, beamScenario, plansMerged) =
       ProfilingUtils.timed(s"Load scenario using $src/$fileFormat", x => logger.info(x)) {
@@ -862,7 +861,8 @@ trait BeamHelper extends LazyLogging {
                 beamScenario,
                 source,
                 new GeoUtilsImpl(beamConfig),
-                Some(merger)
+                Some(merger),
+                Some(outputDir)
               ).loadScenario()
             if (src == "urbansim_v2") {
               new ScenarioAdjuster(
@@ -884,7 +884,13 @@ trait BeamHelper extends LazyLogging {
                   rdr = readers.BeamCsvScenarioReader
                 )
                 val scenarioBuilder = ScenarioBuilder(matsimConfig, beamScenario.network)
-                new BeamScenarioLoader(scenarioBuilder, beamScenario, source, new GeoUtilsImpl(beamConfig))
+                new BeamScenarioLoader(
+                  scenarioBuilder,
+                  beamScenario,
+                  source,
+                  new GeoUtilsImpl(beamConfig),
+                  Some(outputDir)
+                )
                   .loadScenario()
               }.asInstanceOf[MutableScenario]
               (scenario, beamScenario, false)

--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -701,18 +701,29 @@ trait BeamHelper extends LazyLogging {
 
     if (beamScenario.beamConfig.beam.agentsim.snapLocationAndRemoveInvalidInputs) {
       logger.info(s"""
-           |The parameter `beam.agentsim.snapLocationAndRemoveInvalidInputs` is enabled.
-           |This may take some time to finish based on the size of population/households.""".stripMargin)
+      |The parameter `beam.agentsim.snapLocationAndRemoveInvalidInputs` is enabled.
+      |This may take some time to finish depending on the size of population/households.""".stripMargin)
+
+      val beforeHouseholdsCount = scenario.getHouseholds.getHouseholds.size()
+      val beforePopulationCount = scenario.getPopulation.getPersons.size()
+
       val snapLocationHelper = SnapLocationHelper(
         new GeoUtilsImpl(beamScenario.beamConfig),
         beamScenario.transportNetwork.streetLayer,
         beamScenario.beamConfig.beam.routing.r5.linkRadiusMeters
       )
+
       ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
-      logger.info(s"""
-        |After snapping locations and validating scenario:
-        |Number of households: ${scenario.getHouseholds.getHouseholds.size()}
-        |Number of persons: ${scenario.getPopulation.getPersons.size()}""".stripMargin)
+
+      val afterHouseholdsCount = scenario.getHouseholds.getHouseholds.size()
+      val afterPopulationCount = scenario.getPopulation.getPersons.size()
+
+      logger.info(
+        s"""
+      |After snapping locations and validating scenario:
+      |Number of households: $afterHouseholdsCount. Removed: ${beforeHouseholdsCount - afterHouseholdsCount}.
+      |Number of persons: $afterPopulationCount. Removed: ${beforePopulationCount - afterPopulationCount}.""".stripMargin
+      )
     }
 
     // write static metrics, such as population size, vehicles fleet size, etc.

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -27,6 +27,7 @@ import beam.sim.metrics.{Metrics, MetricsSupport, SimulationMetricCollector}
 import beam.sim.monitoring.ErrorListener
 import beam.sim.population.AttributesOfIndividual
 import beam.sim.vehiclesharing.Fleets
+import beam.utils.SnapCoordinateUtils.SnapLocationHelper
 import beam.utils._
 import beam.utils.csv.writers.PlansCsvWriter
 import beam.utils.logging.{LoggingMessageActor, MessageLogger}
@@ -69,6 +70,12 @@ class BeamMobsim @Inject() (
 
   import beamServices._
   val physsimConfig = beamConfig.beam.physsim
+
+  val snapLocationHelper = SnapLocationHelper(
+    geo,
+    beamScenario.transportNetwork.streetLayer,
+    beamConfig.beam.routing.r5.linkRadiusMeters
+  )
 
   override def run(): Unit = {
     logger.info("Starting Iteration")
@@ -224,7 +231,8 @@ class BeamMobsim @Inject() (
               person.getCustomAttributes.get("beam-attributes").asInstanceOf[AttributesOfIndividual],
               destinationChoiceModel,
               beamServices,
-              person.getId
+              person.getId,
+              snapLocationHelper
             )
           val newPlan =
             supplementaryTripGenerator.generateNewPlans(person.getSelectedPlan, destinationChoiceModel, modesAvailable)

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -232,7 +232,7 @@ class BeamMobsim @Inject() (
               destinationChoiceModel,
               beamServices,
               person.getId,
-              Some(snapLocationHelper)
+              snapLocationHelper
             )
           val newPlan =
             supplementaryTripGenerator.generateNewPlans(person.getSelectedPlan, destinationChoiceModel, modesAvailable)

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -232,7 +232,7 @@ class BeamMobsim @Inject() (
               destinationChoiceModel,
               beamServices,
               person.getId,
-              snapLocationHelper
+              Some(snapLocationHelper)
             )
           val newPlan =
             supplementaryTripGenerator.generateNewPlans(person.getSelectedPlan, destinationChoiceModel, modesAvailable)

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -55,7 +55,8 @@ object BeamConfig {
       thresholdForWalkingInMeters: scala.Int,
       timeBinSize: scala.Int,
       toll: BeamConfig.Beam.Agentsim.Toll,
-      tuning: BeamConfig.Beam.Agentsim.Tuning
+      tuning: BeamConfig.Beam.Agentsim.Tuning,
+      snapLocationAndRemoveInvalidInputs: scala.Boolean
     )
 
     object Agentsim {
@@ -2211,7 +2212,11 @@ object BeamConfig {
           tuning = BeamConfig.Beam.Agentsim.Tuning(
             if (c.hasPathOrNull("tuning")) c.getConfig("tuning")
             else com.typesafe.config.ConfigFactory.parseString("tuning{}")
-          )
+          ),
+          snapLocationAndRemoveInvalidInputs =
+            if (c.hasPathOrNull("snapLocationAndRemoveInvalidInputs"))
+              c.getBoolean("snapLocationAndRemoveInvalidInputs")
+            else false
         )
       }
     }

--- a/src/main/scala/beam/sim/population/PopulationScaling.scala
+++ b/src/main/scala/beam/sim/population/PopulationScaling.scala
@@ -378,14 +378,5 @@ object PopulationScaling {
 
     val populationAdjustment = PopulationAdjustment.getPopulationAdjustment(beamServices)
     populationAdjustment.update(scenario)
-
-    // write static metrics, such as population size, vehicles fleet size, etc.
-    // necessary to be called after population sampling
-    BeamStaticMetricsWriter.writeSimulationParameters(
-      scenario,
-      beamScenario,
-      beamServices,
-      beamConfig
-    )
   }
 }

--- a/src/main/scala/beam/utils/SnapCoordinateUtils.scala
+++ b/src/main/scala/beam/utils/SnapCoordinateUtils.scala
@@ -2,7 +2,6 @@ package beam.utils
 
 import beam.sim.common.GeoUtils
 import beam.utils.csv.CsvWriter
-import beam.utils.scenario.PlanElement
 import com.conveyal.r5.streets.StreetLayer
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.Coord

--- a/src/main/scala/beam/utils/SnapCoordinateUtils.scala
+++ b/src/main/scala/beam/utils/SnapCoordinateUtils.scala
@@ -21,12 +21,12 @@ object SnapCoordinateUtils extends LazyLogging {
   final case class SnapLocationHelper(geo: GeoUtils, streetLayer: StreetLayer, maxRadius: Double) {
     private val store: TrieMap[Coord, Option[Coord]] = TrieMap.empty
 
-    def computeResult[A](utmCoord: Coord): Result = {
-      val wgsCoord = geo.utm2Wgs(utmCoord)
-      if (streetLayer.envelope.contains(wgsCoord.getX, wgsCoord.getY)) {
+    def computeResult(planCoord: Coord, isWgs: Boolean = false): Result = {
+      val coord = if (isWgs) planCoord else geo.utm2Wgs(planCoord)
+      if (streetLayer.envelope.contains(coord.getX, coord.getY)) {
         val snapCoordOpt = store.getOrElseUpdate(
-          utmCoord,
-          Option(geo.getR5Split(streetLayer, wgsCoord, maxRadius)).map { split =>
+          planCoord,
+          Option(geo.getR5Split(streetLayer, coord, maxRadius)).map { split =>
             val updatedPlanCoord = geo.splitToCoord(split)
             geo.wgs2Utm(updatedPlanCoord)
           }

--- a/src/main/scala/beam/utils/SnapCoordinateUtils.scala
+++ b/src/main/scala/beam/utils/SnapCoordinateUtils.scala
@@ -21,11 +21,16 @@ object SnapCoordinateUtils extends LazyLogging {
   final case class SnapLocationHelper(geo: GeoUtils, streetLayer: StreetLayer, maxRadius: Double) {
     private val store: TrieMap[Coord, Option[Coord]] = TrieMap.empty
 
+    def find(planCoord: Coord, isWgs: Boolean = false): Option[Coord] = {
+      val coord = if (isWgs) planCoord else geo.utm2Wgs(planCoord)
+      store.get(coord).flatten
+    }
+
     def computeResult(planCoord: Coord, isWgs: Boolean = false): Result = {
       val coord = if (isWgs) planCoord else geo.utm2Wgs(planCoord)
       if (streetLayer.envelope.contains(coord.getX, coord.getY)) {
         val snapCoordOpt = store.getOrElseUpdate(
-          planCoord,
+          coord,
           Option(geo.getR5Split(streetLayer, coord, maxRadius)).map { split =>
             val updatedPlanCoord = geo.splitToCoord(split)
             geo.wgs2Utm(updatedPlanCoord)

--- a/src/main/scala/beam/utils/SnapCoordinateUtils.scala
+++ b/src/main/scala/beam/utils/SnapCoordinateUtils.scala
@@ -54,6 +54,14 @@ object SnapCoordinateUtils extends LazyLogging {
     val FreightCarrier = "Carrier"
   }
 
+  object CsvFile {
+    val Plans = "snapLocationPlanErrors.csv"
+    val Households = "snapLocationHouseholdErrors.csv"
+    val FreightTours = "snapLocationFreightTourErrors.csv"
+    val FreightPayloadPlans = "snapLocationFreightPayloadPlanErrors.csv"
+    val FreightCarriers = "snapLocationFreightCarrierErrors.csv"
+  }
+
   final case class ErrorInfo(id: String, category: String, error: String, planX: Double, planY: Double)
   final case class Processed[A](data: Seq[A] = Seq.empty, errors: Seq[ErrorInfo] = Seq.empty)
 

--- a/src/main/scala/beam/utils/SnapCoordinateUtils.scala
+++ b/src/main/scala/beam/utils/SnapCoordinateUtils.scala
@@ -1,0 +1,64 @@
+package beam.utils
+
+import beam.sim.common.GeoUtils
+import beam.utils.csv.CsvWriter
+import beam.utils.scenario.PlanElement
+import com.conveyal.r5.streets.StreetLayer
+import com.typesafe.scalalogging.LazyLogging
+import org.matsim.api.core.v01.Coord
+
+import scala.collection.concurrent.TrieMap
+
+object SnapCoordinateUtils extends LazyLogging {
+
+  trait Result
+
+  object Result {
+    final case object OutOfBoundingBoxError extends Result
+    final case object R5SplitNullError extends Result
+    final case class Succeed(splitCoord: Coord) extends Result
+  }
+
+  final case class SnapLocationHelper(geo: GeoUtils, streetLayer: StreetLayer, maxRadius: Double) {
+    private val store: TrieMap[Coord, Option[Coord]] = TrieMap.empty
+
+    def computeResult[A](utmCoord: Coord): Result = {
+      val wgsCoord = geo.utm2Wgs(utmCoord)
+      if (streetLayer.envelope.contains(wgsCoord.getX, wgsCoord.getY)) {
+        val snapCoordOpt = store.getOrElseUpdate(
+          utmCoord,
+          Option(geo.getR5Split(streetLayer, wgsCoord, maxRadius)).map { split =>
+            val updatedPlanCoord = geo.splitToCoord(split)
+            geo.wgs2Utm(updatedPlanCoord)
+          }
+        )
+        snapCoordOpt.fold[Result](Result.R5SplitNullError)(Result.Succeed)
+      } else Result.OutOfBoundingBoxError
+    }
+  }
+
+  object Error {
+    val OutOfBoundingBox = "OutOfBoundingBox"
+    val R5SplitNull = "R5SplitNull"
+  }
+
+  object Category {
+    val ScenarioPerson = "Person"
+    val ScenarioHousehold = "Household"
+    val FreightTour = "Tour"
+    val FreightPayloadPlan = "PayloadPlan"
+    val FreightCarrier = "Carrier"
+  }
+
+  final case class ErrorInfo(id: String, category: String, error: String, planX: Double, planY: Double)
+  final case class Processed[A](data: Seq[A] = Seq.empty, errors: Seq[ErrorInfo] = Seq.empty)
+
+  def writeToCsv(path: String, errors: Seq[ErrorInfo]): Unit = {
+    new CsvWriter(path, "id", "category", "error", "x", "y")
+      .writeAllAndClose(
+        errors.map(error => List(error.id, error.category, error.error, error.planX, error.planY))
+      )
+    logger.info("See location error info at {}.", path)
+  }
+
+}

--- a/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
@@ -79,16 +79,16 @@ class BeamScenarioLoader(
       validateHouseholds(households)
     }
 
-    val plans = Await.result(plansF, 1800.seconds)
+    val validPlans = Await.result(plansF, 1800.seconds)
     logger.info(s"Reading plans done.")
     val persons = Await.result(personsF, 1800.seconds)
     logger.info(s"Reading persons done.")
-    val households = Await.result(householdsF, 1800.seconds)
+    val validHouseholds = Await.result(householdsF, 1800.seconds)
     logger.info(s"Reading households done.")
 
     val vehicles = scenarioSource.getVehicles
 
-    val personsWithPlans = getPersonsWithPlan(persons, plans, households)
+    val personsWithPlans = getPersonsWithPlan(persons, validPlans, validHouseholds)
     logger.info(s"There are ${personsWithPlans.size} persons with plans")
 
     beamScenario.privateVehicles.clear()
@@ -101,15 +101,15 @@ class BeamScenarioLoader(
       vehicleInfo.initialSoc.foreach(beamScenario.privateVehicleInitialSoc.put(vehicle.id, _))
     }
 
-    val newHouseholds: Iterable[Household] = buildMatsimHouseholds(households, personsWithPlans, vehicles)
+    val newHouseholds: Iterable[Household] = buildMatsimHouseholds(validHouseholds, personsWithPlans, vehicles)
     val matsimHouseholds: Households = replaceHouseholds(scenario.getHouseholds, newHouseholds)
-    val loadedAttributes = buildAttributesCoordinates(households)
+    val loadedAttributes = buildAttributesCoordinates(validHouseholds)
     replaceHouseholdsAttributes(matsimHouseholds, loadedAttributes)
 
     val scenarioPopulation: Population = buildPopulation(personsWithPlans)
     scenario.setPopulation(scenarioPopulation)
     updateAvailableModesForPopulation(scenario)
-    replacePlansFromPopulation(scenarioPopulation, plans)
+    replacePlansFromPopulation(scenarioPopulation, validPlans)
 
     logger.info("The scenario loading is completed.")
     scenario

--- a/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
@@ -5,9 +5,9 @@ import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType, VehicleManag
 import beam.router.Modes.BeamMode
 import beam.sim.BeamScenario
 import beam.sim.common.GeoUtils
-import beam.utils.logging.ExponentialLazyLogging
 import beam.utils.plan.sampling.AvailableModeUtils
 import com.google.common.annotations.VisibleForTesting
+import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.network.Link
 import org.matsim.api.core.v01.population._
 import org.matsim.api.core.v01.{Coord, Id, Scenario}
@@ -19,29 +19,29 @@ import org.matsim.vehicles.{Vehicle, VehicleType, VehicleUtils}
 
 import java.util
 import java.util.concurrent.atomic.AtomicReference
+import scala.collection.Iterable
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
 class BeamScenarioLoader(
   val scenarioBuilder: ScenarioBuilder,
   var beamScenario: BeamScenario,
   val scenarioSource: ScenarioSource,
-  val geo: GeoUtils
-) extends ExponentialLazyLogging {
+  val geo: GeoUtils,
+  val outputDirOpt: Option[String]
+) extends ScenarioLoaderHelper {
 
   import BeamScenarioLoader._
 
   type IdToAttributes = Map[String, Seq[(String, Double)]]
 
+  private implicit val ex: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   private val availableModes: Seq[String] = BeamMode.allModes.map(_.value)
 
   private val rand: Random = new Random(beamScenario.beamConfig.matsim.modules.global.randomSeed)
-
-  private lazy val plans: Iterable[PlanElement] = {
-    val r = scenarioSource.getPlans
-    logger.info(s"Read ${r.size} plans")
-    r
-  }
 
   private val scenario: MutableScenario = scenarioBuilder.build
 
@@ -61,22 +61,35 @@ class BeamScenarioLoader(
   def loadScenario(): Scenario = {
     logger.info("The scenario loading started...")
 
-    val personsWithPlans = {
-      val persons: Iterable[PersonInfo] = scenarioSource.getPersons
-      val personIdsWithPlanTmp = plans.map(_.personId).toSet
-      val result = persons.filter(person => personIdsWithPlanTmp.contains(person.personId))
-      logger.info(s"There are ${persons.size} people. ${result.size} have plans")
-      result
+    val plansF = Future {
+      val plans = scenarioSource.getPlans
+      logger.info(s"Read ${plans.size} plans")
+      validatePlans(plans)
     }
+
+    val personsF = Future {
+      val persons: Iterable[PersonInfo] = scenarioSource.getPersons
+      logger.info(s"Read ${persons.size} persons")
+      persons
+    }
+
+    val householdsF = Future {
+      val households = scenarioSource.getHousehold
+      logger.info(s"Read ${households.size} households")
+      validateHouseholds(households)
+    }
+
+    val plans = Await.result(plansF, 1800.seconds)
+    logger.info(s"Reading plans done.")
+    val persons = Await.result(personsF, 1800.seconds)
+    logger.info(s"Reading persons done.")
+    val households = Await.result(householdsF, 1800.seconds)
+    logger.info(s"Reading households done.")
 
     val vehicles = scenarioSource.getVehicles
 
-    val loadedHouseholds = scenarioSource.getHousehold
-
-    val newHouseholds: Iterable[Household] =
-      buildMatsimHouseholds(loadedHouseholds, personsWithPlans, vehicles)
-
-    val households: Households = replaceHouseholds(scenario.getHouseholds, newHouseholds)
+    val personsWithPlans = getPersonsWithPlan(persons, plans, households)
+    logger.info(s"There are ${personsWithPlans.size} persons with plans")
 
     beamScenario.privateVehicles.clear()
     beamScenario.privateVehicleInitialSoc.clear()
@@ -88,14 +101,15 @@ class BeamScenarioLoader(
       vehicleInfo.initialSoc.foreach(beamScenario.privateVehicleInitialSoc.put(vehicle.id, _))
     }
 
+    val newHouseholds: Iterable[Household] = buildMatsimHouseholds(households, personsWithPlans, vehicles)
+    val matsimHouseholds: Households = replaceHouseholds(scenario.getHouseholds, newHouseholds)
+    val loadedAttributes = buildAttributesCoordinates(households)
+    replaceHouseholdsAttributes(matsimHouseholds, loadedAttributes)
+
     val scenarioPopulation: Population = buildPopulation(personsWithPlans)
     scenario.setPopulation(scenarioPopulation)
     updateAvailableModesForPopulation(scenario)
-
     replacePlansFromPopulation(scenarioPopulation, plans)
-
-    val loadedAttributes = buildAttributesCoordinates(loadedHouseholds)
-    replaceHouseholdsAttributes(households, loadedAttributes)
 
     logger.info("The scenario loading is completed.")
     scenario
@@ -197,23 +211,24 @@ class BeamScenarioLoader(
       listOfElementsGroupedByPerson.groupBy(_.planIndex).foreach {
         case (_, listOfElementsGroupedByPlan) if listOfElementsGroupedByPlan.nonEmpty =>
           val person = population.getPersons.get(Id.createPersonId(personId.id))
+          if (person != null) {
+            val currentPlan = PopulationUtils.createPlan(person)
+            currentPlan.setScore(listOfElementsGroupedByPlan.head.planScore)
+            person.addPlan(currentPlan)
 
-          val currentPlan = PopulationUtils.createPlan(person)
-          currentPlan.setScore(listOfElementsGroupedByPlan.head.planScore)
-          person.addPlan(currentPlan)
+            val personWithoutSelectedPlan = person.getSelectedPlan == null
+            val isCurrentPlanIndexSelected = listOfElementsGroupedByPlan.head.planSelected
+            val isLastPlanIteration = person.getPlans.size() == listOfElementsGroupedByPerson.size
+            if (personWithoutSelectedPlan && (isCurrentPlanIndexSelected || isLastPlanIteration)) {
+              person.setSelectedPlan(currentPlan)
+            }
 
-          val personWithoutSelectedPlan = person.getSelectedPlan == null
-          val isCurrentPlanIndexSelected = listOfElementsGroupedByPlan.head.planSelected
-          val isLastPlanIteration = person.getPlans.size() == listOfElementsGroupedByPerson.size
-          if (personWithoutSelectedPlan && (isCurrentPlanIndexSelected || isLastPlanIteration)) {
-            person.setSelectedPlan(currentPlan)
-          }
-
-          listOfElementsGroupedByPlan.foreach { planElement =>
-            if (planElement.planElementType == PlanElement.Leg) {
-              buildAndAddLegToPlan(currentPlan, planElement)
-            } else if (planElement.planElementType == PlanElement.Activity) {
-              buildAndAddActivityToPlan(currentPlan, planElement)
+            listOfElementsGroupedByPlan.foreach { planElement =>
+              if (planElement.planElementType == PlanElement.Leg) {
+                buildAndAddLegToPlan(currentPlan, planElement)
+              } else if (planElement.planElementType == PlanElement.Activity) {
+                buildAndAddActivityToPlan(currentPlan, planElement)
+              }
             }
           }
       }
@@ -276,7 +291,7 @@ class BeamScenarioLoader(
   }
 }
 
-object BeamScenarioLoader extends ExponentialLazyLogging {
+object BeamScenarioLoader extends LazyLogging {
 
   private[utils] def buildMatsimHouseholds(
     households: Iterable[HouseholdInfo],

--- a/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/BeamScenarioLoader.scala
@@ -30,7 +30,7 @@ class BeamScenarioLoader(
   var beamScenario: BeamScenario,
   val scenarioSource: ScenarioSource,
   val geo: GeoUtils,
-  val outputDirOpt: Option[String]
+  val outputDirMaybe: Option[String]
 ) extends ScenarioLoaderHelper {
 
   import BeamScenarioLoader._

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -13,7 +13,7 @@ trait ScenarioLoaderHelper extends LazyLogging {
 
   def beamScenario: BeamScenario
   def geo: GeoUtils
-  def outputDirOpt: Option[String]
+  def outputDirMaybe: Option[String]
 
   private val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
     geo,
@@ -112,7 +112,11 @@ trait ScenarioLoaderHelper extends LazyLogging {
 
   protected def validatePlans(plans: Iterable[PlanElement]): Iterable[PlanElement] = {
     val Processed(validPlans, errors) = snapLocationPlans(plans)
-    outputDirOpt.foreach(path => SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv", errors))
+
+    outputDirMaybe.foreach { path =>
+      if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
+      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv.gz", errors)
+    }
 
     val filteredCnt = plans.size - validPlans.size
     if (filteredCnt > 0) {
@@ -123,7 +127,11 @@ trait ScenarioLoaderHelper extends LazyLogging {
 
   protected def validateHouseholds(households: Iterable[HouseholdInfo]): Iterable[HouseholdInfo] = {
     val Processed(validHouseholds, errors) = snapLocationHouseholds(households)
-    outputDirOpt.foreach(path => SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv", errors))
+
+    outputDirMaybe.foreach { path =>
+      if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
+      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv.gz", errors)
+    }
 
     val filteredCnt = households.size - validHouseholds.size
     if (filteredCnt > 0) {

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -40,19 +40,11 @@ object ScenarioLoaderHelper extends LazyLogging {
             case Right(_) =>
               // note: we don't want to update coord in-place here since we might end up removing plan from the person
               errors
-            case Left(Error.OutOfBoundingBoxError) =>
+            case Left(error) =>
               errors :+ ErrorInfo(
                 personId.toString,
                 Category.ScenarioPerson,
-                Error.OutOfBoundingBoxError,
-                planCoord.getX,
-                planCoord.getY
-              )
-            case Left(Error.R5SplitNullError) =>
-              errors :+ ErrorInfo(
-                personId.toString,
-                Category.ScenarioPerson,
-                Error.R5SplitNullError,
+                error,
                 planCoord.getX,
                 planCoord.getY
               )
@@ -137,26 +129,26 @@ object ScenarioLoaderHelper extends LazyLogging {
         case Right(splitCoord) =>
           attr.putAttribute(householdId, "homecoordx", splitCoord.getX)
           attr.putAttribute(householdId, "homecoordy", splitCoord.getY)
-        case Left(Error.OutOfBoundingBoxError) =>
+        case Left(error @ Error.OutOfBoundingBoxError) =>
           household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
           scenario.getHouseholds.getHouseholds.remove(household.getId)
           householdErrors.append(
             ErrorInfo(
               householdId,
               Category.ScenarioHousehold,
-              Error.OutOfBoundingBoxError,
+              error,
               planCoord.getX,
               planCoord.getY
             )
           )
-        case Left(Error.R5SplitNullError) =>
+        case Left(error @ Error.R5SplitNullError) =>
           household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
           scenario.getHouseholds.getHouseholds.remove(household.getId)
           householdErrors.append(
             ErrorInfo(
               householdId,
               Category.ScenarioHousehold,
-              Error.R5SplitNullError,
+              error,
               planCoord.getX,
               planCoord.getY
             )

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -3,7 +3,7 @@ package beam.utils.scenario
 import beam.sim.BeamScenario
 import beam.sim.common.GeoUtils
 import beam.utils.SnapCoordinateUtils
-import beam.utils.SnapCoordinateUtils.{Category, Error, ErrorInfo, Processed, Result, SnapLocationHelper}
+import beam.utils.SnapCoordinateUtils.{Category, CsvFile, Error, ErrorInfo, Processed, Result, SnapLocationHelper}
 import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.api.core.v01.population.{Activity, Leg, Person}
@@ -124,7 +124,7 @@ trait ScenarioLoaderHelper extends LazyLogging {
 
     outputDirMaybe.foreach { path =>
       if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv.gz", errors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Plans}", errors)
     }
 
     val filteredCnt = plans.size - validPlans.size
@@ -139,7 +139,7 @@ trait ScenarioLoaderHelper extends LazyLogging {
 
     outputDirMaybe.foreach { path =>
       if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv.gz", errors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Households}", errors)
     }
 
     val filteredCnt = households.size - validHouseholds.size
@@ -298,10 +298,10 @@ object ScenarioLoaderHelper extends LazyLogging {
 
     outputDirMaybe.foreach { path =>
       if (planErrors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv.gz", planErrors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Plans}", planErrors)
 
       if (householdErrors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv.gz", householdErrors)
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Households}", householdErrors)
     }
   }
 

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -229,9 +229,9 @@ object ScenarioLoaderHelper extends LazyLogging {
       val plans = person.getPlans.asScala.toList
       plans.foreach { plan =>
         val elements: Vector[PlanElement] = plan.getPlanElements.asScala.toVector
-        val es: Vector[ErrorInfo] = updatePlanElementCoord(person.getId, elements, snapLocationHelper)
-        if (es.nonEmpty) {
-          planErrors.appendAll(es)
+        val errors: Vector[ErrorInfo] = updatePlanElementCoord(person.getId, elements, snapLocationHelper)
+        if (errors.nonEmpty) {
+          planErrors.appendAll(errors)
           person.removePlan(plan)
         }
       }

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -5,9 +5,18 @@ import beam.sim.common.GeoUtils
 import beam.utils.SnapCoordinateUtils
 import beam.utils.SnapCoordinateUtils.{Category, Error, ErrorInfo, Processed, Result, SnapLocationHelper}
 import com.typesafe.scalalogging.LazyLogging
-import org.matsim.api.core.v01.Coord
+import org.matsim.api.core.v01.{Coord, Id}
+import org.matsim.api.core.v01.population.{Activity, Leg, Person}
+import org.matsim.core.scenario.MutableScenario
+import org.matsim.households.{Household, HouseholdsFactoryImpl}
 
 import scala.collection.Iterable
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters.{
+  collectionAsScalaIterableConverter,
+  seqAsJavaListConverter,
+  setAsJavaSetConverter
+}
 
 trait ScenarioLoaderHelper extends LazyLogging {
 
@@ -138,6 +147,162 @@ trait ScenarioLoaderHelper extends LazyLogging {
       logger.info(s"Filtered out $filteredCnt plans. Total number of plans: ${validHouseholds.size}")
     }
     validHouseholds
+  }
+
+}
+
+object ScenarioLoaderHelper extends LazyLogging {
+
+  import org.matsim.api.core.v01.population.PlanElement
+
+  private def createHouseholdWithGivenMembers(
+    household: Household,
+    members: List[Id[Person]]
+  ): Household = {
+    val householdResult = new HouseholdsFactoryImpl().createHousehold(household.getId)
+    householdResult.setIncome(household.getIncome)
+    householdResult.setVehicleIds(household.getVehicleIds)
+    householdResult.setMemberIds(members.asJava)
+    householdResult
+  }
+
+  private def updatePlanElementCoord(
+    personId: Id[Person],
+    elements: Vector[PlanElement],
+    snapLocationHelper: SnapLocationHelper
+  ): Vector[ErrorInfo] = {
+    val errors = elements.foldLeft[Vector[ErrorInfo]](Vector.empty) { (errors, element) =>
+      element match {
+        case _: Leg => errors
+        case a: Activity =>
+          val planCoord = a.getCoord
+          snapLocationHelper.computeResult(planCoord) match {
+            case Result.Succeed(_) =>
+              // note: we don't want to update coord in-place here since we might end up removing plan from the person
+              errors
+            case Result.OutOfBoundingBoxError =>
+              errors :+ ErrorInfo(
+                personId.toString,
+                Category.ScenarioPerson,
+                Error.OutOfBoundingBox,
+                planCoord.getX,
+                planCoord.getY
+              )
+            case Result.R5SplitNullError =>
+              errors :+ ErrorInfo(
+                personId.toString,
+                Category.ScenarioPerson,
+                Error.R5SplitNull,
+                planCoord.getX,
+                planCoord.getY
+              )
+          }
+      }
+    }
+
+    if (errors.isEmpty) {
+      elements.foreach {
+        case a: Activity =>
+          val planCoord = a.getCoord
+          snapLocationHelper.find(planCoord) match {
+            case Some(coord) =>
+              a.setCoord(coord)
+            case None =>
+              logger.error("UNEXPECTED: there should be mapped split location for {} coord.", planCoord)
+          }
+        case _ =>
+      }
+    }
+
+    errors
+  }
+
+  def validateScenario(
+    scenario: MutableScenario,
+    snapLocationHelper: SnapLocationHelper,
+    outputDirMaybe: Option[String] = None
+  ): Unit = {
+    val planErrors: ListBuffer[ErrorInfo] = ListBuffer()
+    val householdErrors: ListBuffer[ErrorInfo] = ListBuffer()
+    val people: List[Person] = scenario.getPopulation.getPersons.values().asScala.toList
+    people.foreach { person =>
+      val plans = person.getPlans.asScala.toList
+      plans.foreach { plan =>
+        val elements: Vector[PlanElement] = plan.getPlanElements.asScala.toVector
+        val es: Vector[ErrorInfo] = updatePlanElementCoord(person.getId, elements, snapLocationHelper)
+        if (es.nonEmpty) {
+          planErrors.appendAll(es)
+          person.removePlan(plan)
+        }
+      }
+      val planCount = person.getPlans.size()
+      if (planCount == 0) {
+        scenario.getPopulation.removePerson(person.getId)
+      }
+    }
+
+    val validPeople: Set[Id[Person]] = scenario.getPopulation.getPersons.values().asScala.map(_.getId).toSet
+
+    val households: List[Household] = scenario.getHouseholds.getHouseholds.values().asScala.toList
+    households.foreach { household =>
+      val members = household.getMemberIds.asScala.toSet
+      val validMembers = validPeople.intersect(members)
+
+      if (validMembers.isEmpty) {
+        scenario.getHouseholds.getHouseholds.remove(household.getId)
+        scenario.getHouseholds.getHouseholdAttributes.removeAllAttributes(household.getId.toString)
+      } else {
+        val updatedHousehold = createHouseholdWithGivenMembers(household, validMembers.toList)
+        scenario.getHouseholds.getHouseholds.replace(household.getId, updatedHousehold)
+      }
+    }
+
+    val householdsWithMembers: List[Household] = scenario.getHouseholds.getHouseholds.values().asScala.toList
+    householdsWithMembers.foreach { household =>
+      val householdId = household.getId.toString
+      val attr = scenario.getHouseholds.getHouseholdAttributes
+      val locationX = attr.getAttribute(householdId, "homecoordx").asInstanceOf[Double]
+      val locationY = attr.getAttribute(householdId, "homecoordy").asInstanceOf[Double]
+      val planCoord = new Coord(locationX, locationY)
+
+      snapLocationHelper.computeResult(planCoord) match {
+        case Result.Succeed(splitCoord) =>
+          attr.putAttribute(householdId, "homecoordx", splitCoord.getX)
+          attr.putAttribute(householdId, "homecoordy", splitCoord.getY)
+        case Result.OutOfBoundingBoxError =>
+          household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
+          scenario.getHouseholds.getHouseholds.remove(household.getId)
+          householdErrors.append(
+            ErrorInfo(
+              householdId,
+              Category.ScenarioHousehold,
+              Error.OutOfBoundingBox,
+              planCoord.getX,
+              planCoord.getY
+            )
+          )
+        case Result.R5SplitNullError =>
+          household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
+          scenario.getHouseholds.getHouseholds.remove(household.getId)
+          householdErrors.append(
+            ErrorInfo(
+              householdId,
+              Category.ScenarioHousehold,
+              Error.R5SplitNull,
+              planCoord.getX,
+              planCoord.getY
+            )
+          )
+      }
+    }
+
+    outputDirMaybe.foreach { path =>
+      if (planErrors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
+      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv.gz", planErrors)
+
+      if (householdErrors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
+      else SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv.gz", householdErrors)
+    }
   }
 
 }

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -1,155 +1,15 @@
 package beam.utils.scenario
 
-import beam.sim.BeamScenario
-import beam.sim.common.GeoUtils
 import beam.utils.SnapCoordinateUtils
-import beam.utils.SnapCoordinateUtils.{Category, CsvFile, Error, ErrorInfo, Processed, Result, SnapLocationHelper}
+import beam.utils.SnapCoordinateUtils.{Category, CsvFile, Error, ErrorInfo, Result, SnapLocationHelper}
 import com.typesafe.scalalogging.LazyLogging
-import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.api.core.v01.population.{Activity, Leg, Person}
+import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.scenario.MutableScenario
 import org.matsim.households.{Household, HouseholdsFactoryImpl}
 
-import scala.collection.Iterable
 import scala.collection.mutable.ListBuffer
-import scala.jdk.CollectionConverters.{
-  collectionAsScalaIterableConverter,
-  seqAsJavaListConverter,
-  setAsJavaSetConverter
-}
-
-trait ScenarioLoaderHelper extends LazyLogging {
-
-  def beamScenario: BeamScenario
-  def geo: GeoUtils
-  def outputDirMaybe: Option[String]
-
-  private val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
-    geo,
-    beamScenario.transportNetwork.streetLayer,
-    beamScenario.beamConfig.beam.routing.r5.linkRadiusMeters
-  )
-
-  private def validatePersonPlans(personId: PersonId, plans: Iterable[PlanElement]): Processed[PlanElement] = {
-    plans.foldLeft[Processed[PlanElement]](Processed()) {
-      case (processed, planElement) if planElement.planElementType == PlanElement.Leg =>
-        processed.copy(data = processed.data :+ planElement)
-      case (processed, planElement) if planElement.planElementType == PlanElement.Activity =>
-        val utmCoord = new Coord(planElement.activityLocationX.get, planElement.activityLocationY.get)
-        snapLocationHelper.computeResult(utmCoord) match {
-          case Result.Succeed(splitCoord) =>
-            val updatedPlan = planElement
-              .copy(activityLocationX = Some(splitCoord.getX), activityLocationY = Some(splitCoord.getY))
-            processed.copy(data = processed.data :+ updatedPlan)
-          case Result.OutOfBoundingBoxError =>
-            processed.copy(errors =
-              processed.errors :+ ErrorInfo(
-                personId.id,
-                Category.ScenarioPerson,
-                Error.OutOfBoundingBox,
-                utmCoord.getX,
-                utmCoord.getY
-              )
-            )
-          case Result.R5SplitNullError =>
-            processed.copy(errors =
-              processed.errors :+ ErrorInfo(
-                personId.id,
-                Category.ScenarioPerson,
-                Error.R5SplitNull,
-                utmCoord.getX,
-                utmCoord.getY
-              )
-            )
-        }
-    }
-  }
-
-  private def snapLocationPlans(plans: Iterable[PlanElement]): Processed[PlanElement] = {
-    plans.groupBy(_.personId).foldLeft[Processed[PlanElement]](Processed()) {
-      case (processed, (personId, personPlans)) =>
-        val Processed(updatedPlans, errors) = validatePersonPlans(personId, personPlans)
-        if (updatedPlans.size == personPlans.size) {
-          processed.copy(data = processed.data ++ updatedPlans, errors = processed.errors ++ errors)
-        } else {
-          processed.copy(errors = processed.errors ++ errors)
-        }
-    }
-  }
-
-  private def snapLocationHouseholds(households: Iterable[HouseholdInfo]): Processed[HouseholdInfo] = {
-    households.foldLeft[Processed[HouseholdInfo]](Processed()) { case (processed, household) =>
-      val householdId = household.householdId.id
-      val utmCoord = new Coord(household.locationX, household.locationY)
-      snapLocationHelper.computeResult(utmCoord) match {
-        case Result.Succeed(splitCoord) =>
-          val updatedHousehold = household.copy(locationX = splitCoord.getX, locationY = splitCoord.getY)
-          processed.copy(data = processed.data :+ updatedHousehold)
-        case Result.OutOfBoundingBoxError =>
-          processed.copy(errors =
-            processed.errors :+ ErrorInfo(
-              householdId,
-              Category.ScenarioHousehold,
-              Error.OutOfBoundingBox,
-              utmCoord.getX,
-              utmCoord.getY
-            )
-          )
-        case Result.R5SplitNullError =>
-          processed.copy(errors =
-            processed.errors :+ ErrorInfo(
-              householdId,
-              Category.ScenarioHousehold,
-              Error.R5SplitNull,
-              utmCoord.getX,
-              utmCoord.getY
-            )
-          )
-      }
-    }
-  }
-
-  protected def getPersonsWithPlan(
-    persons: Iterable[PersonInfo],
-    plans: Iterable[PlanElement],
-    households: Iterable[HouseholdInfo]
-  ): Iterable[PersonInfo] = {
-    val personIdsWithPlan = plans.map(_.personId).toSet
-    val householdIds = households.map(_.householdId).toSet
-    persons.filter(person => personIdsWithPlan.contains(person.personId) && householdIds.contains(person.householdId))
-  }
-
-  protected def validatePlans(plans: Iterable[PlanElement]): Iterable[PlanElement] = {
-    val Processed(validPlans, errors) = snapLocationPlans(plans)
-
-    outputDirMaybe.foreach { path =>
-      if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Plans}", errors)
-    }
-
-    val filteredCnt = plans.size - validPlans.size
-    if (filteredCnt > 0) {
-      logger.info(s"Filtered out $filteredCnt plans. Total number of plans: ${validPlans.size}")
-    }
-    validPlans
-  }
-
-  protected def validateHouseholds(households: Iterable[HouseholdInfo]): Iterable[HouseholdInfo] = {
-    val Processed(validHouseholds, errors) = snapLocationHouseholds(households)
-
-    outputDirMaybe.foreach { path =>
-      if (errors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Households}", errors)
-    }
-
-    val filteredCnt = households.size - validHouseholds.size
-    if (filteredCnt > 0) {
-      logger.info(s"Filtered out $filteredCnt plans. Total number of plans: ${validHouseholds.size}")
-    }
-    validHouseholds
-  }
-
-}
+import scala.jdk.CollectionConverters.{collectionAsScalaIterableConverter, seqAsJavaListConverter}
 
 object ScenarioLoaderHelper extends LazyLogging {
 
@@ -222,10 +82,11 @@ object ScenarioLoaderHelper extends LazyLogging {
     snapLocationHelper: SnapLocationHelper,
     outputDirMaybe: Option[String] = None
   ): Unit = {
+
     val planErrors: ListBuffer[ErrorInfo] = ListBuffer()
-    val householdErrors: ListBuffer[ErrorInfo] = ListBuffer()
+
     val people: List[Person] = scenario.getPopulation.getPersons.values().asScala.toList
-    people.foreach { person =>
+    people.par.foreach { person =>
       val plans = person.getPlans.asScala.toList
       plans.foreach { plan =>
         val elements: Vector[PlanElement] = plan.getPlanElements.asScala.toVector
@@ -241,24 +102,31 @@ object ScenarioLoaderHelper extends LazyLogging {
       }
     }
 
+    outputDirMaybe.foreach { path =>
+      if (planErrors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
+      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Plans}", planErrors)
+    }
+
     val validPeople: Set[Id[Person]] = scenario.getPopulation.getPersons.values().asScala.map(_.getId).toSet
 
     val households: List[Household] = scenario.getHouseholds.getHouseholds.values().asScala.toList
-    households.foreach { household =>
+    households.par.foreach { household =>
       val members = household.getMemberIds.asScala.toSet
       val validMembers = validPeople.intersect(members)
 
       if (validMembers.isEmpty) {
-        scenario.getHouseholds.getHouseholds.remove(household.getId)
         scenario.getHouseholds.getHouseholdAttributes.removeAllAttributes(household.getId.toString)
-      } else {
+        scenario.getHouseholds.getHouseholds.remove(household.getId)
+      } else if (validMembers != members) {
         val updatedHousehold = createHouseholdWithGivenMembers(household, validMembers.toList)
         scenario.getHouseholds.getHouseholds.replace(household.getId, updatedHousehold)
       }
     }
 
+    val householdErrors: ListBuffer[ErrorInfo] = ListBuffer()
+
     val householdsWithMembers: List[Household] = scenario.getHouseholds.getHouseholds.values().asScala.toList
-    householdsWithMembers.foreach { household =>
+    householdsWithMembers.par.foreach { household =>
       val householdId = household.getId.toString
       val attr = scenario.getHouseholds.getHouseholdAttributes
       val locationX = attr.getAttribute(householdId, "homecoordx").asInstanceOf[Double]
@@ -297,12 +165,10 @@ object ScenarioLoaderHelper extends LazyLogging {
     }
 
     outputDirMaybe.foreach { path =>
-      if (planErrors.isEmpty) logger.info("No 'snap location' error to report for scenario plans.")
-      else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Plans}", planErrors)
-
       if (householdErrors.isEmpty) logger.info("No 'snap location' error to report for scenario households.")
       else SnapCoordinateUtils.writeToCsv(s"$path/${CsvFile.Households}", householdErrors)
     }
+
   }
 
 }

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -129,19 +129,7 @@ object ScenarioLoaderHelper extends LazyLogging {
         case Right(splitCoord) =>
           attr.putAttribute(householdId, "homecoordx", splitCoord.getX)
           attr.putAttribute(householdId, "homecoordy", splitCoord.getY)
-        case Left(error @ Error.OutOfBoundingBoxError) =>
-          household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
-          scenario.getHouseholds.getHouseholds.remove(household.getId)
-          householdErrors.append(
-            ErrorInfo(
-              householdId,
-              Category.ScenarioHousehold,
-              error,
-              planCoord.getX,
-              planCoord.getY
-            )
-          )
-        case Left(error @ Error.R5SplitNullError) =>
+        case Left(error) =>
           household.getMemberIds.asScala.toList.foreach(personId => scenario.getPopulation.getPersons.remove(personId))
           scenario.getHouseholds.getHouseholds.remove(household.getId)
           householdErrors.append(

--- a/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
+++ b/src/main/scala/beam/utils/scenario/ScenarioLoaderHelper.scala
@@ -1,0 +1,135 @@
+package beam.utils.scenario
+
+import beam.sim.BeamScenario
+import beam.sim.common.GeoUtils
+import beam.utils.SnapCoordinateUtils
+import beam.utils.SnapCoordinateUtils.{Category, Error, ErrorInfo, Processed, Result, SnapLocationHelper}
+import com.typesafe.scalalogging.LazyLogging
+import org.matsim.api.core.v01.Coord
+
+import scala.collection.Iterable
+
+trait ScenarioLoaderHelper extends LazyLogging {
+
+  def beamScenario: BeamScenario
+  def geo: GeoUtils
+  def outputDirOpt: Option[String]
+
+  private val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+    geo,
+    beamScenario.transportNetwork.streetLayer,
+    beamScenario.beamConfig.beam.routing.r5.linkRadiusMeters
+  )
+
+  private def validatePersonPlans(personId: PersonId, plans: Iterable[PlanElement]): Processed[PlanElement] = {
+    plans.foldLeft[Processed[PlanElement]](Processed()) {
+      case (processed, planElement) if planElement.planElementType == PlanElement.Leg =>
+        processed.copy(data = processed.data :+ planElement)
+      case (processed, planElement) if planElement.planElementType == PlanElement.Activity =>
+        val utmCoord = new Coord(planElement.activityLocationX.get, planElement.activityLocationY.get)
+        snapLocationHelper.computeResult(utmCoord) match {
+          case Result.Succeed(splitCoord) =>
+            val updatedPlan = planElement
+              .copy(activityLocationX = Some(splitCoord.getX), activityLocationY = Some(splitCoord.getY))
+            processed.copy(data = processed.data :+ updatedPlan)
+          case Result.OutOfBoundingBoxError =>
+            processed.copy(errors =
+              processed.errors :+ ErrorInfo(
+                personId.id,
+                Category.ScenarioPerson,
+                Error.OutOfBoundingBox,
+                utmCoord.getX,
+                utmCoord.getY
+              )
+            )
+          case Result.R5SplitNullError =>
+            processed.copy(errors =
+              processed.errors :+ ErrorInfo(
+                personId.id,
+                Category.ScenarioPerson,
+                Error.R5SplitNull,
+                utmCoord.getX,
+                utmCoord.getY
+              )
+            )
+        }
+    }
+  }
+
+  private def snapLocationPlans(plans: Iterable[PlanElement]): Processed[PlanElement] = {
+    plans.groupBy(_.personId).foldLeft[Processed[PlanElement]](Processed()) {
+      case (processed, (personId, personPlans)) =>
+        val Processed(updatedPlans, errors) = validatePersonPlans(personId, personPlans)
+        if (updatedPlans.size == personPlans.size) {
+          processed.copy(data = processed.data ++ updatedPlans, errors = processed.errors ++ errors)
+        } else {
+          processed.copy(errors = processed.errors ++ errors)
+        }
+    }
+  }
+
+  private def snapLocationHouseholds(households: Iterable[HouseholdInfo]): Processed[HouseholdInfo] = {
+    households.foldLeft[Processed[HouseholdInfo]](Processed()) { case (processed, household) =>
+      val householdId = household.householdId.id
+      val utmCoord = new Coord(household.locationX, household.locationY)
+      snapLocationHelper.computeResult(utmCoord) match {
+        case Result.Succeed(splitCoord) =>
+          val updatedHousehold = household.copy(locationX = splitCoord.getX, locationY = splitCoord.getY)
+          processed.copy(data = processed.data :+ updatedHousehold)
+        case Result.OutOfBoundingBoxError =>
+          processed.copy(errors =
+            processed.errors :+ ErrorInfo(
+              householdId,
+              Category.ScenarioHousehold,
+              Error.OutOfBoundingBox,
+              utmCoord.getX,
+              utmCoord.getY
+            )
+          )
+        case Result.R5SplitNullError =>
+          processed.copy(errors =
+            processed.errors :+ ErrorInfo(
+              householdId,
+              Category.ScenarioHousehold,
+              Error.R5SplitNull,
+              utmCoord.getX,
+              utmCoord.getY
+            )
+          )
+      }
+    }
+  }
+
+  protected def getPersonsWithPlan(
+    persons: Iterable[PersonInfo],
+    plans: Iterable[PlanElement],
+    households: Iterable[HouseholdInfo]
+  ): Iterable[PersonInfo] = {
+    val personIdsWithPlan = plans.map(_.personId).toSet
+    val householdIds = households.map(_.householdId).toSet
+    persons.filter(person => personIdsWithPlan.contains(person.personId) && householdIds.contains(person.householdId))
+  }
+
+  protected def validatePlans(plans: Iterable[PlanElement]): Iterable[PlanElement] = {
+    val Processed(validPlans, errors) = snapLocationPlans(plans)
+    outputDirOpt.foreach(path => SnapCoordinateUtils.writeToCsv(s"$path/snapLocationPlanErrors.csv", errors))
+
+    val filteredCnt = plans.size - validPlans.size
+    if (filteredCnt > 0) {
+      logger.info(s"Filtered out $filteredCnt plans. Total number of plans: ${validPlans.size}")
+    }
+    validPlans
+  }
+
+  protected def validateHouseholds(households: Iterable[HouseholdInfo]): Iterable[HouseholdInfo] = {
+    val Processed(validHouseholds, errors) = snapLocationHouseholds(households)
+    outputDirOpt.foreach(path => SnapCoordinateUtils.writeToCsv(s"$path/snapLocationHouseholdErrors.csv", errors))
+
+    val filteredCnt = households.size - validHouseholds.size
+    if (filteredCnt > 0) {
+      logger.info(s"Filtered out $filteredCnt plans. Total number of plans: ${validHouseholds.size}")
+    }
+    validHouseholds
+  }
+
+}

--- a/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
@@ -31,7 +31,7 @@ class UrbanSimScenarioLoader(
   val scenarioSource: ScenarioSource,
   val geo: GeoUtils,
   val previousRunPlanMerger: Option[PreviousRunPlanMerger] = None,
-  val outputDirMaybe: Option[String]
+  val outputDirMaybe: Option[String] = None
 ) extends ScenarioLoaderHelper {
 
   private implicit val ex: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
@@ -31,7 +31,7 @@ class UrbanSimScenarioLoader(
   val scenarioSource: ScenarioSource,
   val geo: GeoUtils,
   val previousRunPlanMerger: Option[PreviousRunPlanMerger] = None,
-  val outputDirOpt: Option[String]
+  val outputDirMaybe: Option[String]
 ) extends ScenarioLoaderHelper {
 
   private implicit val ex: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
@@ -45,7 +45,7 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
 
   val rnd = new Random(2333L)
 
-  private val reader = new GenericFreightReader(freightConfig, geoUtils, rnd, tazMap, None)
+  private val reader = new GenericFreightReader(freightConfig, geoUtils, rnd, tazMap)
 
   "PayloadPlansConverter" should {
     "read Payload Plans" in {
@@ -154,12 +154,12 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
   }
 
   private def readCarriers: IndexedSeq[FreightCarrier] = {
-    val converter = new GenericFreightReader(freightConfig, geoUtils, new Random(4324L), tazMap, None)
+    val converter = new GenericFreightReader(freightConfig, geoUtils, new Random(4324L), tazMap)
     val payloadPlans: Map[Id[PayloadPlan], PayloadPlan] = converter.readPayloadPlans()
     val tours = converter.readFreightTours()
     val vehicleTypes = BeamVehicleUtils.readBeamVehicleTypeFile("test/input/beamville/vehicleTypes.csv")
     val freightCarriers: IndexedSeq[FreightCarrier] =
-      new GenericFreightReader(freightConfig, geoUtils, new Random(73737L), tazMap, None).readFreightCarriers(
+      new GenericFreightReader(freightConfig, geoUtils, new Random(73737L), tazMap).readFreightCarriers(
         tours,
         payloadPlans,
         vehicleTypes

--- a/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
@@ -45,7 +45,8 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
 
   val rnd = new Random(2333L)
 
-  private val reader = new GenericFreightReader(freightConfig, geoUtils, rnd, tazMap)
+  private val reader =
+    new GenericFreightReader(freightConfig, geoUtils, rnd, tazMap, snapLocationAndRemoveInvalidInputs = false)
 
   "PayloadPlansConverter" should {
     "read Payload Plans" in {
@@ -154,12 +155,24 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
   }
 
   private def readCarriers: IndexedSeq[FreightCarrier] = {
-    val converter = new GenericFreightReader(freightConfig, geoUtils, new Random(4324L), tazMap)
+    val converter = new GenericFreightReader(
+      freightConfig,
+      geoUtils,
+      new Random(4324L),
+      tazMap,
+      snapLocationAndRemoveInvalidInputs = false
+    )
     val payloadPlans: Map[Id[PayloadPlan], PayloadPlan] = converter.readPayloadPlans()
     val tours = converter.readFreightTours()
     val vehicleTypes = BeamVehicleUtils.readBeamVehicleTypeFile("test/input/beamville/vehicleTypes.csv")
     val freightCarriers: IndexedSeq[FreightCarrier] =
-      new GenericFreightReader(freightConfig, geoUtils, new Random(73737L), tazMap).readFreightCarriers(
+      new GenericFreightReader(
+        freightConfig,
+        geoUtils,
+        new Random(73737L),
+        tazMap,
+        snapLocationAndRemoveInvalidInputs = false
+      ).readFreightCarriers(
         tours,
         payloadPlans,
         vehicleTypes

--- a/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
@@ -5,6 +5,7 @@ import beam.agentsim.infrastructure.taz.TAZTreeMap
 import beam.sim.common.GeoUtils
 import beam.sim.config.BeamConfig.Beam.Agentsim.Agents.Freight
 import beam.utils.BeamVehicleUtils
+import beam.utils.SnapCoordinateUtils.SnapLocationHelper
 import beam.utils.matsim_conversion.MatsimPlanConversion.IdOps
 import org.matsim.api.core.v01.population.{Activity, Person, Plan, PopulationFactory}
 import org.matsim.api.core.v01.{Coord, Id}
@@ -45,8 +46,17 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
 
   val rnd = new Random(2333L)
 
+  val snapLocationHelper = Mockito.mock(classOf[SnapLocationHelper])
+
   private val reader =
-    new GenericFreightReader(freightConfig, geoUtils, rnd, tazMap, snapLocationAndRemoveInvalidInputs = false)
+    new GenericFreightReader(
+      freightConfig,
+      geoUtils,
+      rnd,
+      tazMap,
+      snapLocationAndRemoveInvalidInputs = false,
+      snapLocationHelper
+    )
 
   "PayloadPlansConverter" should {
     "read Payload Plans" in {
@@ -158,7 +168,8 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
       geoUtils,
       new Random(4324L),
       tazMap,
-      snapLocationAndRemoveInvalidInputs = false
+      snapLocationAndRemoveInvalidInputs = false,
+      snapLocationHelper
     )
     val payloadPlans: Map[Id[PayloadPlan], PayloadPlan] = converter.readPayloadPlans()
     val tours = converter.readFreightTours()
@@ -169,7 +180,8 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers {
         geoUtils,
         new Random(73737L),
         tazMap,
-        snapLocationAndRemoveInvalidInputs = false
+        snapLocationAndRemoveInvalidInputs = false,
+        snapLocationHelper
       ).readFreightCarriers(
         tours,
         payloadPlans,

--- a/src/test/scala/beam/utils/ModeExclusionTest.scala
+++ b/src/test/scala/beam/utils/ModeExclusionTest.scala
@@ -32,7 +32,7 @@ class ModeExclusionTest extends AnyWordSpecLike with Matchers with BeforeAndAfte
     val plans = BeamCsvScenarioReader.readPlansFile("test/input/beamville/csvInput/plans.csv")
     val personIdsWithPlanTmp = plans.map(_.personId).toSet
     val personWithPlans = persons.filter(person => personIdsWithPlanTmp.contains(person.personId))
-    val scenarioLoader = new BeamScenarioLoader(scenarioBuilder, beamScenario, scenarioSource, geoUtils, None)
+    val scenarioLoader = new BeamScenarioLoader(scenarioBuilder, beamScenario, scenarioSource, geoUtils)
     val population = scenarioLoader.buildPopulation(personWithPlans)
 
     "check for removal of single mode" in {

--- a/src/test/scala/beam/utils/ModeExclusionTest.scala
+++ b/src/test/scala/beam/utils/ModeExclusionTest.scala
@@ -32,7 +32,7 @@ class ModeExclusionTest extends AnyWordSpecLike with Matchers with BeforeAndAfte
     val plans = BeamCsvScenarioReader.readPlansFile("test/input/beamville/csvInput/plans.csv")
     val personIdsWithPlanTmp = plans.map(_.personId).toSet
     val personWithPlans = persons.filter(person => personIdsWithPlanTmp.contains(person.personId))
-    val scenarioLoader = new BeamScenarioLoader(scenarioBuilder, beamScenario, scenarioSource, geoUtils)
+    val scenarioLoader = new BeamScenarioLoader(scenarioBuilder, beamScenario, scenarioSource, geoUtils, None)
     val population = scenarioLoader.buildPopulation(personWithPlans)
 
     "check for removal of single mode" in {

--- a/src/test/scala/beam/utils/SnapCoordinateSpec.scala
+++ b/src/test/scala/beam/utils/SnapCoordinateSpec.scala
@@ -1,0 +1,67 @@
+package beam.utils
+
+import beam.sim.BeamHelper
+import beam.sim.common.GeoUtilsImpl
+import beam.sim.config.{BeamConfig, MatSimBeamConfigBuilder}
+import beam.utils.SnapCoordinateUtils.{Result, SnapLocationHelper}
+import beam.utils.TestConfigUtils.testConfig
+import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
+import org.matsim.api.core.v01.Coord
+import org.matsim.api.core.v01.population.Activity
+import org.matsim.core.config.Config
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
+
+class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
+
+  "scenario plan" should {
+    "contain all valid locations" in {
+      lazy val config: TypesafeConfig = ConfigFactory
+        .parseString("""
+                       |beam.routing.r5.linkRadiusMeters = 350
+                       |""".stripMargin)
+        .withFallback(testConfig("test/input/beamville/beam.conf"))
+        .resolve()
+
+      val configBuilder = new MatSimBeamConfigBuilder(config)
+      val matsimConfig: Config = configBuilder.buildMatSimConf()
+      matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+      val beamConfig: BeamConfig = BeamConfig(config)
+
+      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
+        beamConfig,
+        matsimConfig
+      )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+
+      val dummyCoord = new Coord()
+      val results: Seq[SnapCoordinateUtils.Result] = scenario.getPopulation.getPersons
+        .values()
+        .asScala
+        .flatMap { person =>
+          person.getPlans.asScala.flatMap { plan =>
+            plan.getPlanElements.asScala.map {
+              case e: Activity => snapLocationHelper.computeResult(e.getCoord)
+              case _           => Result.Succeed(dummyCoord)
+            }
+          }
+        }
+        .toList
+
+      results.forall {
+        case _: Result.Succeed => true
+        case _                 => false
+      } shouldBe true
+    }
+  }
+
+}

--- a/src/test/scala/beam/utils/SnapCoordinateSpec.scala
+++ b/src/test/scala/beam/utils/SnapCoordinateSpec.scala
@@ -6,6 +6,7 @@ import beam.sim.common.GeoUtilsImpl
 import beam.sim.config.{BeamConfig, MatSimBeamConfigBuilder}
 import beam.utils.SnapCoordinateUtils.{CsvFile, ErrorInfo, Result, SnapLocationHelper}
 import beam.utils.TestConfigUtils.testConfig
+import beam.utils.scenario.ScenarioLoaderHelper
 import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
 import org.matsim.api.core.v01.Coord
 import org.matsim.api.core.v01.population.{Activity, Population}
@@ -79,7 +80,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
       matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
       val beamConfig: BeamConfig = BeamConfig(config)
 
-      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+      val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
       val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
@@ -91,6 +92,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
         beamScenario.transportNetwork.streetLayer,
         beamConfig.beam.routing.r5.linkRadiusMeters
       )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       val dummyCoord = new Coord()
       val population: Seq[SnapCoordinateUtils.Result] = scenario.getPopulation.getPersons
@@ -150,10 +152,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
 
@@ -188,10 +197,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       scenario.getPopulation.getPersons.size() shouldBe 1
       intersection(scenario.getPopulation, path = s"$outputDir/${CsvFile.Plans}") shouldBe Set.empty
@@ -217,10 +233,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
 
@@ -249,10 +272,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       scenario.getPopulation.getPersons.size() shouldBe 1
       intersection(scenario.getPopulation, path = s"$outputDir/${CsvFile.Plans}") shouldBe Set.empty
@@ -277,10 +307,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
 
@@ -308,10 +345,17 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
       val outputDir = FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
 
-      val (scenario, _, _) = buildBeamServicesAndScenario(
+      val (scenario, beamScenario, _) = buildBeamServicesAndScenario(
         beamConfig,
         matsimConfig
       )
+
+      val snapLocationHelper: SnapLocationHelper = SnapLocationHelper(
+        new GeoUtilsImpl(beamConfig),
+        beamScenario.transportNetwork.streetLayer,
+        beamConfig.beam.routing.r5.linkRadiusMeters
+      )
+      ScenarioLoaderHelper.validateScenario(scenario, snapLocationHelper, Some(outputDir))
 
       scenario.getPopulation.getPersons.size() shouldBe 1
       intersection(scenario.getPopulation, path = s"$outputDir/${CsvFile.Plans}") shouldBe Set.empty
@@ -325,6 +369,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
         .parseString(s"""
                         |beam.agentsim.agents.freight.toursFilePath = "$pwd/test/test-resources/beam/input/snap-location/freight/freight-tours.csv"
                         |beam.routing.r5.linkRadiusMeters = 350
+                        |beam.agentsim.snapLocationAndRemoveInvalidInputs = true
                         |""".stripMargin)
         .withFallback(testConfig("test/input/beamville/beam-freight.conf"))
         .resolve()
@@ -352,6 +397,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
         .parseString(s"""
                         |beam.agentsim.agents.freight.plansFilePath = "$pwd/test/test-resources/beam/input/snap-location/freight/payload-plans.csv"
                         |beam.routing.r5.linkRadiusMeters = 350
+                        |beam.agentsim.snapLocationAndRemoveInvalidInputs = true
                         |""".stripMargin)
         .withFallback(testConfig("test/input/beamville/beam-freight.conf"))
         .resolve()
@@ -379,6 +425,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
         .parseString(s"""
                         |beam.agentsim.agents.freight.carriersFilePath = "$pwd/test/test-resources/beam/input/snap-location/freight/freight-carriers.csv"
                         |beam.routing.r5.linkRadiusMeters = 350
+                        |beam.agentsim.snapLocationAndRemoveInvalidInputs = true
                         |""".stripMargin)
         .withFallback(testConfig("test/input/beamville/beam-freight.conf"))
         .resolve()

--- a/src/test/scala/beam/utils/SnapCoordinateSpec.scala
+++ b/src/test/scala/beam/utils/SnapCoordinateSpec.scala
@@ -16,6 +16,21 @@ import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 
 class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
 
+  /**
+    * see the notes,
+    *
+    * Scenario:
+    * case1: test/test-resources/beam/input/snap-location/scenario/case1/note
+    *   three invalid plans, update population/households accordingly
+    * case2: test/test-resources/beam/input/snap-location/scenario/case2/note
+    *   one invalid household and three invalid plans, update population/households accordingly
+    *
+    * Freight:
+    * ???
+    */
+
+  val pwd: String = System.getenv("PWD")
+
   "scenario plan" should {
     "contain all valid locations" in {
       lazy val config: TypesafeConfig = ConfigFactory
@@ -44,7 +59,7 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
       )
 
       val dummyCoord = new Coord()
-      val results: Seq[SnapCoordinateUtils.Result] = scenario.getPopulation.getPersons
+      val population: Seq[SnapCoordinateUtils.Result] = scenario.getPopulation.getPersons
         .values()
         .asScala
         .flatMap { person =>
@@ -57,10 +72,151 @@ class SnapCoordinateSpec extends AnyWordSpec with Matchers with BeamHelper {
         }
         .toList
 
-      results.forall {
+      val households: Seq[SnapCoordinateUtils.Result] = scenario.getHouseholds.getHouseholds
+        .values()
+        .asScala
+        .map { household =>
+          val locationX = scenario.getHouseholds.getHouseholdAttributes
+            .getAttribute(household.getId.toString, "homecoordx")
+            .asInstanceOf[Double]
+          val locationY = scenario.getHouseholds.getHouseholdAttributes
+            .getAttribute(household.getId.toString, "homecoordy")
+            .asInstanceOf[Double]
+          val coord = new Coord(locationX, locationY)
+          snapLocationHelper.computeResult(coord)
+        }
+        .toList
+
+      (population ++ households).forall {
         case _: Result.Succeed => true
         case _                 => false
       } shouldBe true
+    }
+
+    "remove/update invalid persons and households [case1 xml input]" in {
+      lazy val config: TypesafeConfig = ConfigFactory
+        .parseString(s"""
+                        |beam.agentsim.agents.plans {
+                        |  inputPlansFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/xml/population.xml"
+                        |  inputPersonAttributesFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/xml/populationAttributes.xml"
+                        |}
+                        |beam.agentsim.agents.households {
+                        |  inputFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/xml/households.xml"
+                        |  inputHouseholdAttributesFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/xml/householdAttributes.xml"
+                        |}
+                        |beam.routing.r5.linkRadiusMeters = 350
+                        |""".stripMargin)
+        .withFallback(testConfig("test/input/beamville/beam.conf"))
+        .resolve()
+
+      val configBuilder = new MatSimBeamConfigBuilder(config)
+      val matsimConfig: Config = configBuilder.buildMatSimConf()
+      matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+      val beamConfig: BeamConfig = BeamConfig(config)
+
+      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+
+      val (scenario, _, _) = buildBeamServicesAndScenario(
+        beamConfig,
+        matsimConfig
+      )
+
+      val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
+
+      scenario.getPopulation.getPersons.size() shouldBe 2
+      households.foreach { household =>
+        household.getMemberIds.size() shouldBe 1
+      }
+    }
+
+    "remove/update invalid persons and households [case2 xml input]" in {
+      lazy val config: TypesafeConfig = ConfigFactory
+        .parseString(s"""
+                        |beam.agentsim.agents.plans {
+                        |  inputPlansFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/xml/population.xml"
+                        |  inputPersonAttributesFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/xml/populationAttributes.xml"
+                        |}
+                        |beam.agentsim.agents.households {
+                        |  inputFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/xml/households.xml"
+                        |  inputHouseholdAttributesFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/xml/householdAttributes.xml"
+                        |}
+                        |beam.routing.r5.linkRadiusMeters = 350
+                        |""".stripMargin)
+        .withFallback(testConfig("test/input/beamville/beam.conf"))
+        .resolve()
+
+      val configBuilder = new MatSimBeamConfigBuilder(config)
+      val matsimConfig: Config = configBuilder.buildMatSimConf()
+      matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+      val beamConfig: BeamConfig = BeamConfig(config)
+
+      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+
+      val (scenario, _, _) = buildBeamServicesAndScenario(
+        beamConfig,
+        matsimConfig
+      )
+
+      scenario.getPopulation.getPersons.size() shouldBe 1
+      scenario.getHouseholds.getHouseholds.size() shouldBe 1
+    }
+
+    "remove invalid persons and households [case1 csv input]" in {
+      lazy val config: TypesafeConfig = ConfigFactory
+        .parseString(s"""
+                        |beam.agentsim.agents.plans.inputPlansFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/csv/plans.csv"
+                        |beam.agentsim.agents.households.inputFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case1/csv/households.csv"
+                        |beam.routing.r5.linkRadiusMeters = 350
+                        |""".stripMargin)
+        .withFallback(testConfig("test/input/beamville/beam-csv.conf"))
+        .resolve()
+
+      val configBuilder = new MatSimBeamConfigBuilder(config)
+      val matsimConfig: Config = configBuilder.buildMatSimConf()
+      matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+      val beamConfig: BeamConfig = BeamConfig(config)
+
+      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+
+      val (scenario, _, _) = buildBeamServicesAndScenario(
+        beamConfig,
+        matsimConfig
+      )
+
+      val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
+
+      scenario.getPopulation.getPersons.size() shouldBe 2
+      households.foreach { household =>
+        household.getMemberIds.size() shouldBe 1
+      }
+    }
+
+    "remove invalid persons and households [case2 csv input]" in {
+      lazy val config: TypesafeConfig = ConfigFactory
+        .parseString(s"""
+                        |beam.agentsim.agents.plans.inputPlansFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/csv/plans.csv"
+                        |beam.agentsim.agents.households.inputFilePath = "$pwd/test/test-resources/beam/input/snap-location/scenario/case2/csv/households.csv"
+                        |beam.routing.r5.linkRadiusMeters = 350
+                        |""".stripMargin)
+        .withFallback(testConfig("test/input/beamville/beam-csv.conf"))
+        .resolve()
+
+      val configBuilder = new MatSimBeamConfigBuilder(config)
+      val matsimConfig: Config = configBuilder.buildMatSimConf()
+      matsimConfig.planCalcScore().setMemorizingExperiencedPlans(true)
+      val beamConfig: BeamConfig = BeamConfig(config)
+
+      FileUtils.setConfigOutputFile(beamConfig, matsimConfig)
+
+      val (scenario, _, _) = buildBeamServicesAndScenario(
+        beamConfig,
+        matsimConfig
+      )
+
+      val households = scenario.getHouseholds.getHouseholds.values().asScala.toList
+
+      scenario.getPopulation.getPersons.size() shouldBe 1
+      scenario.getHouseholds.getHouseholds.size() shouldBe 1
     }
   }
 

--- a/test/test-resources/beam/input/snap-location/freight/freight-carriers.csv
+++ b/test/test-resources/beam/input/snap-location/freight/freight-carriers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:403e9ccbedb831269fd57e1a5edd48e068cdf33750bf1bd02867246d7a8c058e
+size 232

--- a/test/test-resources/beam/input/snap-location/freight/freight-tours.csv
+++ b/test/test-resources/beam/input/snap-location/freight/freight-tours.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05f0f2b94046948b249cd3bf5d683b3bbb34951d40fc1be70a28ba6ef2256d0
+size 248

--- a/test/test-resources/beam/input/snap-location/freight/payload-plans.csv
+++ b/test/test-resources/beam/input/snap-location/freight/payload-plans.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ca6c183d0add95c0d68a7b2d26bb6c62bab40d723b13271ef697c38060ca92e
+size 939

--- a/test/test-resources/beam/input/snap-location/scenario/case1/csv/households.csv
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/csv/households.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40a521bee13f8eccc5d13843cb4125f75e91da7425ed4f2bbe1e385f4a0b0312
+size 95

--- a/test/test-resources/beam/input/snap-location/scenario/case1/csv/plans.csv
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/csv/plans.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10f892985fdd48bf3cdae8fe1d10f62352b4ce8032f61244fb8a9c0693672c9d
+size 1314

--- a/test/test-resources/beam/input/snap-location/scenario/case1/note
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/note
@@ -1,0 +1,8 @@
+OutOfBoundingBox
+Person 1 x 1627138.4 y 1117.0
+
+R5SplitNull
+Person 1 x 166045.2 y 2705.4
+Person 3 x 166675.4 y 3068.543
+Person 4 x 170108.4 y 1960.535
+

--- a/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/blocks.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/blocks.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:567708718a96701b3977ddb90c21917b6d5dcbab79ad54d302cc8b91dfdb6cca
+size 249

--- a/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/households.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/households.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fee1ebbd211c0f9d9b53f9294a053dd930e5d20edcaf84534cf5395e6c02d1b4
+size 156

--- a/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/persons.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/persons.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a4f7fc7716d6f202f51e60baa5da09d7ac44480c9ec1e71db6a3a7805f662c1
+size 217

--- a/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/plans.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/urbansim_v2/plans.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be7f1b757d480628e044501adbe99f1a48245467d6c767fa440a7d233971a978
+size 615

--- a/test/test-resources/beam/input/snap-location/scenario/case1/xml/householdAttributes.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/xml/householdAttributes.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b239a0087a0fea5d6d629dc8b90177fa818fbf9bd4eadb650bfc1c2f13f3f253
+size 705

--- a/test/test-resources/beam/input/snap-location/scenario/case1/xml/households.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/xml/households.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe9c0a5dc3f9469f909434edece253fb100b89b307ef2a0ef24c88e3f3e56b92
+size 859

--- a/test/test-resources/beam/input/snap-location/scenario/case1/xml/households.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/xml/households.xml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe9c0a5dc3f9469f909434edece253fb100b89b307ef2a0ef24c88e3f3e56b92
-size 859
+oid sha256:1749a97d76b2735b8736104ffee1c1c887be650224cf39e4a62426ce17cf3a18
+size 875

--- a/test/test-resources/beam/input/snap-location/scenario/case1/xml/population.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/xml/population.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53c0ae571973fe243adda66f3d68ae6dc1dce8962187d17575373bc89e03efbd
+size 2850

--- a/test/test-resources/beam/input/snap-location/scenario/case1/xml/populationAttributes.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case1/xml/populationAttributes.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb3199cd0c3d15ee9244af92c81479522908329ca44893bd7cb958554856f37
+size 998

--- a/test/test-resources/beam/input/snap-location/scenario/case2/csv/households.csv
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/csv/households.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:621b455d74f0323748f7e481f890cd5cbd3080262b681749efb4492e093a2b41
+size 96

--- a/test/test-resources/beam/input/snap-location/scenario/case2/csv/plans.csv
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/csv/plans.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:456f1efc4fc8933ac32f832b51a0fa5b670716be7450c4cd7fb6e7d7b9244c28
+size 1313

--- a/test/test-resources/beam/input/snap-location/scenario/case2/note
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/note
@@ -1,0 +1,7 @@
+OutOfBoundingBox
+Household 1 x 1627138.4 y 1117.0
+
+R5SplitNull
+Person 1 x 166045.2 y 2705.4
+Person 3 x 166675.4 y 3068.543
+Person 4 x 170108.4 y 1960.535

--- a/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/blocks.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/blocks.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4b46994dcb316c264c77feed485283bee13cf25fea4bf80c3b49b075e82eedd
+size 250

--- a/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/households.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/households.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fee1ebbd211c0f9d9b53f9294a053dd930e5d20edcaf84534cf5395e6c02d1b4
+size 156

--- a/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/persons.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/persons.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8c1661871669f2c20b4f22272184285ab64a5ea213aaf248d1a81ca9ec9a1c5
+size 217

--- a/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/plans.csv.gz
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/urbansim_v2/plans.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7d3af7a4245e2e843b0c77666a2d04a4a2f26024f4ad76b62f6b8102ffc618c
+size 613

--- a/test/test-resources/beam/input/snap-location/scenario/case2/xml/householdAttributes.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/xml/householdAttributes.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56c400740feb094463a5baabf1a66d719ef6a8059bd07ac930f390786b039f3e
+size 706

--- a/test/test-resources/beam/input/snap-location/scenario/case2/xml/households.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/xml/households.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe9c0a5dc3f9469f909434edece253fb100b89b307ef2a0ef24c88e3f3e56b92
+size 859

--- a/test/test-resources/beam/input/snap-location/scenario/case2/xml/households.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/xml/households.xml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe9c0a5dc3f9469f909434edece253fb100b89b307ef2a0ef24c88e3f3e56b92
-size 859
+oid sha256:1749a97d76b2735b8736104ffee1c1c887be650224cf39e4a62426ce17cf3a18
+size 875

--- a/test/test-resources/beam/input/snap-location/scenario/case2/xml/population.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/xml/population.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9cfa90074dc01de642da79b6896271d74d3d36967731dabdea2a006f345568c
+size 2849

--- a/test/test-resources/beam/input/snap-location/scenario/case2/xml/populationAttributes.xml
+++ b/test/test-resources/beam/input/snap-location/scenario/case2/xml/populationAttributes.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb3199cd0c3d15ee9244af92c81479522908329ca44893bd7cb958554856f37
+size 998


### PR DESCRIPTION
closes #3489

Use `beam.agentsim.snapLocationAndRemoveInvalidInputs` parameter to enable the snapping module. It will snap location and remove invalid plans (beam, urbansim, freight) before starting simulation.

Error csv can be found at the root of output directory:
1. `snapLocationPlanErrors.csv`: scenario plan errors
2. `snapLocationHouseholdErrors.csv`: scenario household errors
3. `snapLocationFreightTourErrors.csv`: freight tour errors
4. `snapLocationFreightPayloadPlanErrors.csv`: freight payload plan errors
5. `snapLocationFreightCarrierErrors.csv`: freight carrier errors

Csv will have `id,category,error,x,y` columns.
`error` could be either `OutOfBoundingBox` and `R5SplitNull`.
`category` defines the type of an entity for given id. (ex, Person, Household, PayloadPlan etc)
`x` and `y` is original location in plan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3513)
<!-- Reviewable:end -->
