### PR TITLE
added runtime validation (where household and plans are required in t…

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -7,7 +7,7 @@ import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailSurgePri
 import beam.agentsim.agents.vehicles.VehicleCategory.MediumDutyPassenger
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events.handling.BeamEventsHandling
-import beam.agentsim.infrastructure.taz.{H3TAZ, TAZ, TAZTreeMap}
+import beam.agentsim.infrastructure.taz.{H3TAZ, TAZTreeMap}
 import beam.analysis.ActivityLocationPlotter
 import beam.analysis.plots.{GraphSurgePricing, RideHailRevenueAnalysis}
 import beam.matsim.{CustomPlansDumpingImpl, MatsimConfigUpdater}
@@ -38,13 +38,7 @@ import beam.utils.scenario.generic.GenericScenarioSource
 import beam.utils.scenario.matsim.BeamScenarioSource
 import beam.utils.scenario.urbansim.censusblock.{ScenarioAdjuster, UrbansimReaderV2}
 import beam.utils.scenario.urbansim.{CsvScenarioReader, ParquetScenarioReader, UrbanSimScenarioSource}
-import beam.utils.scenario.{
-  BeamScenarioLoader,
-  InputType,
-  PreviousRunPlanMerger,
-  ScenarioLoaderHelper,
-  UrbanSimScenarioLoader
-}
+import beam.utils.scenario._
 import com.conveyal.r5.streets.StreetLayer
 import com.conveyal.r5.transit.TransportNetwork
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -55,7 +49,6 @@ import com.google.inject.name.Names
 import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
 import com.typesafe.scalalogging.LazyLogging
 import kamon.Kamon
-import org.matsim.api.core.v01.network.Link
 import org.matsim.api.core.v01.population.{Activity, Population}
 import org.matsim.api.core.v01.{Id, Scenario}
 import org.matsim.core.api.experimental.events.EventsManager
@@ -66,7 +59,6 @@ import org.matsim.core.controler.corelisteners.{ControlerDefaultCoreListenersMod
 import org.matsim.core.events.ParallelEventsManagerImpl
 import org.matsim.core.scenario.{MutableScenario, ScenarioBuilder, ScenarioByInstanceModule, ScenarioUtils}
 import org.matsim.core.trafficmonitoring.TravelTimeCalculator
-import org.matsim.core.utils.collections.QuadTree
 import org.matsim.households.Households
 import org.matsim.utils.objectattributes.AttributeConverter
 import org.matsim.vehicles.Vehicle
@@ -82,7 +74,7 @@ import scala.concurrent.Await
 import scala.sys.process.Process
 import scala.util.{Random, Try}
 
-trait BeamHelper extends LazyLogging {
+trait BeamHelper extends LazyLogging with BeamValidationHelper {
   //  Kamon.init()
 
   private val originalConfigLocationPath = "originalConfigLocation"
@@ -889,6 +881,7 @@ trait BeamHelper extends LazyLogging {
           }
           (scenario, beamScenario, plansMerged)
         } else if (src == "beam") {
+          ensureRequiredValuesExist(matsimConfig)
           fileFormat match {
             case "csv" =>
               val beamScenario = loadScenario(beamConfig, outputDirOpt)

--- a/src/main/scala/beam/sim/BeamValidationHelper.scala
+++ b/src/main/scala/beam/sim/BeamValidationHelper.scala
@@ -1,0 +1,26 @@
+package beam.sim
+
+import org.matsim.core.config.{Config => MatsimConfig}
+import com.typesafe.scalalogging.LazyLogging
+
+trait BeamValidationHelper extends LazyLogging {
+
+  def ensureRequiredValuesExist(matsimConfig: MatsimConfig): Unit  = {
+    logger.info("ensureRequiredValuesExist() entry")
+    if (Option(matsimConfig.households().getInputFile).forall(_.isEmpty)) {
+      throw new RuntimeException("No households input file, please specify 'beam.agentsim.agents.households.inputFilePath' in your config file")
+    }
+
+    if (Option(matsimConfig.households().getInputHouseholdAttributesFile).forall(_.isEmpty)) {
+      throw new RuntimeException("No households attributes file, please specify 'beam.agentsim.agents.households.inputHouseholdAttributesFilePath' in your config file")
+    }
+
+    if (Option(matsimConfig.plans().getInputFile).forall(_.isEmpty)) {
+      throw new RuntimeException("No plans input file, please specify 'beam.agentsim.agents.plans.inputPlansFilePath' in your config file")
+    }
+
+    if (Option(matsimConfig.plans().getInputPersonAttributeFile).forall(_.isEmpty)) {
+      throw new RuntimeException("No plans attributes file, please specify 'beam.agentsim.agents.plans.inputPersonAttributesFilePath' in your config file")
+    }
+  }
+}

--- a/src/main/scala/beam/sim/BeamValidationHelper.scala
+++ b/src/main/scala/beam/sim/BeamValidationHelper.scala
@@ -5,22 +5,30 @@ import com.typesafe.scalalogging.LazyLogging
 
 trait BeamValidationHelper extends LazyLogging {
 
-  def ensureRequiredValuesExist(matsimConfig: MatsimConfig): Unit  = {
+  def ensureRequiredValuesExist(matsimConfig: MatsimConfig): Unit = {
     logger.info("ensureRequiredValuesExist() entry")
     if (Option(matsimConfig.households().getInputFile).forall(_.isEmpty)) {
-      throw new RuntimeException("No households input file, please specify 'beam.agentsim.agents.households.inputFilePath' in your config file")
+      throw new RuntimeException(
+        "No households input file, please specify 'beam.agentsim.agents.households.inputFilePath' in your config file"
+      )
     }
 
     if (Option(matsimConfig.households().getInputHouseholdAttributesFile).forall(_.isEmpty)) {
-      throw new RuntimeException("No households attributes file, please specify 'beam.agentsim.agents.households.inputHouseholdAttributesFilePath' in your config file")
+      throw new RuntimeException(
+        "No households attributes file, please specify 'beam.agentsim.agents.households.inputHouseholdAttributesFilePath' in your config file"
+      )
     }
 
     if (Option(matsimConfig.plans().getInputFile).forall(_.isEmpty)) {
-      throw new RuntimeException("No plans input file, please specify 'beam.agentsim.agents.plans.inputPlansFilePath' in your config file")
+      throw new RuntimeException(
+        "No plans input file, please specify 'beam.agentsim.agents.plans.inputPlansFilePath' in your config file"
+      )
     }
 
     if (Option(matsimConfig.plans().getInputPersonAttributeFile).forall(_.isEmpty)) {
-      throw new RuntimeException("No plans attributes file, please specify 'beam.agentsim.agents.plans.inputPersonAttributesFilePath' in your config file")
+      throw new RuntimeException(
+        "No plans attributes file, please specify 'beam.agentsim.agents.plans.inputPersonAttributesFilePath' in your config file"
+      )
     }
   }
 }

--- a/src/main/scala/beam/sim/RunBeam.scala
+++ b/src/main/scala/beam/sim/RunBeam.scala
@@ -32,7 +32,7 @@ object RunBeam extends BeamHelper {
       case e: Exception =>
         val threadDumpFileName = "thread_dump_from_RunBeam.txt.gz"
         println(s"Exception occurred: ${e.toString}")
-        logger.error(s"Exception occurred: {}", e.getMessage)
+        logger.error("Exception occurred:", e)
         FileUtils.writeToFile(threadDumpFileName, DebugLib.currentThreadsDump().asScala.iterator)
         logger.info("Thread dump has been saved to the file {}", threadDumpFileName)
         System.exit(2)

--- a/test/input/beamville/beam-urbansimv2.conf
+++ b/test/input/beamville/beam-urbansimv2.conf
@@ -45,14 +45,6 @@ beam.agentsim.agents.tripBehaviors.multinomialLogit.trip_nest_scale_factor = 1.0
 
 # beam.agentsim.agents.modeIncentive.filePath = ${beam.inputDirectory}"/incentives.csv"
 # beam.agentsim.agents.ptFare.filePath = ${beam.inputDirectory}"/ptFares.csv"
-beam.agentsim.agents.plans {
-  inputPlansFilePath = ${beam.inputDirectory}"/population.xml"
-  inputPersonAttributesFilePath = ${beam.inputDirectory}"/populationAttributes.xml"
-}
-beam.agentsim.agents.households {
-  inputFilePath = ${beam.inputDirectory}"/households.xml"
-  inputHouseholdAttributesFilePath = ${beam.inputDirectory}"/householdAttributes.xml"
-}
 # #BeamVehicles Params
 beam.agentsim.agents.vehicles.linkToGradePercentFilePath = ${beam.inputDirectory}"/linkToGradePercent.csv"
 beam.agentsim.agents.vehicles.fuelTypesFilePath = ${beam.inputDirectory}"/beamFuelTypes.csv"

--- a/test/input/common/matsim.conf
+++ b/test/input/common/matsim.conf
@@ -33,12 +33,12 @@ matsim.modules {
     inputNetworkFile = ${beam.physsim.inputNetworkFilePath}
   }
   plans {
-    inputPlansFile = ${beam.agentsim.agents.plans.inputPlansFilePath}
-    inputPersonAttributesFile = ${beam.agentsim.agents.plans.inputPersonAttributesFilePath}
+    inputPlansFile = ${?beam.agentsim.agents.plans.inputPlansFilePath}
+    inputPersonAttributesFile = ${?beam.agentsim.agents.plans.inputPersonAttributesFilePath}
   }
   households {
-    inputFile = ${beam.agentsim.agents.households.inputFilePath}
-    inputHouseholdAttributesFile = ${beam.agentsim.agents.households.inputHouseholdAttributesFilePath}
+    inputFile = ${?beam.agentsim.agents.households.inputFilePath}
+    inputHouseholdAttributesFile = ${?beam.agentsim.agents.households.inputHouseholdAttributesFilePath}
   }
   strategy {
     maxAgentPlanMemorySize = ${beam.replanning.maxAgentPlanMemorySize}


### PR DESCRIPTION
added runtime validation (where household and plans are required in the old format) for legacy-beam-scenario-specific runs, while making these params optional in matsim.conf, so that we can reduce verbosity of config files

1) Scenario 1
- When: beam.conf or other legacy beam config not include household or plans
- Expected result: run fails, letting user know what config params is missing. Simulation did not proceed.

2) Scenario 2
- When: urbanism-v2/conf or other new beam config not include household or plans
- Expected result: run goes without error, simulation runs smoothly with expected result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3593)
<!-- Reviewable:end -->
