### PR TITLE
Increased stuck threshold at init stage

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -792,6 +792,7 @@ beam.debug {
   messageLogging = "boolean | false"
   # the max of the next 2 values is taken for the initialization step
   maxSimulationStepTimeBeforeConsideredStuckMin = "int | 60"
+  maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin = "int | 600"
 }
 
 beam.logger.keepConsoleAppenderOn = "boolean | true"

--- a/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
+++ b/src/main/scala/beam/agentsim/scheduler/BeamAgentScheduler.scala
@@ -271,7 +271,11 @@ class BeamAgentScheduler(
 
     case SimulationStuckCheck =>
       if (started) {
-        val stuckThresholdMin = beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckMin
+        val stuckThresholdMin =
+          if (nowInSeconds < maxWindow)
+            beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin
+          else
+            beamConfig.beam.debug.maxSimulationStepTimeBeforeConsideredStuckMin
         val currentDelayMillis = System.currentTimeMillis() - nowUpdateTime
         if (currentDelayMillis > stuckThresholdMin * 60000L) {
           log.error(

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2585,6 +2585,7 @@ object BeamConfig {
       clearRoutedOutstandingWorkEnabled: scala.Boolean,
       debugActorTimerIntervalInSec: scala.Int,
       debugEnabled: scala.Boolean,
+      maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin: scala.Int,
       maxSimulationStepTimeBeforeConsideredStuckMin: scala.Int,
       memoryConsumptionDisplayTimeoutInSec: scala.Int,
       messageLogging: scala.Boolean,
@@ -2746,6 +2747,10 @@ object BeamConfig {
           debugActorTimerIntervalInSec =
             if (c.hasPathOrNull("debugActorTimerIntervalInSec")) c.getInt("debugActorTimerIntervalInSec") else 0,
           debugEnabled = c.hasPathOrNull("debugEnabled") && c.getBoolean("debugEnabled"),
+          maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin =
+            if (c.hasPathOrNull("maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin"))
+              c.getInt("maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin")
+            else 600,
           maxSimulationStepTimeBeforeConsideredStuckMin =
             if (c.hasPathOrNull("maxSimulationStepTimeBeforeConsideredStuckMin"))
               c.getInt("maxSimulationStepTimeBeforeConsideredStuckMin")


### PR DESCRIPTION
At zero time there are a lot of init calculation happens. If it takes somwhat long time then Beam can be terminated.
This PR fixes it by introducing a new parameter:
beam.debug.maxSimulationStepTimeBeforeConsideredStuckAtInitializationMin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3666)
<!-- Reviewable:end -->
