### PR TITLE
Fixed Memory Leak that caused keeping EventsManagerImpl for the whole run

### DIFF
--- a/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
+++ b/src/main/java/beam/physsim/jdeqsim/AgentSimToPhysSimPlanConverter.java
@@ -96,8 +96,6 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
     private final Random rand = MatsimRandom.getRandom();
     private final boolean agentSimPhysSimInterfaceDebuggerEnabled;
 
-    private final List<CompletableFuture> completableFutures = new ArrayList<>();
-
     final Map<String, Boolean> caccVehiclesMap = new TreeMap<>();
     private final Map<Integer, Mean> binSpeed = new HashMap<>();
 
@@ -276,6 +274,7 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
 
         router.tell(new BeamRouter.UpdateTravelTimeLocal(travelTimeForR5), ActorRef.noSender());
 
+        List<CompletableFuture<Void>> completableFutures = new ArrayList<>();
         completableFutures.add(CompletableFuture.runAsync(() -> linkSpeedStatsGraph.notifyIterationEnds(iterationNumber, travelTimeFromPhysSim)));
 
         completableFutures.add(CompletableFuture.runAsync(() -> linkSpeedDistributionStatsGraph.notifyIterationEnds(iterationNumber, travelTimeFromPhysSim)));
@@ -332,7 +331,7 @@ public class AgentSimToPhysSimPlanConverter implements BasicEventHandler, Metric
     private void writePhyssimPlans(IterationEndsEvent event) {
         if (shouldWritePlans(event.getIteration())) {
             final String plansFilename = controlerIO.getIterationFilename(event.getIteration(), "physsimPlans.xml.gz");
-            completableFutures.add(CompletableFuture.runAsync(() -> new PopulationWriter(jdeqsimPopulation).write(plansFilename)));
+            CompletableFuture.runAsync(() -> new PopulationWriter(jdeqsimPopulation).write(plansFilename));
         }
     }
 

