### PR TITLE
Remove obsolete maven repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ allprojects {
         // maven { url "http://maven.icm.edu.pl/artifactory/repo/" }
         // maven { url "https://maven.geotoolkit.org/" }
         maven { url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases" }
-        maven { url "https://central.maven.org/maven2" }
         maven { url "https://repo.maven.apache.org/maven2" }
         maven { url "https://repo.matsim.org/repository/matsim" }
         // Used for graphql-java and matsim.contrib.decongestion specific versions -
@@ -110,10 +109,6 @@ allprojects {
         maven { url "https://people.apache.org/repo/m1-ibiblio-rsync-repository/org.apache.axis2/" }
         maven { url "https://maven.geo-solutions.it" }
         mavenLocal()
-        maven {
-            url "http://nexus.onebusaway.org/content/groups/public/"
-            allowInsecureProtocol = true
-        }
         maven { url "https://jitpack.io" }
     }
 }
@@ -215,7 +210,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.8'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '2.27.0'
-    testImplementation group: "org.mockito", name: "mockito-core", version: "2.+"
+    testImplementation group: "org.mockito", name: "mockito-core", version: "2.28.2"
     jmhImplementation group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.23'
     jmhImplementation group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.23'
 


### PR DESCRIPTION
central.maven.org doesn't exist for a long time

nexus.onebusaway.org seems to be not used based on a git history and now causing exception when resolving mockito dependency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3595)
<!-- Reviewable:end -->
