### PR TITLE
Storing the scheduler state in case of beam exists with an error

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -773,8 +773,7 @@ beam.debug {
     writeRealizedModeChoiceFile = "boolean | false"
     messageLogging = "boolean | false"
     # the max of the next 2 values is taken for the initialization step
-    maxSimulationStepTimeBeforeConsideredStuckMin = "int | 999999"
-    maxInitializationTimeBeforeConsideredStuckMin = "int | 180"
+    maxSimulationStepTimeBeforeConsideredStuckMin = "int | 60"
 }
 
 beam.logger.keepConsoleAppenderOn = "boolean | true"

--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -273,13 +273,7 @@ class BeamAgentScheduler(
 
     case SimulationStuckCheck =>
       if (started) {
-        val stuckThresholdMin =
-          if (nowInSeconds == 0)
-            Math.max(
-              beamConfig.beam.debug.maxInitializationTimeBeforeConsideredStuckMin,
-              beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckMin
-            )
-          else beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckMin
+        val stuckThresholdMin = beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckMin
         val currentDelayMillis = System.currentTimeMillis() - nowUpdateTime
         if (currentDelayMillis > stuckThresholdMin * 60000L) {
           log.error(

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -381,6 +381,7 @@ class BeamMobsimIteration(
     Props(
       classOf[BeamAgentScheduler],
       beamConfig,
+      beamServices.matsimServices.getControlerIO.getIterationPath(beamServices.matsimServices.getIterationNumber),
       Time.parseTime(beamConfig.matsim.modules.qsim.endTime).toInt,
       config.schedulerParallelismWindow,
       new StuckFinder(beamConfig.beam.debug.stuckAgentDetection)

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2479,7 +2479,6 @@ object BeamConfig {
       clearRoutedOutstandingWorkEnabled: scala.Boolean,
       debugActorTimerIntervalInSec: scala.Int,
       debugEnabled: scala.Boolean,
-      maxInitializationTimeBeforeConsideredStuckMin: scala.Int,
       maxSimulationStepTimeBeforeConsideredStuckMin: scala.Int,
       memoryConsumptionDisplayTimeoutInSec: scala.Int,
       messageLogging: scala.Boolean,
@@ -2641,14 +2640,10 @@ object BeamConfig {
           debugActorTimerIntervalInSec =
             if (c.hasPathOrNull("debugActorTimerIntervalInSec")) c.getInt("debugActorTimerIntervalInSec") else 0,
           debugEnabled = c.hasPathOrNull("debugEnabled") && c.getBoolean("debugEnabled"),
-          maxInitializationTimeBeforeConsideredStuckMin =
-            if (c.hasPathOrNull("maxInitializationTimeBeforeConsideredStuckMin"))
-              c.getInt("maxInitializationTimeBeforeConsideredStuckMin")
-            else 180,
           maxSimulationStepTimeBeforeConsideredStuckMin =
             if (c.hasPathOrNull("maxSimulationStepTimeBeforeConsideredStuckMin"))
               c.getInt("maxSimulationStepTimeBeforeConsideredStuckMin")
-            else 999999,
+            else 60,
           memoryConsumptionDisplayTimeoutInSec =
             if (c.hasPathOrNull("memoryConsumptionDisplayTimeoutInSec"))
               c.getInt("memoryConsumptionDisplayTimeoutInSec")

--- a/src/test/scala/beam/agentsim/infrastructure/ChargingNetworkManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/ChargingNetworkManagerSpec.scala
@@ -111,7 +111,7 @@ class ChargingNetworkManagerSpec
     stopTick: Int,
     override val maxWindow: Int,
     override val stuckFinder: StuckFinder
-  ) extends BeamAgentScheduler(beamConfig, stopTick, maxWindow, stuckFinder) {
+  ) extends BeamAgentScheduler(beamConfig, ".", stopTick, maxWindow, stuckFinder) {
 
     override def receive: Receive = {
       case Finish => context.stop(self)


### PR DESCRIPTION
1. Remoived maxInitializationTimeBeforeConsideredStuckMin param as we actually don't need it.
2. Enabled killing beam by default
3. Saving internal scheduler state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3555)
<!-- Reviewable:end -->