--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -803,6 +803,8 @@ beam.debug {
   secondsToWaitToClearRoutedOutstandingWork = 60
 
   vmInformation.createGCClassHistogram = "boolean | false"
+  # it implies vmInformation.createGCClassHistogram = true
+  vmInformation.writeHeapDump = "boolean | false"
   writeModeChoiceAlternatives = "boolean | false"
 
   writeRealizedModeChoiceFile = "boolean | false"

--- a/src/main/scala/beam/physsim/jdeqsim/JDEQSimRunner.scala
+++ b/src/main/scala/beam/physsim/jdeqsim/JDEQSimRunner.scala
@@ -84,9 +84,10 @@ class JDEQSimRunner(
 
     val maybeEventWriter = if (writeEvents) {
       val writer = PhysSimEventWriter(beamServices, jdeqsimEvents)
-      //adding this writer as a BEAM shutdown listener so that it could prevent BEAM from exiting
+      //adding the listener so that it could prevent BEAM from exiting
       //before the writer writes everything to disk.
-      beamServices.matsimServices.addControlerListener(writer)
+      //we cannot make the writer a shutdown listener because Matsim will keep it until the program end
+      beamServices.matsimServices.addControlerListener(writer.getShutdownListener)
       jdeqsimEvents.addHandler(writer)
       Some(writer)
     } else None
@@ -104,7 +105,11 @@ class JDEQSimRunner(
       }
 
     val simName = beamConfig.beam.physsim.name
-    jdeqsimEvents.initProcessing()
+    if (simName != "JDEQSim") {
+      // JDEQSim initializes the event manager itself. If we do it twice a memory leak is possible
+      // due to abandoning event processing threads, see org.matsim.core.events.ParallelEventsManagerImpl.initProcessing
+      jdeqsimEvents.initProcessing()
+    }
     try {
       ProfilingUtils.timed(
         s"PhysSim iteration $currentPhysSimIter for ${population.getPersons.size()} people",

--- a/src/main/scala/beam/sim/BeamMobsim.scala
+++ b/src/main/scala/beam/sim/BeamMobsim.scala
@@ -84,7 +84,7 @@ class BeamMobsim @Inject() (
   )
 
   override def run(): Unit = {
-    logger.info("Starting Iteration")
+    logger.info(s"Starting Iteration ${matsimServices.getIterationNumber}")
     startMeasuringIteration()
     logger.info("Preparing new Iteration (Start)")
     startMeasuring("iteration-preparation:mobsim")
@@ -192,7 +192,7 @@ class BeamMobsim @Inject() (
 
     Await.result(iteration ? "Run!", timeout.duration)
 
-    logger.info("Agentsim finished.")
+    logger.info(s"Agentsim finished. Iteration = ${matsimServices.getIterationNumber}.")
     eventsManager.finishProcessing()
     logger.info("Events drained.")
     stopMeasuring("agentsim-events:agentsim")

--- a/src/main/scala/beam/sim/BeamSim.scala
+++ b/src/main/scala/beam/sim/BeamSim.scala
@@ -152,9 +152,8 @@ class BeamSim @Inject() (
     beamServices.geo
   )
 
-  val vmInformationWriter: VMInformationCollector = new VMInformationCollector(
-    beamServices.matsimServices.getControlerIO
-  )
+  val vmInformationWriter: VMInformationCollector =
+    new VMInformationCollector(beamServices.beamConfig, beamServices.matsimServices.getControlerIO)
 
   val maybePickUpDropOffCollector =
     if (beamServices.beamConfig.beam.physsim.pickUpDropOffAnalysis.enabled) {
@@ -544,9 +543,7 @@ class BeamSim @Inject() (
 
       writeEventsAnalysisUsing(event)
     }
-    if (beamConfig.beam.debug.vmInformation.createGCClassHistogram) {
-      vmInformationWriter.notifyIterationEnds(event)
-    }
+    vmInformationWriter.notifyIterationEnds(event)
 
     beamServices.skims.parking_skimmer.displaySkimStats()
     beamServices.skims.od_skimmer.displaySkimStats()

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -2782,14 +2782,17 @@ object BeamConfig {
       }
 
       case class VmInformation(
-        createGCClassHistogram: scala.Boolean
+        createGCClassHistogram: scala.Boolean,
+        writeHeapDump: scala.Boolean
       )
 
       object VmInformation {
 
         def apply(c: com.typesafe.config.Config): BeamConfig.Beam.Debug.VmInformation = {
           BeamConfig.Beam.Debug.VmInformation(
-            createGCClassHistogram = c.hasPathOrNull("createGCClassHistogram") && c.getBoolean("createGCClassHistogram")
+            createGCClassHistogram =
+              c.hasPathOrNull("createGCClassHistogram") && c.getBoolean("createGCClassHistogram"),
+            writeHeapDump = c.hasPathOrNull("writeHeapDump") && c.getBoolean("writeHeapDump")
           )
         }
       }

--- a/src/main/scala/beam/utils/VMUtils.scala
+++ b/src/main/scala/beam/utils/VMUtils.scala
@@ -149,7 +149,6 @@ class VMUtils(val mbeanObjectName: ObjectName) {
   }
 
   def gcClassHistogram(takeTopClasses: Int): Seq[VMClassInfo] = {
-    gcRun()
     parseClassHistogram(invoke(JFRCommandWithoutArguments.GcClassHistogram), takeTopClasses)
   }
 

--- a/src/test/scala/beam/analysis/VMInformationCollectorTest.scala
+++ b/src/test/scala/beam/analysis/VMInformationCollectorTest.scala
@@ -35,7 +35,7 @@ class VMInformationCollectorTest extends AnyFlatSpec with Matchers {
     parts1.length shouldBe 5
     parts5.length shouldBe 5
 
-    val vmInfoWriter = new VMInformationCollector(null)
+    val vmInfoWriter = new VMInformationCollector(null, null)
 
     def check(map: mutable.Map[String, ListBuffer[Long]], numberOfRecords: Int, lengthOfIterationValues: Int): Unit = {
       map.size shouldBe numberOfRecords


### PR DESCRIPTION
1. Instead of adding `PhysSimEventWriter` which keeps a reference to the EventManager to the matsim controller listeners we add a small object that keeps a reference only to a terminated threadpool.
2. Do not init `PrallelEventManagerImpl` multiple times because it abandons blocked threads that are GC Roots. They keep their frames until the app exits.
3. Added a new parameter `vmInformation.writeHeapDump` in order to write a heap dump at each iteration so that we could debug memory leaks easier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lbnl-ucb-sti/beam/3703)
<!-- Reviewable:end -->
