### PR TITLE
Don't fail if we're missing a vehicle's fuel type

### DIFF
--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -119,7 +119,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
       updatedLeg.travelPath.distanceInM,
       updatedLeg.duration,
       vehicleType,
-      fuelTypePrices(vehicleType.primaryFuelType)
+      fuelTypePrices.getOrElse(vehicleType.primaryFuelType, 0.0)
     )
     val totalCost = drivingCost + (if (updatedLeg.mode == BeamMode.CAR) toll else 0)
 


### PR DESCRIPTION
I was running into an error in the second iteration when an agent has a bike trip in their plan memory, which happens when the R5Wrapper is trying to look up the fuel cost for "food" and it isn't in the input table. I think it's safe to assume that if the fuel cost of a certain type of fuel isn't defined we can just use 0 by default

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3689)
<!-- Reviewable:end -->
