### PR TITLE
Add an option to specify logback config for running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -570,7 +570,6 @@ applicationDefaultJvmArgs = ["-Xmx${myAvailableRam}g", "-Xms${halfOfAvailableMem
 println(applicationDefaultJvmArgs)
 
 run {
-    println("here")
     if (project.hasProperty("appArgs")) {
         args Eval.me(appArgs)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -382,6 +382,12 @@ tasks.withType(ScalaCompile) {
     }
 }
 
+tasks.withType(JavaExec).configureEach {task ->
+    if (!task.name.equals("run")) {
+        jvmArgs = project.hasProperty('logbackCfg') ? ["-Dlogback.configurationFile=${project.property('logbackCfg')}"] : []
+    }
+}
+
 
 // Task to run scala tests, as Scala tests not picked up by Gradle by default.
 // You can run it with a number of threads: ./gradlew spec -PnumThreads=4
@@ -564,6 +570,7 @@ applicationDefaultJvmArgs = ["-Xmx${myAvailableRam}g", "-Xms${halfOfAvailableMem
 println(applicationDefaultJvmArgs)
 
 run {
+    println("here")
     if (project.hasProperty("appArgs")) {
         args Eval.me(appArgs)
     }


### PR DESCRIPTION
It is useful to be able to optionally see detailed logs when running tests. I am adding an option to specify `-PlogbackCfg=logback.xml`  which enables logging configuration for tests. If no option specified it behaves as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3596)
<!-- Reviewable:end -->
