### PR TITLE
External script at AWS EC2 instances that saves beam thread dump

### DIFF
--- a/aws/src/main/python/beam_lambda/lambda_function.py
+++ b/aws/src/main/python/beam_lambda/lambda_function.py
@@ -97,10 +97,9 @@ write_files:
           curl -X POST -H 'Content-type: application/json' --data-binary @/tmp/slack.json $SLACK_HOOK_WITH_TOKEN
       path: /tmp/slack.sh
     - content: |
-          0 * * * * curl -X POST -H "Content-type: application/json" --data '"'"'{"$(ec2metadata --instance-type) instance $(ec2metadata --instance-id) running... \\n Batch [$UID] completed and instance of type $(ec2metadata --instance-type) is still running in $REGION since last $(($(($(date +%s) - $(cat /tmp/.starttime))) / 3600)) Hour $(($(($(date +%s) - $(cat /tmp/.starttime))) / 60)) Minute."}'"'"
           */10 * * * * /home/ubuntu/beam_stuck_guard.sh
           
-      path: /tmp/slack_notification
+      path: /tmp/cron_jobs
     - content: |
             #!/bin/bash
             pip install setuptools
@@ -246,7 +245,7 @@ runcmd:
   - chmod +x /tmp/slack.sh
   - echo "notification sent..."
   - echo "notification saved..."
-  - crontab /tmp/slack_notification
+  - crontab /tmp/cron_jobs
   - crontab -l
   - echo "notification scheduled..."
 

--- a/aws/src/main/python/beam_lambda/lambda_function.py
+++ b/aws/src/main/python/beam_lambda/lambda_function.py
@@ -98,6 +98,8 @@ write_files:
       path: /tmp/slack.sh
     - content: |
           0 * * * * curl -X POST -H "Content-type: application/json" --data '"'"'{"$(ec2metadata --instance-type) instance $(ec2metadata --instance-id) running... \\n Batch [$UID] completed and instance of type $(ec2metadata --instance-type) is still running in $REGION since last $(($(($(date +%s) - $(cat /tmp/.starttime))) / 3600)) Hour $(($(($(date +%s) - $(cat /tmp/.starttime))) / 60)) Minute."}'"'"
+          */10 * * * * /home/ubuntu/beam_stuck_guard.sh
+          
       path: /tmp/slack_notification
     - content: |
             #!/bin/bash
@@ -132,10 +134,31 @@ write_files:
                     echo $timestamp_CPU, $ram_used_available
             done
       path: /home/ubuntu/write-cpu-ram-usage.sh
+    - content: |
+            #!/bin/bash
+            pgrep -f RunBeam || exit 0
+            out_dir=$(find /home/ubuntu/git/beam/output -maxdepth 2 -mindepth 2 -type d -print -quit)
+            if [[ -z "${out_dir}" ]]; then exit 0; fi
+            log_file="$out_dir/beamLog.out"
+            if [[ ! -f $log_file ]] ; then exit 0; fi
+            last_completed=$(tac $log_file | grep -m 1 completed | grep -m 1 -Eo '^[0-9]{2}:[0-9]{2}:[0-9]{2}')
+            if [[ -z "${last_completed}" ]]; then
+              last_completed=$(tac $log_file | grep -m 1 -Eo '^[0-9]{2}:[0-9]{2}:[0-9]{2}')
+            fi
+            beam_status=$(python3 -c "import datetime as dt; diff = dt.datetime.now() - dt.datetime.combine(dt.datetime.today(), dt.time.fromisoformat('$last_completed')); x = 'OK' if dt.timedelta(0) <= diff and diff < dt.timedelta(hours=3) else 'Bad'; print(x)")
+            pid=$(pgrep -f RunBeam)
+            if [ "$beam_status" == 'Bad' ] && [ "$pid" != "" ]; then
+              jstack $pid | gzip > "$out_dir/kill_thread_dump.txt.gz"
+              kill $pid
+              sleep 5m
+              kill -9 $pid
+            fi
+      path: /home/ubuntu/beam_stuck_guard.sh
 
 runcmd:
   - sudo chmod +x /home/ubuntu/install-and-run-helics-scripts.sh
   - sudo chmod +x /home/ubuntu/write-cpu-ram-usage.sh
+  - sudo chmod +x /home/ubuntu/beam_stuck_guard.sh
   - cd /home/ubuntu
   - ./write-cpu-ram-usage.sh 20 > cpu_ram_usage.csv &
   - cd /home/ubuntu/git

--- a/src/main/java/beam/utils/DebugLib.java
+++ b/src/main/java/beam/utils/DebugLib.java
@@ -3,6 +3,13 @@ package beam.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class DebugLib {
     private static final Logger log = LoggerFactory.getLogger(DebugLib.class);
 
@@ -29,6 +36,12 @@ public class DebugLib {
     public static void busyWait(int nanos) {
         long start = System.nanoTime();
         while(System.nanoTime() - start < nanos);
+    }
+
+    public static List<String> currentThreadDump() {
+        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        ThreadInfo[] infos = bean.dumpAllThreads(true, true);
+        return Arrays.stream(infos).map(Object::toString).collect(Collectors.toList());
     }
 
 }

--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -7,7 +7,7 @@ import beam.agentsim.agents.ridehail.RideHailManager.RideHailRepositioningTrigge
 import beam.agentsim.scheduler.BeamAgentScheduler._
 import beam.agentsim.scheduler.Trigger.TriggerWithId
 import beam.sim.config.BeamConfig
-import beam.utils.{FileUtils, StuckFinder}
+import beam.utils.{DebugLib, FileUtils, StuckFinder}
 import beam.utils.logging.{LogActorState, LoggingMessageActor}
 import com.google.common.collect.TreeMultimap
 
@@ -413,6 +413,10 @@ class BeamAgentScheduler(
       FileUtils.writeToFile(
         awaitingResponseFile,
         (s"total awaitingResponse size = ${awaitingResponse.size()}\n" +: triggers).iterator
+      )
+      FileUtils.writeToFile(
+        s"$outputDir/scheduler_shutdown_thread_dump.txt.gz",
+        DebugLib.currentThreadDump().asScala.iterator
       )
     }
   }

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -381,7 +381,7 @@ class BeamMobsimIteration(
     Props(
       classOf[BeamAgentScheduler],
       beamConfig,
-      beamServices.matsimServices.getControlerIO.getIterationPath(beamServices.matsimServices.getIterationNumber),
+      beamServices.matsimServices.getControlerIO.getOutputPath,
       Time.parseTime(beamConfig.matsim.modules.qsim.endTime).toInt,
       config.schedulerParallelismWindow,
       new StuckFinder(beamConfig.beam.debug.stuckAgentDetection)


### PR DESCRIPTION
1. Moved scheduler state files to the root of the output folder.
2. Save thread dump by scheduler.
3. Save thread dump and kill beam by an external process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3559)
<!-- Reviewable:end -->
