### PR TITLE
Improvements to previous run plan merging

### DIFF
--- a/src/main/scala/beam/sim/BeamHelper.scala
+++ b/src/main/scala/beam/sim/BeamHelper.scala
@@ -862,6 +862,7 @@ trait BeamHelper extends LazyLogging with BeamValidationHelper {
             val merger = new PreviousRunPlanMerger(
               beamConfig.beam.agentsim.agents.plans.merge.fraction,
               beamConfig.beam.agentsim.agentSampleSizeAsFractionOfPopulation,
+              Some(beamConfig.beam.replanning.maxAgentPlanMemorySize),
               Paths.get(beamConfig.beam.input.lastBaseOutputDir),
               beamConfig.beam.input.simulationPrefix,
               new Random(),

--- a/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
+++ b/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
@@ -100,13 +100,6 @@ object PreviousRunPlanMerger extends LazyLogging {
           }
       }
     }
-
-    //    val unselectedPlanElements =
-//      oldToBeReplaced.groupBy(plan => (plan.personId, plan.planIndex)).flatMap { case (_, elems) =>
-//        elems.toList.sortBy(_.planScore).take(maximumNumberOfPlansToKeep.getOrElse(0)).map { case elem =>
-//          elem.copy(planIndex = elem.planIndex + 1, planSelected = false)
-//        }
-//      }
     oldElements ++ unselectedPlanElements ++ elementsFromExistingPersonsToAdd ++ elementsFromNewPersonsToAdd
   }
 }

