### PR TITLE
Fix NPE when loading RideHail skims

### DIFF
--- a/src/main/scala/beam/router/skim/core/RideHailSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/RideHailSkimmer.scala
@@ -38,8 +38,8 @@ class RideHailSkimmer @Inject() (
         reservationType = if (line("reservationType").equalsIgnoreCase("pooled")) Pooled else Solo
       ),
       RidehailSkimmerInternal(
-        waitTime = line("waitTime").toDouble,
-        costPerMile = line("costPerMile").toDouble,
+        waitTime = Option(line("waitTime")).map(_.toDouble).getOrElse(Double.NaN),
+        costPerMile = Option(line("costPerMile")).map(_.toDouble).getOrElse(Double.NaN),
         unmatchedRequestsPercent = line("unmatchedRequestsPercent").toDouble,
         observations = line("observations").toInt,
         iterations = line("iterations").toInt


### PR DESCRIPTION
In case we get `UnmatchedRideHailRequestSkimmerEvent` for RideHail skims then  `waitTime` and `costPerMile` values are `Double.NaN` and they are written to skim csv file as empty values. When reading it back it causes NPE. The workaround is to assign `Double.NaN` in this case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3606)
<!-- Reviewable:end -->
