### PR TITLE
uk/#3561-skimsUsageStats

### DIFF
--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -67,7 +67,6 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
   var numberOfRequests: Long = 0
   var numberOfSkimValueFound: Long = 0
-  var numberOfDefaultSkimValueFound: Long = 0
   def currentIteration: Int = currentIterationInternal
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
@@ -75,13 +74,11 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   def displaySkimStats(): Unit = {
     logger.info(s"Number of skim requests = $numberOfRequests")
     logger.info(s"Number of times actual value from skim map was returned = $numberOfSkimValueFound")
-    logger.info(s"Number of times default value from skim map was returned = $numberOfDefaultSkimValueFound")
   }
 
   def resetSkimStats(): Unit = {
     numberOfRequests = 0
     numberOfSkimValueFound = 0
-    numberOfDefaultSkimValueFound = 0
   }
 }
 

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -73,7 +73,6 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
 
   def displaySkimStats(): Unit = {
     logger.info(s"Number of skim requests = $numberOfRequests")
-
     logger.info(s"Number of times actual value from skim map was returned = $numberOfSkimValueFound")
   }
 

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -67,6 +67,7 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
   var numberOfRequests: Long = 0
   var numberOfSkimValueFound: Long = 0
+  var numberOfDefaultSkimValueFound: Long = 0
   def currentIteration: Int = currentIterationInternal
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
@@ -74,11 +75,13 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   def displaySkimStats(): Unit = {
     logger.info(s"Number of Skim Requests = $numberOfRequests")
     logger.info(s"Number of times actual value from Skim Map was returned = $numberOfSkimValueFound")
+    logger.info(s"Number of times default value from Skim Map was returned = $numberOfDefaultSkimValueFound")
   }
 
   def resetSkimStats(): Unit = {
     numberOfRequests = 0
     numberOfSkimValueFound = 0
+    numberOfDefaultSkimValueFound = 0
   }
 }
 

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -65,10 +65,21 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] var currentIterationInternal: Int = -1
   private[core] var aggregatedFromPastSkimsInternal = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
-
+  var numberOfRequests: Int = 0
+  var noOfReturnsSkimMapActualValue: Int = 0
   def currentIteration: Int = currentIterationInternal
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
+
+  def displaySkimStats(): Unit = {
+    logger.info(s"Number of Skim Requests = $numberOfRequests" )
+    logger.info(s"Number of Times Actual Value from Skim Map Was returned = $noOfReturnsSkimMapActualValue" )
+  }
+
+  def resetSkimStats(): Unit = {
+    numberOfRequests = 0
+    noOfReturnsSkimMapActualValue = 0
+  }
 }
 
 abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirectoryHierarchy)

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -73,7 +73,7 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
 
   def displaySkimStats(): Unit = {
     logger.info(s"Number of Skim Requests = $numberOfRequests")
-    logger.info(s"Number of Times Actual Value from Skim Map Was returned = $numberOfSkimValueFound")
+    logger.info(s"Number of times actual value from Skim Map was returned = $numberOfSkimValueFound")
   }
 
   def resetSkimStats(): Unit = {

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -73,6 +73,7 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
 
   def displaySkimStats(): Unit = {
     logger.info(s"Number of skim requests = $numberOfRequests")
+
     logger.info(s"Number of times actual value from skim map was returned = $numberOfSkimValueFound")
   }
 

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -66,19 +66,19 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] var aggregatedFromPastSkimsInternal = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
   var numberOfRequests: Int = 0
