### PR TITLE
Fixes the tick and trigger issue on SingleModeSpec test

### DIFF
--- a/src/test/scala/beam/utils/SimRunnerForTest.scala
+++ b/src/test/scala/beam/utils/SimRunnerForTest.scala
@@ -1,13 +1,10 @@
 package beam.utils
 
-import java.io.File
-
 import akka.actor.ActorSystem
 import beam.agentsim.agents.modalbehaviors.ModeChoiceCalculator
 import beam.agentsim.events.eventbuilder.{ComplexEventBuilder, EventBuilderActor}
-import beam.api.{BeamCustomizationAPI, DefaultAPIImplementation}
 import beam.sim.config.{BeamConfig, BeamConfigHolder, MatSimBeamConfigBuilder}
-import beam.sim.{BeamHelper, BeamScenario, BeamServices, BeamServicesImpl, RunBeam}
+import beam.sim._
 import com.google.inject.Injector
 import org.matsim.core.api.experimental.events.EventsManager
 import org.matsim.core.config.Config
@@ -16,6 +13,8 @@ import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting
 import org.matsim.core.events.EventsManagerImpl
 import org.matsim.core.scenario.MutableScenario
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+
+import java.io.File
 
 trait SimRunnerForTest extends BeamHelper with BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
   def config: com.typesafe.config.Config

--- a/src/test/scala/beam/utils/SimRunnerForTest.scala
+++ b/src/test/scala/beam/utils/SimRunnerForTest.scala
@@ -42,6 +42,7 @@ trait SimRunnerForTest extends BeamHelper with BeforeAndAfterAll with BeforeAndA
         List.empty[ComplexEventBuilder]
       )
     )
+    beamScenario.privateVehicles.foreach(_._2.resetState())
   }
 
   override protected def beforeAll(): Unit = {


### PR DESCRIPTION
This issue happens because the test "let everybody take drive_transit when their plan says so" leaves some electric vehicles plugged into the charging station, then these vehicles are in an unexpected state when the next test "let everybody drive when their plan says so" starts.

Running ``beamScenario.privateVehicles.foreach(_._2.resetState())`` right at the begining of the aforementioned second test fixes the issue. I will be adding this code to SimRunnerForTest.beforeEach() and comparing the CI output before and after the change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3676)
<!-- Reviewable:end -->
