### PR TITLE
fix null linkid lookup when writing bad lookups

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -112,7 +112,7 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
       writer.write("linkId,count")
       writer.write(System.lineSeparator())
       failedLinkLookups.toList.groupBy(identity).mapValues(_.size).foreach { case (linkId, count) =>
-        writer.write(Option(linkId).map(_.toString).getOrElse(""))
+        writer.write(Option(linkId).mkString)
         writer.write(",")
         writer.write(count.toString)
         writer.write(System.lineSeparator())

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -112,7 +112,7 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
       writer.write("linkId,count")
       writer.write(System.lineSeparator())
       failedLinkLookups.toList.groupBy(identity).mapValues(_.size).foreach { case (linkId, count) =>
-        writer.write(linkId.toString)
+        writer.write(Option(linkId).map(_.toString).getOrElse(""))
         writer.write(",")
         writer.write(count.toString)
         writer.write(System.lineSeparator())


### PR DESCRIPTION
Fixes null pointer exception that sometimes shows up when we write links outside of the zone boundaries when we provide BEAM a shapefile to use for mapping links to TAZs. Sometimes a point isn't successfully mapped to a link at all

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3688)
<!-- Reviewable:end -->
