### PR TITLE
Bugfix: in case logger is not initialized yet

### DIFF
--- a/src/main/scala/beam/sim/RunBeam.scala
+++ b/src/main/scala/beam/sim/RunBeam.scala
@@ -31,6 +31,7 @@ object RunBeam extends BeamHelper {
     } catch {
       case e: Exception =>
         val threadDumpFileName = "thread_dump_from_RunBeam.txt.gz"
+        println(s"Exception occurred: ${e.toString}")
         logger.error(s"Exception occurred: {}", e.getMessage)
         FileUtils.writeToFile(threadDumpFileName, DebugLib.currentThreadsDump().asScala.iterator)
         logger.info("Thread dump has been saved to the file {}", threadDumpFileName)


### PR DESCRIPTION
In case the logger is not yet initialized or the log was not dumped into output file but BEAM has died already, we are loosing exception information.
This fix will allow us to have the exception terminating BEAM to be logged both in beamLog.out (if it is exist) and in cloud-init file on aws or in the output if BEAM was started not from IDEA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3584)
<!-- Reviewable:end -->
