### PR TITLE
Added trip id to transitVehicleTypesByRoute File

### DIFF
--- a/src/main/scala/beam/agentsim/agents/TransitSystem.scala
+++ b/src/main/scala/beam/agentsim/agents/TransitSystem.scala
@@ -3,6 +3,7 @@ package beam.agentsim.agents
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{ActorLogging, ActorRef, OneForOneStrategy, Terminated}
 import beam.agentsim.agents.BeamAgent.Finish
+import beam.agentsim.agents.TransitVehicleInitializer.loadGtfsVehicleTypes
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType, VehicleManager}
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger}
@@ -13,8 +14,9 @@ import beam.router.{Modes, TransitInitializer}
 import beam.sim.common.GeoUtils
 import beam.sim.config.BeamConfig
 import beam.sim.{BeamScenario, BeamServices}
+import beam.utils.csv.GenericCsvReader
 import beam.utils.logging.{ExponentialLazyLogging, LoggingMessageActor}
-import beam.utils.{FileUtils, NetworkHelper}
+import beam.utils.NetworkHelper
 import com.conveyal.r5.profile.StreetMode
 import com.conveyal.r5.transit.{RouteInfo, TransitLayer, TransportNetwork}
 import org.matsim.api.core.v01.{Id, Scenario}
@@ -22,7 +24,7 @@ import org.matsim.core.api.experimental.events.EventsManager
 import org.matsim.vehicles.Vehicle
 
 import java.util.concurrent.atomic.AtomicReference