-  var noOfReturnsSkimMapActualValue: Int = 0
+  var numberOfSkimValueFound: Int = 0
   def currentIteration: Int = currentIterationInternal
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
 
   def displaySkimStats(): Unit = {
-    logger.info(s"Number of Skim Requests = $numberOfRequests" )
-    logger.info(s"Number of Times Actual Value from Skim Map Was returned = $noOfReturnsSkimMapActualValue" )
+    logger.info(s"Number of Skim Requests = $numberOfRequests")
+    logger.info(s"Number of Times Actual Value from Skim Map Was returned = $numberOfSkimValueFound")
   }
 
   def resetSkimStats(): Unit = {
     numberOfRequests = 0
-    noOfReturnsSkimMapActualValue = 0
+    numberOfSkimValueFound = 0
   }
 }
 

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -73,9 +73,9 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap
 
   def displaySkimStats(): Unit = {
-    logger.info(s"Number of Skim Requests = $numberOfRequests")
-    logger.info(s"Number of times actual value from Skim Map was returned = $numberOfSkimValueFound")
-    logger.info(s"Number of times default value from Skim Map was returned = $numberOfDefaultSkimValueFound")
+    logger.info(s"Number of skim requests = $numberOfRequests")
+    logger.info(s"Number of times actual value from skim map was returned = $numberOfSkimValueFound")
+    logger.info(s"Number of times default value from skim map was returned = $numberOfDefaultSkimValueFound")
   }
 
   def resetSkimStats(): Unit = {

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -65,8 +65,8 @@ abstract class AbstractSkimmerReadOnly extends LazyLogging {
   private[core] var currentIterationInternal: Int = -1
   private[core] var aggregatedFromPastSkimsInternal = Map.empty[AbstractSkimmerKey, AbstractSkimmerInternal]
   private[core] val pastSkimsInternal = mutable.HashMap.empty[Int, Map[AbstractSkimmerKey, AbstractSkimmerInternal]]
-  var numberOfRequests: Int = 0
-  var numberOfSkimValueFound: Int = 0
+  var numberOfRequests: Long = 0
+  var numberOfSkimValueFound: Long = 0
   def currentIteration: Int = currentIterationInternal
   def aggregatedFromPastSkims: Map[AbstractSkimmerKey, AbstractSkimmerInternal] = aggregatedFromPastSkimsInternal
   def pastSkims: Map[Int, collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]] = pastSkimsInternal.toMap

--- a/src/main/scala/beam/router/skim/readonly/FreightSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/FreightSkims.scala
@@ -16,10 +16,17 @@ class FreightSkims extends AbstractSkimmerReadOnly {
   ): Option[FreightSkimmerInternal] = {
     val key = FreightSkimmerKey(tazId, hour)
 
-    pastSkims
+    val getSkimValue = pastSkims
       .get(currentIteration - 1)
       .flatMap(_.get(key))
       .orElse(aggregatedFromPastSkims.get(key))
       .asInstanceOf[Option[FreightSkimmerInternal]]
+
+    if (getSkimValue.nonEmpty) {
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
+    }
+    numberOfRequests = numberOfRequests + 1
+
+    getSkimValue
   }
 }

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -220,8 +220,8 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
       .orElse(aggregatedFromPastSkims.get(ODSkimmerKey(timeToBin(time), mode, orig.toString, dest.toString)))
       .asInstanceOf[Option[ODSkimmerInternal]]
 
-    if(getSkimValue.nonEmpty){
-      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+    if (getSkimValue.nonEmpty) {
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
     }
     numberOfRequests = numberOfRequests + 1
 

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -20,6 +20,7 @@ import beam.router.Modes.BeamMode.{
 import beam.router.skim.SkimsUtils.{distanceAndTime, getRideHailCost, timeToBin}
 import beam.router.skim.core.AbstractSkimmerReadOnly
 import beam.router.skim.core.ODSkimmer.{ExcerptData, ODSkimmerInternal, ODSkimmerKey, Skim}
+import beam.router.skim.readonly
 import beam.sim.config.BeamConfig
 import beam.sim.{BeamHelper, BeamScenario, BeamServices}
 import org.matsim.api.core.v01.{Coord, Id}

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -214,11 +214,18 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
   }
 
   private def getSkimValue(time: Int, mode: BeamMode, orig: Id[TAZ], dest: Id[TAZ]): Option[ODSkimmerInternal] = {
-    pastSkims
+    val getSkimValue = pastSkims
       .get(currentIteration - 1)
       .flatMap(_.get(ODSkimmerKey(timeToBin(time), mode, orig.toString, dest.toString)))
       .orElse(aggregatedFromPastSkims.get(ODSkimmerKey(timeToBin(time), mode, orig.toString, dest.toString)))
       .asInstanceOf[Option[ODSkimmerInternal]]
+
+    if(getSkimValue.nonEmpty){
+      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+    }
+    numberOfRequests = numberOfRequests + 1
+
+    getSkimValue
   }
 
 }