--- a/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
+++ b/src/main/scala/beam/utils/scenario/PreviousRunPlanMerger.scala
@@ -15,6 +15,7 @@ import scala.util.{Random, Try}
 class PreviousRunPlanMerger(
   fractionOfNewPlansToUpdate: Double,
   sampleFraction: Double,
+  maximumNumberOfPlansToKeep: Option[Int],
   outputDir: Path,
   dirPrefix: String,
   rnd: Random,
@@ -36,7 +37,14 @@ class PreviousRunPlanMerger(
           XmlPlanElementReader.read(planPath.toString)
         }
         val convertedPlans = previousPlans.map(adjustForScenario)
-        PreviousRunPlanMerger.merge(convertedPlans, plans, fractionOfNewPlansToUpdate, sampleFraction, rnd) -> true
+        PreviousRunPlanMerger.merge(
+          convertedPlans,
+          plans,
+          fractionOfNewPlansToUpdate,
+          sampleFraction,
+          maximumNumberOfPlansToKeep,
+          rnd
+        ) -> true
       case None =>
         logger.warn(
           "Not found appropriate output plans in the beam output directory: {}, dirPrefix = {}",
@@ -55,6 +63,7 @@ object PreviousRunPlanMerger extends LazyLogging {
     plansToMerge: Iterable[PlanElement],
     fractionOfPlansToUpdate: Double,
     populationSample: Double,
+    maximumNumberOfPlansToKeep: Option[Int],
     random: Random
   ): Iterable[PlanElement] = {
     val persons = plans.map(_.personId).toSet
@@ -72,10 +81,32 @@ object PreviousRunPlanMerger extends LazyLogging {
     )
     val shouldReplace = (plan: PlanElement) => personIdsToReplace.contains(plan.personId)
     val (oldToBeReplaced, oldElements) = plans.partition(shouldReplace)
-    val elementsFromExistingPersonsToAdd = plansToMerge.filter(shouldReplace)
+    val elementsFromExistingPersonsToAdd =
+      plansToMerge.filter(shouldReplace).map(_.copy(planSelected = true, planIndex = 0))
     val shouldAdd = (plan: PlanElement) => personIdsToAdd.contains(plan.personId)
-    val elementsFromNewPersonsToAdd = plansToMerge.filter(shouldAdd)
-    val unselectedPlanElements = oldToBeReplaced.map(_.copy(planSelected = false))
+    val elementsFromNewPersonsToAdd = plansToMerge.filter(shouldAdd).map(_.copy(planSelected = true, planIndex = 0))
+    val unselectedPlanElements = {
+      oldToBeReplaced.groupBy(_.personId).flatMap { case (_, elements) =>
+        elements
+          .groupBy(_.planIndex)
+          .toList
+          .sortBy { case (_, elements) => -elements.head.planScore }
+          .zipWithIndex
+          .take(maximumNumberOfPlansToKeep.getOrElse(0))
+          .flatMap { case ((_, elems), idx) =>
+            elems.map { case elem =>
+              elem.copy(planIndex = idx + 1, planSelected = false)
+            }
+          }
+      }
+    }
+
+    //    val unselectedPlanElements =
+//      oldToBeReplaced.groupBy(plan => (plan.personId, plan.planIndex)).flatMap { case (_, elems) =>
+//        elems.toList.sortBy(_.planScore).take(maximumNumberOfPlansToKeep.getOrElse(0)).map { case elem =>
+//          elem.copy(planIndex = elem.planIndex + 1, planSelected = false)
+//        }
+//      }
     oldElements ++ unselectedPlanElements ++ elementsFromExistingPersonsToAdd ++ elementsFromNewPersonsToAdd
   }
 }

--- a/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
+++ b/src/main/scala/beam/utils/scenario/UrbanSimScenarioLoader.scala
@@ -561,15 +561,23 @@ class UrbanSimScenarioLoader(
       val (plan, state) = if (currentPlanSize == 0) {
         val newState = State(planInfo.planIndex, planInfo.planSelected)
         val plan = PopulationUtils.createPlan(person)
+        plan.setScore(planInfo.planScore)
         store += (planInfo.personId -> Vector(newState))
         person.addPlan(plan)
+        if (planInfo.planSelected) {
+          person.setSelectedPlan(plan)
+        }
         plan -> newState
       } else {
         val lookingFor = State(planInfo.planIndex, planInfo.planSelected)
         val states = store(planInfo.personId)
         val index = states.zipWithIndex.find(_._1 == lookingFor).map(_._2).getOrElse {
           // couldn't find in store, create new plan
-          person.addPlan(PopulationUtils.createPlan(person))
+          val newPlan = PopulationUtils.createPlan(person)
+          person.addPlan(newPlan)
+          if (planInfo.planSelected) {
+            person.setSelectedPlan(newPlan)
+          }
           store += (planInfo.personId -> (states :+ lookingFor))
           currentPlanSize
         }
@@ -593,11 +601,10 @@ class UrbanSimScenarioLoader(
               val leg = PopulationUtils.createLeg(mode)
               leg.getAttributes.putAttribute("trip_id", tripId)
               plan.addLeg(leg)
-              plan.getAttributes.putAttribute("trip_id", tripId)
             case None =>
               val leg = PopulationUtils.createLeg("")
               leg.getAttributes.putAttribute("trip_id", tripId)
-              plan.getAttributes.putAttribute("trip_id", tripId)
+              plan.addLeg(leg)
           }
         } else if (planElement == PlanElement.Activity) {
           assert(

--- a/src/test/scala/beam/utils/scenario/PreviousRunPlanMergerTest.scala
+++ b/src/test/scala/beam/utils/scenario/PreviousRunPlanMergerTest.scala
@@ -16,12 +16,12 @@ class PreviousRunPlanMergerTest extends AnyWordSpecLike with Matchers {
 
     "should throw error when fraction is not within range [0, 1]" in {
       assertThrows[IllegalArgumentException] {
-        new PreviousRunPlanMerger(-1, 1, outputPath, "", new Random(), identity)
+        new PreviousRunPlanMerger(-1, 1, Some(5), outputPath, "", new Random(), identity)
       }
     }
 
     "should return same plans when fraction = 0" in {
-      val planMerger = new PreviousRunPlanMerger(0, 1, outputPath, "", new Random(), identity)
+      val planMerger = new PreviousRunPlanMerger(0, 1, Some(5), outputPath, "", new Random(), identity)
 
       val (res, actuallyMerged) = planMerger.merge(newPlans)
 
@@ -33,146 +33,229 @@ class PreviousRunPlanMergerTest extends AnyWordSpecLike with Matchers {
   "PreviousRunPlanMerger with fraction >= 0" should {
 
     "should return same plans when fraction = 0" in {
-      val res = PreviousRunPlanMerger.merge(oldPlans, newPlans, 0, 0, new Random())
-
-      res should be(oldPlans)
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, newPlans, 0, 0, Some(5), new Random())
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+      val oldPlansSorted = oldPlans.toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+      res should be(oldPlansSorted)
     }
 
     "should return same plans when activity sim plans empty" in {
 
-      val res = PreviousRunPlanMerger.merge(oldPlans, Seq(), 0.5, 0, new Random())
-
-      res should be(oldPlans)
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, Seq(), 0.5, 0, Some(5), new Random())
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+      val oldPlansSorted = oldPlans.toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+      res should be(oldPlansSorted)
     }
 
     "should return half of plans merged and all new plans when fraction = 0.5 and sample = 1" in {
-      val res = PreviousRunPlanMerger.merge(oldPlans, newPlans, 0.5, 1.0, new Random(1))
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, newPlans, 0.5, 1.0, Some(5), new Random(1))
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
 
       res.toSet.count(oldPlans.contains) should be(5)
       res.toSet.count(newPlans.contains) should be(12)
 
       res should be(
         Seq(
-          createPlanElement("7", 0, 49501),
-          createPlanElement("7", 1, 49502), //old as unique
-          createPlanElement("2", 0, 49503),
-          createPlanElement("2", 1, 49504), //old
-          createPlanElement("6", 2, 49508), //old as unique
-          createPlanElement("0", 0, 49499, planSelected = false),
-          createPlanElement("0", 1, 49500, planSelected = false),
-          createPlanElement("3", 0, 49505, planSelected = false),
-          createPlanElement("3", 1, 49506, planSelected = false),
-          createPlanElement("3", 2, 49507, planSelected = false),
-          createPlanElement("4", 2, 49508, planSelected = false),
-          createPlanElement("0", 0, 49509),
-          createPlanElement("0", 1, 49510),
-          createPlanElement("0", 2, 49511), //new merged
-          createPlanElement("3", 0, 49513),
-          createPlanElement("3", 1, 49514), //new merged
-          createPlanElement("4", 0, 49515),
-          createPlanElement("4", 1, 49516),
-          createPlanElement("4", 2, 49517), //new merged
-          createPlanElement("5", 0, 49518), //new added
-          createPlanElement("8", 0, 49515), //new added
-          createPlanElement("8", 1, 49516), //new added
-          createPlanElement("8", 2, 49517) //new added
-        )
+          createPlanElement("7", 0, 0, 49501),
+          createPlanElement("7", 0, 1, 49502), //old as unique
+          createPlanElement("6", 0, 0, 49508), //old as unique
+          createPlanElement("0", 1, 0, 49499, planSelected = false),
+          createPlanElement("0", 1, 1, 49500, planSelected = false),
+          createPlanElement("2", 0, 0, 49503), // kept because not selected
+          createPlanElement("2", 0, 1, 49504),
+          createPlanElement("3", 1, 0, 49509, score = 50, planSelected = false),
+          createPlanElement("3", 1, 1, 49510, score = 50, planSelected = false),
+          createPlanElement("3", 1, 2, 49511, score = 50, planSelected = false),
+          createPlanElement("3", 2, 0, 49505, planSelected = false),
+          createPlanElement("3", 2, 1, 49506, planSelected = false),
+          createPlanElement("3", 2, 2, 49507, planSelected = false),
+          createPlanElement("4", 1, 0, 49508, planSelected = false),
+          createPlanElement("0", 0, 0, 49509),
+          createPlanElement("0", 0, 1, 49510),
+          createPlanElement("0", 0, 2, 49511), //new merged
+          //          createPlanElement("2", 0, 0, 49512), //new merged but not selected
+          createPlanElement("3", 0, 0, 49513),
+          createPlanElement("3", 0, 1, 49514), //new merged
+          createPlanElement("4", 0, 0, 49515),
+          createPlanElement("4", 0, 1, 49516),
+          createPlanElement("4", 0, 2, 49517), //new merged
+          createPlanElement("5", 0, 0, 49518), //new added
+          createPlanElement("8", 0, 0, 49515), //new added
+          createPlanElement("8", 0, 1, 49516), //new added
+          createPlanElement("8", 0, 2, 49517) //new added
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
       )
     }
 
     "should return half of plans merged and half of new plans when fraction = 0.5 and sample = 0.5" in {
-      val res = PreviousRunPlanMerger.merge(oldPlans, newPlans, 0.5, 0.5, new Random(1))
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, newPlans, 0.5, 0.5, Some(5), new Random(1))
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
 
       res.toSet.count(oldPlans.contains) should be(5)
       res.toSet.count(newPlans.contains) should be(9)
 
       res should be(
         Seq(
-          createPlanElement("7", 0, 49501),
-          createPlanElement("7", 1, 49502), //old as unique
-          createPlanElement("2", 0, 49503),
-          createPlanElement("2", 1, 49504), //old
-          createPlanElement("6", 2, 49508), //old as unique
-          createPlanElement("0", 0, 49499, planSelected = false),
-          createPlanElement("0", 1, 49500, planSelected = false),
-          createPlanElement("3", 0, 49505, planSelected = false),
-          createPlanElement("3", 1, 49506, planSelected = false),
-          createPlanElement("3", 2, 49507, planSelected = false),
-          createPlanElement("4", 2, 49508, planSelected = false),
-          createPlanElement("0", 0, 49509),
-          createPlanElement("0", 1, 49510),
-          createPlanElement("0", 2, 49511), //new merged
-          createPlanElement("3", 0, 49513),
-          createPlanElement("3", 1, 49514), //new merged
-          createPlanElement("4", 0, 49515),
-          createPlanElement("4", 1, 49516),
-          createPlanElement("4", 2, 49517), //new merged
-          createPlanElement("5", 0, 49518) //new added
-        )
+          createPlanElement("7", 0, 0, 49501),
+          createPlanElement("7", 0, 1, 49502), //old as unique
+          createPlanElement("6", 0, 0, 49508), //old as unique
+          createPlanElement("0", 1, 0, 49499, planSelected = false),
+          createPlanElement("0", 1, 1, 49500, planSelected = false),
+          createPlanElement("2", 0, 0, 49503), // kept because not selected
+          createPlanElement("2", 0, 1, 49504),
+          createPlanElement("3", 1, 0, 49509, score = 50, planSelected = false),
+          createPlanElement("3", 1, 1, 49510, score = 50, planSelected = false),
+          createPlanElement("3", 1, 2, 49511, score = 50, planSelected = false),
+          createPlanElement("3", 2, 0, 49505, planSelected = false),
+          createPlanElement("3", 2, 1, 49506, planSelected = false),
+          createPlanElement("3", 2, 2, 49507, planSelected = false),
+          createPlanElement("4", 1, 0, 49508, planSelected = false),
+          createPlanElement("0", 0, 0, 49509),
+          createPlanElement("0", 0, 1, 49510),
+          createPlanElement("0", 0, 2, 49511), //new merged
+//          createPlanElement("2", 0, 0, 49512), //new merged but not selected
+          createPlanElement("3", 0, 0, 49513),
+          createPlanElement("3", 0, 1, 49514), //new merged
+          createPlanElement("4", 0, 0, 49515),
+          createPlanElement("4", 0, 1, 49516),
+          createPlanElement("4", 0, 2, 49517), //new merged
+          createPlanElement("5", 0, 0, 49518) //new added
+//          createPlanElement("8", 0, 0, 49515), //new added
+//          createPlanElement("8", 0, 1, 49516), //new added
+//          createPlanElement("8", 0, 2, 49517) //new added
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
       )
 
     }
 
     "should return all plans merged and all new persons when fraction = 1.0" in {
-      val res = PreviousRunPlanMerger.merge(oldPlans, newPlans, 1.0, 1.0, new Random(1))
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, newPlans, 1.0, 1.0, Some(5), new Random(1))
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
 
       res.toSet.count(oldPlans.contains) should be(3)
       res.toSet.count(newPlans.contains) should be(13)
 
       res should be(
         Seq(
-          createPlanElement("7", 0, 49501),
-          createPlanElement("7", 1, 49502), //old as unique
-          createPlanElement("6", 2, 49508), //old as unique
-          createPlanElement("0", 0, 49499, planSelected = false),
-          createPlanElement("0", 1, 49500, planSelected = false),
-          createPlanElement("2", 0, 49503, planSelected = false),
-          createPlanElement("2", 1, 49504, planSelected = false),
-          createPlanElement("3", 0, 49505, planSelected = false),
-          createPlanElement("3", 1, 49506, planSelected = false),
-          createPlanElement("3", 2, 49507, planSelected = false),
-          createPlanElement("4", 2, 49508, planSelected = false),
-          createPlanElement("0", 0, 49509),
-          createPlanElement("0", 1, 49510),
-          createPlanElement("0", 2, 49511), //new merged
-          createPlanElement("2", 0, 49512), //new merged
-          createPlanElement("3", 0, 49513),
-          createPlanElement("3", 1, 49514), //new merged
-          createPlanElement("4", 0, 49515),
-          createPlanElement("4", 1, 49516),
-          createPlanElement("4", 2, 49517), //new merged
-          createPlanElement("5", 0, 49518), //new added
-          createPlanElement("8", 0, 49515), //new added
-          createPlanElement("8", 1, 49516), //new added
-          createPlanElement("8", 2, 49517) //new added
-        )
+          createPlanElement("7", 0, 0, 49501),
+          createPlanElement("7", 0, 1, 49502), //old as unique
+          createPlanElement("6", 0, 0, 49508), //old as unique
+          createPlanElement("0", 1, 0, 49499, planSelected = false),
+          createPlanElement("0", 1, 1, 49500, planSelected = false),
+          createPlanElement("2", 1, 0, 49503, planSelected = false),
+          createPlanElement("2", 1, 1, 49504, planSelected = false),
+          createPlanElement("3", 1, 0, 49509, score = 50, planSelected = false),
+          createPlanElement("3", 1, 1, 49510, score = 50, planSelected = false),
+          createPlanElement("3", 1, 2, 49511, score = 50, planSelected = false),
+          createPlanElement("3", 2, 0, 49505, planSelected = false),
+          createPlanElement("3", 2, 1, 49506, planSelected = false),
+          createPlanElement("3", 2, 2, 49507, planSelected = false),
+          createPlanElement("4", 1, 0, 49508, planSelected = false),
+          createPlanElement("0", 0, 0, 49509),
+          createPlanElement("0", 0, 1, 49510),
+          createPlanElement("0", 0, 2, 49511), //new merged
+          createPlanElement("2", 0, 0, 49512), //new merged
+          createPlanElement("3", 0, 0, 49513),
+          createPlanElement("3", 0, 1, 49514), //new merged
+          createPlanElement("4", 0, 0, 49515),
+          createPlanElement("4", 0, 1, 49516),
+          createPlanElement("4", 0, 2, 49517), //new merged
+          createPlanElement("5", 0, 0, 49518), //new added
+          createPlanElement("8", 0, 0, 49515), //new added
+          createPlanElement("8", 0, 1, 49516), //new added
+          createPlanElement("8", 0, 2, 49517) //new added
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
       )
     }
+
+    "should trim low score plans when fraction = 1.0 and maximum plan memory size is 1" in {
+      val res = PreviousRunPlanMerger
+        .merge(oldPlans, newPlans, 1.0, 1.0, Some(1), new Random(1))
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+
+      res.toSet.count(oldPlans.contains) should be(3)
+      res.toSet.count(newPlans.contains) should be(13)
+
+      res should be(
+        Seq(
+          createPlanElement("7", 0, 0, 49501),
+          createPlanElement("7", 0, 1, 49502), //old as unique
+          createPlanElement("6", 0, 0, 49508), //old as unique
+          createPlanElement("0", 1, 0, 49499, planSelected = false),
+          createPlanElement("0", 1, 1, 49500, planSelected = false),
+          createPlanElement("2", 1, 0, 49503, planSelected = false),
+          createPlanElement("2", 1, 1, 49504, planSelected = false),
+//          createPlanElement("3", 1, 0, 49505, planSelected = false), // Trimmed
+//          createPlanElement("3", 1, 1, 49506, planSelected = false),
+//          createPlanElement("3", 1, 2, 49507, planSelected = false),
+          createPlanElement("3", 1, 0, 49509, score = 50, planSelected = false),
+          createPlanElement("3", 1, 1, 49510, score = 50, planSelected = false),
+          createPlanElement("3", 1, 2, 49511, score = 50, planSelected = false),
+          createPlanElement("4", 1, 0, 49508, planSelected = false),
+          createPlanElement("0", 0, 0, 49509),
+          createPlanElement("0", 0, 1, 49510),
+          createPlanElement("0", 0, 2, 49511), //new merged
+          createPlanElement("2", 0, 0, 49512), //new merged
+          createPlanElement("3", 0, 0, 49513),
+          createPlanElement("3", 0, 1, 49514), //new merged
+          createPlanElement("4", 0, 0, 49515),
+          createPlanElement("4", 0, 1, 49516),
+          createPlanElement("4", 0, 2, 49517), //new merged
+          createPlanElement("5", 0, 0, 49518), //new added
+          createPlanElement("8", 0, 0, 49515), //new added
+          createPlanElement("8", 0, 1, 49516), //new added
+          createPlanElement("8", 0, 2, 49517) //new added
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
+      )
+    }
+
   }
 
   "PreviousRunPlanMerger with valid inputs" should {
     "must read previous xml plans without error" in {
-      val planMerger = new PreviousRunPlanMerger(1.0, 0.0, outputPath, "beamville", new Random(), identity)
-      val activitySimPlans = getOldPlans //to avoid naming mess
+      val planMerger = new PreviousRunPlanMerger(1.0, 0.0, Some(5), outputPath, "beamville", new Random(), identity)
+      val activitySimPlans = {
+        getOldPlans.filter(_.planSelected).map { case plan => plan.copy(planIndex = 0) } //to avoid naming mess
+        // Assumption here is that activitysim plans always are selected and have planIndex = 0
+      }
 
       val (mergedPlans, merged) = planMerger.merge(activitySimPlans)
 
       merged should be(true)
-      mergedPlans.filter { activitySimPlans.contains }.toList should be(
+      mergedPlans
+        .filter { activitySimPlans.contains }
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex)) should be(
         Seq(
-          createPlanElement("7", 0, 49501),
-          createPlanElement("7", 1, 49502),
-          createPlanElement("2", 0, 49503),
-          createPlanElement("2", 1, 49504),
-          createPlanElement("3", 0, 49505),
-          createPlanElement("3", 1, 49506),
-          createPlanElement("3", 2, 49507),
-          createPlanElement("4", 2, 49508),
-          createPlanElement("6", 2, 49508)
-        )
+//          createPlanElement("0", 0, 0, 49499), // This agent doesn't exist in the merged plans and sampleFraction = 0 so we don't take him
+//          createPlanElement("0", 0, 1, 49500),
+          createPlanElement("7", 0, 0, 49501),
+          createPlanElement("7", 0, 1, 49502),
+          createPlanElement("2", 0, 0, 49503),
+          createPlanElement("2", 0, 1, 49504),
+          createPlanElement("3", 0, 0, 49509, score = 50),
+          createPlanElement("3", 0, 1, 49510, score = 50),
+          createPlanElement("3", 0, 2, 49511, score = 50),
+          createPlanElement("4", 0, 0, 49508),
+          createPlanElement("6", 0, 0, 49508)
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
       )
 
-      mergedPlans.filter(_.personId.id == "1").toList should be(
+      mergedPlans
+        .filter(_.personId.id == "1")
+        .toList
+        .sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex)) should be(
         Seq(
           createActivityPlanElement("Home", 166321.9, 1568.87, 49500.0, "1", 0, -494.58068848294334),
           createLegPlanElement("walk", "1", 1, -494.58068848294334),
@@ -183,59 +266,64 @@ class PreviousRunPlanMergerTest extends AnyWordSpecLike with Matchers {
           createActivityPlanElement("Shopping", 166045.2, 2705.4, 71006.0, "1", 6, -494.58068848294334),
           createLegPlanElement("car", "1", 7, -494.58068848294334),
           createActivityPlanElement("Home", 166321.9, 1568.87, Double.NegativeInfinity, "1", 8, -494.58068848294334)
-        )
+        ).toList.sortBy(p => (p.personId.id.toInt, p.planIndex, p.planElementIndex))
       )
     }
   }
 
   def getOldPlans: Seq[PlanElement] = {
     Seq(
-      createPlanElement("0", 0, 49499),
-      createPlanElement("0", 1, 49500),
-      createPlanElement("7", 0, 49501),
-      createPlanElement("7", 1, 49502),
-      createPlanElement("2", 0, 49503),
-      createPlanElement("2", 1, 49504),
-      createPlanElement("3", 0, 49505),
-      createPlanElement("3", 1, 49506),
-      createPlanElement("3", 2, 49507),
-      createPlanElement("4", 2, 49508),
-      createPlanElement("6", 2, 49508)
+      createPlanElement("0", 0, 0, 49499),
+      createPlanElement("0", 0, 1, 49500),
+      createPlanElement("7", 0, 0, 49501),
+      createPlanElement("7", 0, 1, 49502),
+      createPlanElement("2", 0, 0, 49503),
+      createPlanElement("2", 0, 1, 49504),
+      createPlanElement("3", 0, 0, 49505, score = 0, planSelected = false),
+      createPlanElement("3", 0, 1, 49506, score = 0, planSelected = false),
+      createPlanElement("3", 0, 2, 49507, score = 0, planSelected = false),
+      createPlanElement("3", 1, 0, 49509, score = 50, planSelected = true),
+      createPlanElement("3", 1, 1, 49510, score = 50, planSelected = true),
+      createPlanElement("3", 1, 2, 49511, score = 50, planSelected = true),
+      createPlanElement("4", 0, 0, 49508),
+      createPlanElement("6", 0, 0, 49508)
     )
   }
 
   def getNewPlans: Seq[PlanElement] = {
     Seq(
-      createPlanElement("0", 0, 49509),
-      createPlanElement("0", 1, 49510),
-      createPlanElement("0", 2, 49511),
-      createPlanElement("2", 0, 49512),
-      createPlanElement("3", 0, 49513),
-      createPlanElement("3", 1, 49514),
-      createPlanElement("4", 0, 49515),
-      createPlanElement("4", 1, 49516),
-      createPlanElement("4", 2, 49517),
-      createPlanElement("5", 0, 49518),
-      createPlanElement("8", 0, 49515),
-      createPlanElement("8", 1, 49516),
-      createPlanElement("8", 2, 49517)
+      createPlanElement("0", 0, 0, 49509),
+      createPlanElement("0", 0, 1, 49510),
+      createPlanElement("0", 0, 2, 49511),
+      createPlanElement("2", 0, 0, 49512),
+      createPlanElement("3", 0, 0, 49513),
+      createPlanElement("3", 0, 1, 49514),
+      createPlanElement("4", 0, 0, 49515),
+      createPlanElement("4", 0, 1, 49516),
+      createPlanElement("4", 0, 2, 49517),
+      createPlanElement("5", 0, 0, 49518),
+      createPlanElement("8", 0, 0, 49515),
+      createPlanElement("8", 0, 1, 49516),
+      createPlanElement("8", 0, 2, 49517)
     )
   }
 
   def createPlanElement(
     personId: String,
     planIndex: Int,
+    planElementIndex: Int,
     activityEndTime: Double,
-    planSelected: Boolean = true
+    planSelected: Boolean = true,
+    score: Double = 0.0
   ): PlanElement = {
     PlanElement(
       "",
       PersonId(personId),
       planIndex,
-      1,
+      score,
       planSelected = planSelected,
       PlanElement.Activity,
-      0,
+      planElementIndex,
       Some("a"),
       Some(1),
       Some(1),


### PR DESCRIPTION
There was some weirdness in PILATES runs where agents are choosing the wrong plans from their memory of past plans, plus there was no limit on how many plans could be remembered and it was growing unwieldy

This PR makes some changes to the loading of plans, including making sure the planIndex field is correct and dropping the lowest scoring plan once the library reaches its maximum size. The test is also updated to document this change.

Currently a draft while it's being tested in a PILATES run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3690)
<!-- Reviewable:end -->
