### PR TITLE
Fix of wrong usage of teleportation vehicle

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -1376,9 +1376,16 @@ trait ChoosesMode {
                   availableAlternatives = availableAlts
                 )
               }
-            case Some(_) =>
+            case Some(mode) =>
               //give another chance to make a choice without predefined mode
-              self ! MobilityStatusResponse(choosesModeData.allAvailableStreetVehicles, getCurrentTriggerId.get)
+              val availableVehicles =
+                if (mode.isTeleportation)
+                  //we need to remove our teleportation vehicle since we cannot use it if it's not a teleportation mode
+                  choosesModeData.allAvailableStreetVehicles.filterNot(vehicle =>
+                    BeamVehicle.isSharedTeleportationVehicle(vehicle.id)
+                  )
+                else choosesModeData.allAvailableStreetVehicles
+              self ! MobilityStatusResponse(availableVehicles, getCurrentTriggerId.get)
               stay() using ChoosesModeData(
                 personData = personData.copy(currentTourMode = None),
                 currentLocation = choosesModeData.currentLocation,

--- a/src/main/scala/beam/router/Modes.scala
+++ b/src/main/scala/beam/router/Modes.scala
@@ -34,6 +34,7 @@ object Modes {
     def isTransit: Boolean = isR5TransitMode(this)
     def isMassTransit: Boolean = this == SUBWAY || this == RAIL || this == FERRY || this == TRAM
     def isRideHail: Boolean = this == RIDE_HAIL
+    def isTeleportation: Boolean = this == HOV2_TELEPORTATION || this == HOV3_TELEPORTATION
   }
 
   object BeamMode extends StringEnum[BeamMode] with StringCirceEnum[BeamMode] {


### PR DESCRIPTION
Teleporation vehicles were used in regular legs. This PR fixes it.
This is the exception that is rised without this fix.
02:56:17.136 [ClusterSystem-akka.actor.default-dispatcher-22] ERROR akka.actor.OneForOneStrategy - None.get
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at beam.agentsim.agents.PersonAgent$$anonfun$9.$anonfun$applyOrElse$17(PersonAgent.scala:901)
	at beam.agentsim.agents.PersonAgent$$anonfun$9.$anonfun$applyOrElse$17$adapted(PersonAgent.scala:901)
	at scala.Option.foreach(Option.scala:407) (edited)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3650)
<!-- Reviewable:end -->