-import scala.util.{Random, Try}
+import scala.util.Random
 
 class TransitSystem(
   val beamServices: BeamServices,
@@ -111,7 +113,10 @@ object TransitSystem {}
 class TransitVehicleInitializer(val beamConfig: BeamConfig, val vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleType])
     extends ExponentialLazyLogging {
 
-  private val transitVehicleTypesByRoute: Map[String, Map[String, String]] = loadTransitVehicleTypesMap()
+  //contains entries: agencyId -> Map[(routeId, Option(transitVehicleId)) -> VehicleType]
+  //if an Option is empty that vehicle type works for entire route
+  private val transitVehicleTypesByRoute: Map[String, Map[(String, Option[Id[BeamVehicle]]), String]] =
+    loadTransitVehicleTypesMap()
 
   def createTransitVehicle(
     transitVehId: Id[Vehicle],
@@ -119,7 +124,7 @@ class TransitVehicleInitializer(val beamConfig: BeamConfig, val vehicleTypes: Ma
     randomSeed: Int
   ): Option[BeamVehicle] = {
     val mode = Modes.mapTransitMode(TransitLayer.getTransitModes(route.route_type))
-    val vehicleType = getVehicleType(route, mode)
+    val vehicleType = getVehicleType(route, transitVehId, mode)
     mode match {
       case BUS | SUBWAY | TRAM | CABLE_CAR | RAIL | FERRY | GONDOLA if vehicleType != null =>
         val powertrain = Powertrain(Option(vehicleType.primaryFuelConsumptionInJoulePerMeter))
@@ -140,11 +145,15 @@ class TransitVehicleInitializer(val beamConfig: BeamConfig, val vehicleTypes: Ma
     }
   }
 
-  def getVehicleType(route: RouteInfo, mode: Modes.BeamMode): BeamVehicleType = {
+  def getVehicleType(route: RouteInfo, transitVehId: Id[Vehicle], mode: Modes.BeamMode): BeamVehicleType = {
     val vehicleTypeId = Id.create(
       transitVehicleTypesByRoute
         .get(route.agency_id)
-        .fold(None.asInstanceOf[Option[String]])(_.get(route.route_id))
+        .fold(Option.empty[String]) { vehicleTypes =>
+          vehicleTypes
+            .get(route.route_id -> Some(transitVehId))
+            .orElse(vehicleTypes.get(route.route_id -> None))
+        }
         .getOrElse(mode.toString.toUpperCase + "-" + route.agency_id),
       classOf[BeamVehicleType]
     )
@@ -164,20 +173,37 @@ class TransitVehicleInitializer(val beamConfig: BeamConfig, val vehicleTypes: Ma
     }
   }
 
-  private def loadTransitVehicleTypesMap(): Map[String, Map[String, String]] = {
+  private def loadTransitVehicleTypesMap(): Map[String, Map[(String, Option[Id[BeamVehicle]]), String]] = {
     val file = beamConfig.beam.agentsim.agents.vehicles.transitVehicleTypesByRouteFile
-    Try(
-      FileUtils.readAllLines(file).toList.tail
-    ).getOrElse(List())
-      .map(_.trim.split(","))
-      .filter(_.length > 2)
-      .groupBy(_(0))
-      .mapValues(_.groupBy(_(1)).mapValues(_.head(2)))
+    loadGtfsVehicleTypes(file)
   }
-
 }
 
 object TransitVehicleInitializer {
+
+  def loadGtfsVehicleTypes(file: String): Map[String, Map[(String, Option[Id[BeamVehicle]]), String]] = {
+    case class VehicleTypeRow(
+      agencyId: String,
+      routeId: String,
+      transitVehicleId: Option[Id[BeamVehicle]],
+      vehicleTypeId: String
+    )
+    val rows: IndexedSeq[VehicleTypeRow] = GenericCsvReader.readAsSeq[VehicleTypeRow](file) { rec =>
+      VehicleTypeRow(
+        rec.get("agencyId"),
+        rec.get("routeId"),
+        Option(rec.get("tripId")).map(gtfsTripIdToBeamVehicleId),
+        rec.get("vehicleTypeId")
+      )
+    }
+    rows
+      .groupBy(_.agencyId)
+      .mapValues(_.groupBy(row => row.routeId -> row.transitVehicleId).mapValues(_.head.vehicleTypeId))
+  }
+
+  def gtfsTripIdToBeamVehicleId(tripId: String): Id[BeamVehicle] = {
+    Id.create(BeamVehicle.noSpecialChars(tripId), classOf[BeamVehicle])
+  }
 
   def transitModeToBeamVehicleType(mode: Modes.BeamMode): Id[BeamVehicleType] = {
     Id.create(mode.toString.toUpperCase + "-DEFAULT", classOf[BeamVehicleType])

--- a/src/main/scala/beam/router/TransitInitializer.scala
+++ b/src/main/scala/beam/router/TransitInitializer.scala
@@ -1,9 +1,10 @@
 package beam.router
 
+import beam.agentsim.agents.TransitVehicleInitializer
+
 import java.util
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
-
 import beam.agentsim.agents.vehicles.BeamVehicle
 import beam.agentsim.events.SpaceTime
 import beam.router.Modes.isOnStreetTransit
@@ -173,7 +174,7 @@ class TransitInitializer(
         .filter(tripSchedule => activeServicesToday.get(tripSchedule.serviceCode))
         .map { tripSchedule =>
           // First create a unique id for this trip which will become the transit agent and vehicle id
-          val tripVehId = Id.create(BeamVehicle.noSpecialChars(tripSchedule.tripId), classOf[BeamVehicle])
+          val tripVehId = TransitVehicleInitializer.gtfsTripIdToBeamVehicleId(tripSchedule.tripId)
           val legs =
             tripSchedule.departures.zipWithIndex
               .sliding(2)

--- a/src/test/scala/beam/router/TransitVehicleInitializerSpec.scala
+++ b/src/test/scala/beam/router/TransitVehicleInitializerSpec.scala
@@ -1,45 +1,117 @@
 package beam.router
 
 import beam.agentsim.agents.TransitVehicleInitializer
+import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType}
 import beam.integration.IntegrationSpecCommon
 import beam.router.Modes.BeamMode
 import beam.sim.config.BeamConfig
 import beam.utils.BeamVehicleUtils.readBeamVehicleTypeFile
+import beam.utils.matsim_conversion.MatsimPlanConversion.IdOps
 import com.conveyal.r5.transit.RouteInfo
 import com.typesafe.config.ConfigValueFactory
+import org.matsim.api.core.v01.Id
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class TransitVehicleInitializerSpec extends AnyWordSpecLike with Matchers with IntegrationSpecCommon {
+  private val arbitraryVehicleId = Id.createVehicleId("dummy-vehicle-id")
   "getVehicleType" should {
-    val transitInitializer: TransitVehicleInitializer = init
+    val transitInitializer: TransitVehicleInitializer =
+      init("test/test-resources/beam/router/transitVehicleTypesByRoute.csv")
 
     "return SUV, based on agency[217] and route[1342] map" in {
       val expectedType = "BUS-DEFAULT"
-      val actualType = transitInitializer.getVehicleType(routeInfo("217", "1342"), BeamMode.BUS).id.toString
+      val actualType =
+        transitInitializer.getVehicleType(routeInfo("217", "1342"), arbitraryVehicleId, BeamMode.BUS).id.toString
 
       actualType shouldEqual expectedType
     }
 
     "return RAIL-DEFAULT, based on agency[DEFAULT] " in {
       val expectedType = "RAIL-DEFAULT"
-      val actualType = transitInitializer.getVehicleType(routeInfo("DEFAULT", "dummy"), BeamMode.RAIL).id.toString
+      val actualType =
+        transitInitializer.getVehicleType(routeInfo("DEFAULT", "dummy"), arbitraryVehicleId, BeamMode.RAIL).id.toString
 
       actualType shouldEqual expectedType
     }
 
     "return BUS-DEFAULT, as a default vehicle type" in {
       val expectedType = "BUS-DEFAULT"
-      val actualType = transitInitializer.getVehicleType(routeInfo("dummy", "dummy"), BeamMode.BUS).id.toString
+      val actualType =
+        transitInitializer.getVehicleType(routeInfo("dummy", "dummy"), arbitraryVehicleId, BeamMode.BUS).id.toString
 
       actualType shouldEqual expectedType
     }
 
     "not be BUS-AC, as vehicleTypes doesn't have it" in {
       val expectedType = "BUS-AC"
-      val actualType = transitInitializer.getVehicleType(routeInfo("217", "1350"), BeamMode.BUS).id.toString
+      val actualType =
+        transitInitializer.getVehicleType(routeInfo("217", "1350"), arbitraryVehicleId, BeamMode.BUS).id.toString
 
       actualType should not be expectedType
+    }
+  }
+
+  "getVehicleType" when {
+    "provided with routeIds/tripIds" should {
+      val transitInitializer: TransitVehicleInitializer =
+        init("test/test-resources/beam/router/transitVehicleTypesByRouteWithTripId.csv")
+      "return SUV, based on agency[217] and route[1342] map" in {
+        val actualType = transitInitializer.getVehicleType(routeInfo("217", "1342"), arbitraryVehicleId, BeamMode.BUS)
+
+        actualType.id.toString shouldEqual "BUS-DEFAULT"
+      }
+      "return RAIL-DEFAULT, based on agency[217] and route[1342] and trip[1] map" in {
+        val actualType =
+          transitInitializer.getVehicleType(routeInfo("217", "1342"), "1".createId[BeamVehicle], BeamMode.BUS)
+
+        actualType.id.toString shouldEqual "RAIL-DEFAULT"
+      }
+      "return TRAM-DEFAULT, based on agency[3234] and route[12] map" in {
+        val actualType =
+          transitInitializer.getVehicleType(routeInfo("3234", "12"), "2".createId[BeamVehicle], BeamMode.BUS)
+
+        actualType.id.toString shouldEqual "TRAM-DEFAULT"
+      }
+    }
+  }
+
+  "loadGtfsVehicleTypes" should {
+    "load vehicle types" in {
+      val result =
+        TransitVehicleInitializer.loadGtfsVehicleTypes("test/test-resources/beam/router/transitVehicleTypesByRoute.csv")
+      result shouldBe (
+        Map(
+          "217" -> Map(
+            ("1342", None) -> "SUV",
+            ("1350", None) -> "BUS-AC",
+            ("22", None)   -> "BUS-DEFAULT"
+          ),
+          "3234" -> Map(
+            ("12", None)   -> "CABLE_CAR",
+            ("1350", None) -> "BABAR"
+          )
+        )
+      )
+    }
+    "load vehicle types with trip ids" in {
+      val result = TransitVehicleInitializer.loadGtfsVehicleTypes(
+        "test/test-resources/beam/router/transitVehicleTypesByRouteWithTripId.csv"
+      )
+
+      result shouldBe (
+        Map(
+          "217" -> Map(
+            ("1342", None)                            -> "SUV",
+            ("1342", Some("1".createId[BeamVehicle])) -> "RAIL-DEFAULT",
+            ("22", Some("2".createId[BeamVehicle]))   -> "BUS-DEFAULT"
+          ),
+          "3234" -> Map(
+            ("12", None)   -> "TRAM-DEFAULT",
+            ("1350", None) -> "BABAR"
+          )
+        )
+      )
     }
   }
 
@@ -50,13 +122,13 @@ class TransitVehicleInitializerSpec extends AnyWordSpecLike with Matchers with I
     route
   }
 
-  private def init = {
+  private def init(filePath: String) = {
     val beamConfig = BeamConfig(
       baseConfig
         .withValue(
           "beam.agentsim.agents.vehicles.transitVehicleTypesByRouteFile",
           ConfigValueFactory
-            .fromAnyRef("test/test-resources/beam/router/transitVehicleTypesByRoute.csv")
+            .fromAnyRef(filePath)
         )
     )
     val vehicleTypes = readBeamVehicleTypeFile(beamConfig.beam.agentsim.agents.vehicles.vehicleTypesFilePath)

--- a/test/input/beamville/transitVehicleTypesByRoute.csv
+++ b/test/input/beamville/transitVehicleTypesByRoute.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b2c4107cf2512a1567e9ddf3b8a3f4f1fd7e15414ad884a0b5015c738447c5c
-size 123
+oid sha256:83ff83682554eb5c220db8f66b514a8bbc634553e86ee6309deddc44d2002fe3
+size 238

--- a/test/test-resources/beam/router/transitVehicleTypesByRouteWithTripId.csv
+++ b/test/test-resources/beam/router/transitVehicleTypesByRouteWithTripId.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e58b0cd0d44aea6245dcd4a0d86bac0e0d65558398eb9f223ca1da90418342db
+size 142


### PR DESCRIPTION
`tripId`s in that file should be the same as returned by `com.conveyal.r5.transit.TripSchedule` class of r5 library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3673)
<!-- Reviewable:end -->
