### PR TITLE
Fix for display long legend text for NonArrivedAgentsAtTheEndOfSimula…

### DIFF
--- a/src/main/java/beam/analysis/plots/PersonTravelTimeAnalysis.java
+++ b/src/main/java/beam/analysis/plots/PersonTravelTimeAnalysis.java
@@ -342,6 +342,9 @@ public class PersonTravelTimeAnalysis implements GraphAnalysis, IterationSummary
 
         final JFreeChart chart = GraphUtils.createStackedBarChartWithDefaultSettings(defaultCategoryDataset, graphTitle, "modes", "count", false);
         CategoryPlot plot = chart.getCategoryPlot();
+
+        plot.getDomainAxis().setMaximumCategoryLabelLines(3);
+
         GraphUtils.plotLegendItems(plot, defaultCategoryDataset.getRowCount());
         String graphImageFile = ioCotroller.getIterationFilename(iterationNumber, "NonArrivedAgentsAtTheEndOfSimulation.png");
         GraphUtils.saveJFreeChartAsPNG(chart, graphImageFile, GraphsStatsAgentSimEventsListener.GRAPH_WIDTH, GraphsStatsAgentSimEventsListener.GRAPH_HEIGHT);


### PR DESCRIPTION
…tion.png

https://github.com/LBNL-UCB-STI/beam/issues/3564

after:
![0 NonArrivedAgentsAtTheEndOfSimulation](https://user-images.githubusercontent.com/11138469/180838996-7198b1c7-391c-4186-bc4f-f58b9b8ecaa3.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3565)
<!-- Reviewable:end -->