@@ -233,6 +240,7 @@ object ODSkims extends BeamHelper {
     beamVehicleType: BeamVehicleType,
     fuelPrice: Double
   ): Skim = {
+
     val (travelDistance, travelTime) = distanceAndTime(mode, originUTM, destinationUTM)
     val votMultiplier: Double = mode match {
       case CAV => beamConfig.beam.agentsim.agents.modalBehaviors.modeVotMultiplier.CAV

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -241,7 +241,6 @@ object ODSkims extends BeamHelper {
     beamVehicleType: BeamVehicleType,
     fuelPrice: Double
   ): Skim = {
-
     val (travelDistance, travelTime) = distanceAndTime(mode, originUTM, destinationUTM)
     val votMultiplier: Double = mode match {
       case CAV => beamConfig.beam.agentsim.agents.modalBehaviors.modeVotMultiplier.CAV

--- a/src/main/scala/beam/router/skim/readonly/ParkingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ParkingSkims.scala
@@ -17,10 +17,17 @@ class ParkingSkims extends AbstractSkimmerReadOnly {
   ): Option[ParkingSkimmerInternal] = {
     val key = ParkingSkimmerKey(tazId, hour, chargerType)
 
-    pastSkims
+    val getSkimValue = pastSkims
       .get(currentIteration - 1)
       .flatMap(_.get(key))
       .orElse(aggregatedFromPastSkims.get(key))
       .asInstanceOf[Option[ParkingSkimmerInternal]]
+
+    if (getSkimValue.nonEmpty) {
+      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+    }
+    numberOfRequests = numberOfRequests + 1
+
+    getSkimValue
   }
 }

--- a/src/main/scala/beam/router/skim/readonly/ParkingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ParkingSkims.scala
@@ -24,7 +24,7 @@ class ParkingSkims extends AbstractSkimmerReadOnly {
       .asInstanceOf[Option[ParkingSkimmerInternal]]
 
     if (getSkimValue.nonEmpty) {
-      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
     }
     numberOfRequests = numberOfRequests + 1
 

--- a/src/main/scala/beam/router/skim/readonly/RideHailSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/RideHailSkims.scala
@@ -25,7 +25,7 @@ class RideHailSkims extends AbstractSkimmerReadOnly {
       .asInstanceOf[Option[RidehailSkimmerInternal]]
 
     if (getSkimValue.nonEmpty) {
-      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
     }
     numberOfRequests = numberOfRequests + 1
 

--- a/src/main/scala/beam/router/skim/readonly/RideHailSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/RideHailSkims.scala
@@ -18,10 +18,17 @@ class RideHailSkims extends AbstractSkimmerReadOnly {
   ): Option[RidehailSkimmerInternal] = {
     val key = RidehailSkimmerKey(tazId, hour, reservationType)
 
-    pastSkims
+    val getSkimValue = pastSkims
       .get(currentIteration - 1)
       .flatMap(_.get(key))
       .orElse(aggregatedFromPastSkims.get(key))
       .asInstanceOf[Option[RidehailSkimmerInternal]]
+
+    if (getSkimValue.nonEmpty) {
+      noOfReturnsSkimMapActualValue = noOfReturnsSkimMapActualValue + 1
+    }
+    numberOfRequests = numberOfRequests + 1
+
+    getSkimValue
   }
 }

--- a/src/main/scala/beam/router/skim/readonly/TAZSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TAZSkims.scala
@@ -9,11 +9,18 @@ class TAZSkims() extends AbstractSkimmerReadOnly {
 
   def isLatestSkimEmpty: Boolean = pastSkims.isEmpty
 
-  def getLatestSkim(time: Int, geoId: Id[_], actor: String, key: String): Option[TAZSkimmerInternal] =
-    pastSkims
+  def getLatestSkim(time: Int, geoId: Id[_], actor: String, key: String): Option[TAZSkimmerInternal] = {
+    val getSkimValue = pastSkims
       .get(currentIteration - 1)
       .flatMap(_.get(TAZSkimmerKey(time, geoId.toString, actor, key)))
       .asInstanceOf[Option[TAZSkimmerInternal]]
+    if (getSkimValue.nonEmpty) {
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
+    }
+    numberOfRequests = numberOfRequests + 1
+
+    getSkimValue
+  }
 
   def getLatestSkim(time: Int, geoId: String, actor: String, key: String): Option[TAZSkimmerInternal] =
     getLatestSkim(time, geoId, actor, key)

--- a/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
@@ -87,7 +87,6 @@ class TransitCrowdingSkims(vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleTyp
     def getValueFrom(x: collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]) = {
       x.get(key).asInstanceOf[Option[TransitCrowdingSkimmerInternal]]
     }
-
     val pastSkimsValue = pastSkims.get(currentIteration - 1).flatMap(getValueFrom)
     val aggregatedPastSkims = getValueFrom(aggregatedFromPastSkims)
     if (pastSkimsValue.nonEmpty || aggregatedPastSkims.nonEmpty) {

--- a/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
@@ -87,16 +87,16 @@ class TransitCrowdingSkims(vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleTyp
     def getValueFrom(x: collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]) = {
       x.get(key).asInstanceOf[Option[TransitCrowdingSkimmerInternal]]
     }
-    val aggregatedFromPastSkims = getValueFrom(aggregatedFromPastSkims)
-    val pastSkimsValue = pastSkims.get(currentIteration - 1).flatMap(getValueFrom)
 
-    if (aggregatedFromPastSkims.nonEmpty || pastSkimsValue.nonEmpty) {
+    val pastSkimsValue = pastSkims.get(currentIteration - 1).flatMap(getValueFrom)
+    val aggregatedPastSkims = getValueFrom(aggregatedFromPastSkims)
+    if (pastSkimsValue.nonEmpty || aggregatedPastSkims.nonEmpty) {
       numberOfSkimValueFound = numberOfSkimValueFound + 1
     }
     numberOfRequests = numberOfRequests + 1
 
     average(
-      aggregatedFromPastSkims,
+      aggregatedPastSkims,
       pastSkimsValue,
       vehicleTypeId
     )

--- a/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
@@ -87,10 +87,17 @@ class TransitCrowdingSkims(vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleTyp
     def getValueFrom(x: collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]) = {
       x.get(key).asInstanceOf[Option[TransitCrowdingSkimmerInternal]]
     }
+    val aggregatedFromPastSkims = getValueFrom(aggregatedFromPastSkims)
+    val pastSkimsValue = pastSkims.get(currentIteration - 1).flatMap(getValueFrom)
+
+    if (aggregatedFromPastSkims.nonEmpty || pastSkimsValue.nonEmpty) {
+      numberOfSkimValueFound = numberOfSkimValueFound + 1
+    }
     numberOfRequests = numberOfRequests + 1
+
     average(
-      getValueFrom(aggregatedFromPastSkims),
-      pastSkims.get(currentIteration - 1).flatMap(getValueFrom),
+      aggregatedFromPastSkims,
+      pastSkimsValue,
       vehicleTypeId
     )
   }

--- a/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/TransitCrowdingSkims.scala
@@ -87,7 +87,7 @@ class TransitCrowdingSkims(vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleTyp
     def getValueFrom(x: collection.Map[AbstractSkimmerKey, AbstractSkimmerInternal]) = {
       x.get(key).asInstanceOf[Option[TransitCrowdingSkimmerInternal]]
     }
-
+    numberOfRequests = numberOfRequests + 1
     average(
       getValueFrom(aggregatedFromPastSkims),
       pastSkims.get(currentIteration - 1).flatMap(getValueFrom),

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -156,6 +156,8 @@ class BeamMobsim @Inject() (
       beamServices.skims.rh_skimmer.displaySkimStats()
       beamServices.skims.freight_skimmer.displaySkimStats()
       beamServices.skims.taz_skimmer.displaySkimStats()
+      beamServices.skims.dt_skimmer.displaySkimStats()
+      beamServices.skims.tc_skimmer.displaySkimStats()
     }
 
     if (beamServices.beamConfig.beam.output.writePlansAndStopSimulation) {

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -151,6 +151,9 @@ class BeamMobsim @Inject() (
       fillInSecondaryActivities(
         beamServices.matsimServices.getScenario.getHouseholds
       )
+      beamServices.skims.od_skimmer.displaySkimStats()
+      beamServices.skims.parking_skimmer.displaySkimStats()
+      beamServices.skims.rh_skimmer.displaySkimStats()
     }
 
     if (beamServices.beamConfig.beam.output.writePlansAndStopSimulation) {

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -155,6 +155,7 @@ class BeamMobsim @Inject() (
       beamServices.skims.parking_skimmer.displaySkimStats()
       beamServices.skims.rh_skimmer.displaySkimStats()
       beamServices.skims.freight_skimmer.displaySkimStats()
+      beamServices.skims.taz_skimmer.displaySkimStats()
     }
 
     if (beamServices.beamConfig.beam.output.writePlansAndStopSimulation) {

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -154,6 +154,7 @@ class BeamMobsim @Inject() (
       beamServices.skims.od_skimmer.displaySkimStats()
       beamServices.skims.parking_skimmer.displaySkimStats()
       beamServices.skims.rh_skimmer.displaySkimStats()
+      beamServices.skims.freight_skimmer.displaySkimStats()
     }
 
     if (beamServices.beamConfig.beam.output.writePlansAndStopSimulation) {

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -340,6 +340,8 @@ class BeamSim @Inject() (
     beamServices.skims.rh_skimmer.resetSkimStats()
     beamServices.skims.freight_skimmer.resetSkimStats()
     beamServices.skims.taz_skimmer.resetSkimStats()
+    beamServices.skims.dt_skimmer.resetSkimStats()
+    beamServices.skims.tc_skimmer.resetSkimStats()
 
     backgroundSkimsCreator.foreach(_.reduceParallelismTo(1))
     beamServices.eventBuilderActor = actorSystem.actorOf(
@@ -551,6 +553,8 @@ class BeamSim @Inject() (
     beamServices.skims.rh_skimmer.displaySkimStats()
     beamServices.skims.freight_skimmer.displaySkimStats()
     beamServices.skims.taz_skimmer.displaySkimStats()
+    beamServices.skims.dt_skimmer.displaySkimStats()
+    beamServices.skims.tc_skimmer.displaySkimStats()
 
     if (beamConfig.beam.agentsim.agents.vehicles.linkSocAcrossIterations)
       beamServices.beamScenario.setInitialSocOfPrivateVehiclesFromCurrentStateOfVehicles()

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -335,6 +335,11 @@ class BeamSim @Inject() (
   }
 
   override def notifyIterationStarts(event: IterationStartsEvent): Unit = {
+    beamServices.skims.parking_skimmer.resetSkimStats()
+    beamServices.skims.od_skimmer.resetSkimStats()
+    beamServices.skims.rh_skimmer.resetSkimStats()
+
+
     backgroundSkimsCreator.foreach(_.reduceParallelismTo(1))
     beamServices.eventBuilderActor = actorSystem.actorOf(
       EventBuilderActor.props(
@@ -539,6 +544,11 @@ class BeamSim @Inject() (
     if (beamConfig.beam.debug.vmInformation.createGCClassHistogram) {
       vmInformationWriter.notifyIterationEnds(event)
     }
+
+    beamServices.skims.parking_skimmer.displaySkimStats()
+    beamServices.skims.od_skimmer.displaySkimStats()
+    beamServices.skims.rh_skimmer.displaySkimStats()
+
 
     if (beamConfig.beam.agentsim.agents.vehicles.linkSocAcrossIterations)
       beamServices.beamScenario.setInitialSocOfPrivateVehiclesFromCurrentStateOfVehicles()

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -338,7 +338,7 @@ class BeamSim @Inject() (
     beamServices.skims.parking_skimmer.resetSkimStats()
     beamServices.skims.od_skimmer.resetSkimStats()
     beamServices.skims.rh_skimmer.resetSkimStats()
-
+    beamServices.skims.freight_skimmer.resetSkimStats()
 
     backgroundSkimsCreator.foreach(_.reduceParallelismTo(1))
     beamServices.eventBuilderActor = actorSystem.actorOf(
@@ -548,7 +548,7 @@ class BeamSim @Inject() (
     beamServices.skims.parking_skimmer.displaySkimStats()
     beamServices.skims.od_skimmer.displaySkimStats()
     beamServices.skims.rh_skimmer.displaySkimStats()
-
+    beamServices.skims.freight_skimmer.displaySkimStats()
 
     if (beamConfig.beam.agentsim.agents.vehicles.linkSocAcrossIterations)
       beamServices.beamScenario.setInitialSocOfPrivateVehiclesFromCurrentStateOfVehicles()

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -339,6 +339,7 @@ class BeamSim @Inject() (
     beamServices.skims.od_skimmer.resetSkimStats()
     beamServices.skims.rh_skimmer.resetSkimStats()
     beamServices.skims.freight_skimmer.resetSkimStats()
+    beamServices.skims.taz_skimmer.resetSkimStats()
 
     backgroundSkimsCreator.foreach(_.reduceParallelismTo(1))
     beamServices.eventBuilderActor = actorSystem.actorOf(
@@ -549,6 +550,7 @@ class BeamSim @Inject() (
     beamServices.skims.od_skimmer.displaySkimStats()
     beamServices.skims.rh_skimmer.displaySkimStats()
     beamServices.skims.freight_skimmer.displaySkimStats()
+    beamServices.skims.taz_skimmer.displaySkimStats()
 
     if (beamConfig.beam.agentsim.agents.vehicles.linkSocAcrossIterations)
       beamServices.beamScenario.setInitialSocOfPrivateVehiclesFromCurrentStateOfVehicles()

--- a/src/main/scala/beam/utils/StuckFinder.scala
+++ b/src/main/scala/beam/utils/StuckFinder.scala
@@ -162,7 +162,7 @@ class StuckFinder(val cfg: StuckAgentDetection) extends LazyLogging {
       Class.forName(t.triggerType)
     }
     val allSubClasses = new ReflectionUtils { val packageName = "beam.agentsim" }.classesOfType[Trigger]
-    if(iterationNumber == 0) {//StuckFinder Warnings should only be displayed during the 0th iteration
+    if (iterationNumber == 0) { //StuckFinder Warnings should only be displayed during the 0th iteration
       allSubClasses.diff(definedTypes).foreach { clazz =>
         logger.warn("There is no configuration for '{}'", clazz);
       }


### PR DESCRIPTION
Collected usage statistics of skims:
1. number of requests
2. number of times the actual value from skims map was returned

Currently, collection is done for ODSkims, ParkingSkims, FreightSkims, TAZSkims, DriveTimeSkims, TransitCrowdingSkims and RideHailSkims

Resets stats at the beginning of each iteration, writes stats to logs at the end of each iteration. Writes stats to logs after generation of activities

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3607)
<!-- Reviewable:end -->
