### PR TITLE
Fix config for memory

### DIFF
--- a/src/main/scala/beam/utils/logging/LoggingMessageActor.scala
+++ b/src/main/scala/beam/utils/logging/LoggingMessageActor.scala
@@ -24,9 +24,10 @@ trait LoggingMessageActor extends Actor {
 }
 
 object LoggingMessageActor {
+
   def messageLoggingEnabled(config: Config): Boolean =
-    if(config.hasPathOrNull("beam.debug.messageLogging")){
-      config.getBoolean(("beam.debug.messageLogging"))
+    if (config.hasPathOrNull("beam.debug.messageLogging")) {
+      config.getBoolean("beam.debug.messageLogging")
     } else false
 }
 

--- a/src/main/scala/beam/utils/logging/LoggingMessageActor.scala
+++ b/src/main/scala/beam/utils/logging/LoggingMessageActor.scala
@@ -24,12 +24,10 @@ trait LoggingMessageActor extends Actor {
 }
 
 object LoggingMessageActor {
-  import scala.collection.JavaConverters._
-
   def messageLoggingEnabled(config: Config): Boolean =
-    config
-      .withFallback(ConfigFactory.parseMap(Map("beam.debug.messageLogging" -> false).asJava))
-      .getBoolean("beam.debug.messageLogging")
+    if(config.hasPathOrNull("beam.debug.messageLogging")){
+      config.getBoolean(("beam.debug.messageLogging"))
+    } else false
 }
 
 trait LoggingMessagePublisher extends Actor {


### PR DESCRIPTION
The old way is fine if it is a `val`, but as a `def` the config gets rebuild over and over - making a fairly large memory overhead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3641)
<!-- Reviewable:end -->
