### PR TITLE
RideHail name in OD skim

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -687,6 +687,7 @@ class PersonAgent(
       new RideHailReservationConfirmationEvent(
         tick,
         Id.createPersonId(id),
+        None,
         RideHailReservationConfirmationEvent.typeWhenPooledIs(response.request.asPooled),
         Some(error.errorCode),
         response.request.requestTime.getOrElse(response.request.departAt),
@@ -699,6 +700,7 @@ class PersonAgent(
         response.directTripTravelProposal.map(proposal =>
           proposal.travelTimeForCustomer(bodyVehiclePersonId) + proposal.timeToCustomer(bodyVehiclePersonId)
         ),
+        None,
         response.request.withWheelchair
       )
     )
@@ -781,6 +783,7 @@ class PersonAgent(
         new RideHailReservationConfirmationEvent(
           tick,
           Id.createPersonId(id),
+          travelProposal.map(_.rideHailAgentLocation.vehicleId),
           RideHailReservationConfirmationEvent.typeWhenPooledIs(req.asPooled),
           None,
           req.requestTime.getOrElse(req.departAt),
@@ -793,6 +796,7 @@ class PersonAgent(
           ),
           directTripTravelProposal.map(_.travelDistanceForCustomer(bodyVehiclePersonId)),
           directTripTravelProposal.map(_.travelTimeForCustomer(bodyVehiclePersonId)),
+          travelProposal.map(_.estimatedPrice(req.customer.personId)),
           req.withWheelchair
         )
       )

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -1429,6 +1429,7 @@ trait ChoosesMode {
     val skim: ODSkimmer.Skim = ODSkims.getSkimDefaultValue(
       beamServices.beamConfig,
       mode,
+      "",
       originLocation,
       destinationLocation,
       beamScenario.vehicleTypes(dummyRHVehicle.vehicleTypeId),

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -373,7 +373,7 @@ trait ChoosesMode {
           requester = self,
           rideHailServiceSubscription = attributes.rideHailServiceSubscription,
           triggerId = getCurrentTriggerIdOrGenerate,
-          asPooled = true
+          asPooled = !choosesModeData.personData.currentTourMode.contains(RIDE_HAIL)
         )
         //        println(s"requesting: ${inquiry.requestId}")
         rideHailManager ! inquiry

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -635,6 +635,7 @@ class RideHailManager(
                 request,
                 singleOccupantQuoteAndPoolingInfo.rideHailAgentLocation.vehicleType.id,
                 driverPassengerSchedule,
+                isPooledTrip = false,
                 baseFare
               )
             ),
@@ -1188,12 +1189,13 @@ class RideHailManager(
     request: RideHailRequest,
     rideHailVehicleTypeId: Id[BeamVehicleType],
     trip: PassengerSchedule,
+    isPooledTrip: Boolean,
     additionalCost: Double
   ): (Id[Person], Double) = {
     var costPerSecond = 0.0
     var costPerMile = 0.0
     var baseCost = 0.0
-    if (trip.isPooledTrip) {
+    if (isPooledTrip) {
       costPerSecond = pooledCostPerSecond
       costPerMile = pooledCostPerMile
       baseCost = pooledBaseCost
@@ -1760,7 +1762,15 @@ class RideHailManager(
       alloc.rideHailAgentLocation,
       updatedPassengerSchedule,
       alloc.request.thisRequestWithGroupedRequests
-        .map(calcFare(_, alloc.rideHailAgentLocation.vehicleType.id, updatedPassengerSchedule, baseFare))
+        .map(request =>
+          calcFare(
+            request,
+            alloc.rideHailAgentLocation.vehicleType.id,
+            updatedPassengerSchedule,
+            isPooledTrip = request.asPooled,
+            baseFare
+          )
+        )
         .toMap,
       rideHailResourceAllocationManager.maxWaitTimeInSec,
       None

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -112,7 +112,7 @@ object RideHailManager {
             asDriver = false,
             estimatedPrice(passenger.personId),
             unbecomeDriverOnCompletion = false,
-            isPooledTrip = passengerSchedule.schedule.values.exists(_.riders.size > 1)
+            isPooledTrip = passengerSchedule.isPooledTrip
           )
         }
         .toVector
@@ -1193,8 +1193,7 @@ class RideHailManager(
     var costPerSecond = 0.0
     var costPerMile = 0.0
     var baseCost = 0.0
-    val pooled = trip.schedule.values.exists(_.riders.size > 1)
-    if (pooled) {
+    if (trip.isPooledTrip) {
       costPerSecond = pooledCostPerSecond
       costPerMile = pooledCostPerMile
       baseCost = pooledBaseCost

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -1193,7 +1193,8 @@ class RideHailManager(
     var costPerSecond = 0.0
     var costPerMile = 0.0
     var baseCost = 0.0
-    if (request.asPooled) {
+    val pooled = trip.schedule.values.exists(_.riders.size > 1)
+    if (pooled) {
       costPerSecond = pooledCostPerSecond
       costPerMile = pooledCostPerMile
       baseCost = pooledBaseCost

--- a/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/allocation/PoolingAlonsoMora.scala
@@ -39,6 +39,7 @@ class PoolingAlonsoMora(val rideHailManager: RideHailManager)
           inquiry.pickUpLocationUTM,
           inquiry.destinationUTM,
           inquiry.departAt,
+          rideHailManager.managerConfig.name,
           rideHailManager.beamServices
         )
         SingleOccupantQuoteAndPoolingInfo(

--- a/src/main/scala/beam/agentsim/agents/vehicles/PassengerSchedule.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/PassengerSchedule.scala
@@ -63,6 +63,8 @@ case class PassengerSchedule(schedule: TreeMap[BeamLeg, Manifest]) {
     new PassengerSchedule(newSchedule)
   }
 
+  def isPooledTrip: Boolean = schedule.values.exists(_.riders.size > 1)
+
   def uniquePassengers: Set[PersonIdWithActorRef] = schedule.values.flatMap(_.riders).toSet
 
   def passengersWhoNeverBoard: Set[PersonIdWithActorRef] = {

--- a/src/main/scala/beam/agentsim/events/RideHailReservationConfirmationEvent.scala
+++ b/src/main/scala/beam/agentsim/events/RideHailReservationConfirmationEvent.scala
@@ -6,10 +6,12 @@ import beam.agentsim.events.resources.ReservationErrorCode
 import org.matsim.api.core.v01.events.Event
 import org.matsim.api.core.v01.population.Person
 import org.matsim.api.core.v01.{Coord, Id}
+import org.matsim.vehicles.Vehicle
 
 object RideHailReservationConfirmationEvent {
   val EVENT_TYPE: String = "RideHailReservationConfirmation"
   val ATTRIBUTE_PERSON = "person"
+  val ATTRIBUTE_VEHICLE = "vehicle"
   val ATTRIBUTE_RESERVATION_TYPE: String = "reservationType"
   val ATTRIBUTE_RESERVATION_ERROR_CODE: String = "errorCode"
   val ATTRIBUTE_RESERVATION_TIME: String = "reservationTime"
@@ -22,6 +24,7 @@ object RideHailReservationConfirmationEvent {
   val ATTRIBUTE_OFFERED_PICKUP_TIME: String = "offeredPickupTime"
   val ATTRIBUTE_DIRECT_ROUTE_DISTANCE: String = "directRouteDistanceInM"
   val ATTRIBUTE_DIRECT_ROUTE_TIME: String = "directRouteDurationInS"
+  val ATTRIBUTE_ESTIMATED_PRICE: String = "cost"
   val ATTRIBUTE_WHEELCHAIR_REQUIREMENT: String = "wheelchairRequirement"
 
   def typeWhenPooledIs(isPooled: Boolean): RideHailReservationType = {
@@ -42,6 +45,7 @@ object RideHailReservationConfirmationEvent {
 class RideHailReservationConfirmationEvent(
   val time: Double,
   val personId: Id[Person],
+  val vehicleId: Option[Id[Vehicle]],
   val reservationType: RideHailReservationType,
   val reservationErrorCodeOpt: Option[ReservationErrorCode],
   val reservationTime: Int,
@@ -55,6 +59,7 @@ class RideHailReservationConfirmationEvent(
   val offeredPickUpTimeOpt: Option[Int], /*  None if the reservation failed */
   val directRouteDistanceInMOpt: Option[Double],
   val directRouteDurationInSOpt: Option[Int],
+  val estimatedPrice: Option[Double],
   val wheelchairRequirement: Boolean
 ) extends Event(time)
     with ScalaEvent {
@@ -66,6 +71,7 @@ class RideHailReservationConfirmationEvent(
     val attributes = super.getAttributes
     attributes.put(ATTRIBUTE_RESERVATION_TYPE, reservationType.toString)
     attributes.put(ATTRIBUTE_PERSON, personId.toString)
+    attributes.put(ATTRIBUTE_VEHICLE, vehicleId.map(_.toString).getOrElse(""))
     attributes.put(ATTRIBUTE_RESERVATION_ERROR_CODE, reservationErrorCodeOpt.map(_.toString).getOrElse(""))
     attributes.put(ATTRIBUTE_RESERVATION_TIME, reservationTime.toString)
     attributes.put(ATTRIBUTE_REQUESTED_PICKUP_TIME, requestedPickUpTime.toString)
@@ -77,6 +83,7 @@ class RideHailReservationConfirmationEvent(
     attributes.put(ATTRIBUTE_OFFERED_PICKUP_TIME, offeredPickUpTimeOpt.map(_.toString).getOrElse(""))
     attributes.put(ATTRIBUTE_DIRECT_ROUTE_DISTANCE, directRouteDistanceInMOpt.map(_.toString).getOrElse(""))
     attributes.put(ATTRIBUTE_DIRECT_ROUTE_TIME, directRouteDurationInSOpt.map(_.toString).getOrElse(""))
+    attributes.put(ATTRIBUTE_ESTIMATED_PRICE, estimatedPrice.map(_.toString).getOrElse(""))
     attributes.put(ATTRIBUTE_WHEELCHAIR_REQUIREMENT, wheelchairRequirement.toString)
     attributes
   }

--- a/src/main/scala/beam/router/Modes.scala
+++ b/src/main/scala/beam/router/Modes.scala
@@ -33,7 +33,7 @@ object Modes {
 
     def isTransit: Boolean = isR5TransitMode(this)
     def isMassTransit: Boolean = this == SUBWAY || this == RAIL || this == FERRY || this == TRAM
-    def isRideHail: Boolean = this == RIDE_HAIL
+    def isRideHail: Boolean = this == RIDE_HAIL || this == RIDE_HAIL_POOLED
     def isTeleportation: Boolean = this == HOV2_TELEPORTATION || this == HOV3_TELEPORTATION
   }
 

--- a/src/main/scala/beam/router/model/EmbodiedBeamTrip.scala
+++ b/src/main/scala/beam/router/model/EmbodiedBeamTrip.scala
@@ -63,7 +63,6 @@ case class EmbodiedBeamTrip(legs: IndexedSeq[EmbodiedBeamLeg], router: Option[St
     val personalLegs = legs.takeWhile(leg =>
       !leg.beamLeg.mode.isTransit
       && !leg.beamLeg.mode.isRideHail
-      && leg.beamLeg.mode != RIDE_HAIL_POOLED
       && leg.beamLeg.mode != CAV
     )
     val updatedLegs = personalLegs.map { leg =>

--- a/src/main/scala/beam/router/skim/ActivitySimSkimmerEvent.scala
+++ b/src/main/scala/beam/router/skim/ActivitySimSkimmerEvent.scala
@@ -5,7 +5,6 @@ import beam.router.model.EmbodiedBeamTrip
 import beam.router.skim.ActivitySimPathType.{toBeamMode, toKeyMode}
 import beam.router.skim.ActivitySimSkimmer.{ActivitySimSkimmerInternal, ActivitySimSkimmerKey}
 import beam.router.skim.core.{AbstractSkimmerEvent, AbstractSkimmerInternal, AbstractSkimmerKey}
-import beam.router.skim.event.ODSkimmerEvent
 import com.typesafe.scalalogging.LazyLogging
 
 case class ActivitySimSkimmerEvent(

--- a/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/AbstractSkimmer.scala
@@ -93,7 +93,7 @@ abstract class AbstractSkimmer(beamConfig: BeamConfig, ioController: OutputDirec
   protected val skimFileHeader: String
   protected val skimName: String
   protected val skimType: SkimType.Value
-  private lazy val eventType = skimName + "-event"
+  protected lazy val eventType: String = skimName + "-event"
 
   private val awaitSkimLoading = 20.minutes
   private val skimCfg = beamConfig.beam.router.skim

--- a/src/main/scala/beam/router/skim/core/ODSkimmer.scala
+++ b/src/main/scala/beam/router/skim/core/ODSkimmer.scala
@@ -263,6 +263,7 @@ class ODSkimmer @Inject() (matsimServices: MatsimServices, beamScenario: BeamSce
                 .asInstanceOf[ODSkims]
                 .getSkimDefaultValue(
                   mode,
+                  rideHailName,
                   origin.center,
                   destCoord,
                   vehicleType,
@@ -272,7 +273,7 @@ class ODSkimmer @Inject() (matsimServices: MatsimServices, beamScenario: BeamSce
 
         //     "hour,mode,origTaz,destTaz,travelTimeInS,generalizedTimeInS,cost,generalizedCost,distanceInM,energy,level4CavTravelTimeScalingFactor,observations,iterations"
         writer.write(
-          s"$timeBin,$mode,${origin.id},${destination.id},${theSkim.time},${theSkim.generalizedTime},${theSkim.cost},${theSkim.generalizedCost},${theSkim.distance},${theSkim.payloadWeight},${theSkim.energy},${theSkim.level4CavTravelTimeScalingFactor},${theSkim.failedTrips},${theSkim.count}\n"
+          s"$timeBin,$mode,$rideHailName,${origin.id},${destination.id},${theSkim.time},${theSkim.generalizedTime},${theSkim.cost},${theSkim.generalizedCost},${theSkim.distance},${theSkim.payloadWeight},${theSkim.energy},${theSkim.level4CavTravelTimeScalingFactor},${theSkim.failedTrips},${theSkim.count},${theSkim}\n"
         )
       }
   }
@@ -338,6 +339,7 @@ class ODSkimmer @Inject() (matsimServices: MatsimServices, beamScenario: BeamSce
             .asInstanceOf[ODSkims]
             .getSkimDefaultValue(
               mode,
+              "",
               origin.coord,
               adjustedDestCoord,
               beamScenario.vehicleTypes(dummyId),

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -32,11 +32,13 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
 
   def getSkimDefaultValue(
     mode: BeamMode,
+    rideHailName: String,
     originUTM: Location,
     destinationUTM: Location,
     beamVehicleType: BeamVehicleType,
     fuelPrice: Double
-  ): Skim = ODSkims.getSkimDefaultValue(beamConfig, mode, originUTM, destinationUTM, beamVehicleType, fuelPrice)
+  ): Skim =
+    ODSkims.getSkimDefaultValue(beamConfig, mode, rideHailName, originUTM, destinationUTM, beamVehicleType, fuelPrice)
 
   def getRideHailPoolingTimeAndCostRatios(
     origin: Location,
@@ -59,7 +61,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
           generalizedTimeInS = 0,
           generalizedCost = 0,
           distanceInM = travelDistance.toDouble,
-          cost = getRideHailCost(RIDE_HAIL, travelDistance, travelTime, beamConfig),
+          cost = getRideHailCost(RIDE_HAIL, travelDistance, travelTime, rideHailName, beamConfig),
           payloadWeightInKg = 0.0,
           energy = 0.0,
           level4CavTravelTimeScalingFactor = 1.0,
@@ -83,6 +85,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
             RIDE_HAIL_POOLED,
             solo.distanceInM,
             solo.travelTimeInS * poolingTravelTimeOveheadFactor,
+            rideHailName,
             beamConfig
           ),
           payloadWeightInKg = 0.0,
@@ -131,6 +134,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
       case None =>
         getSkimDefaultValue(
           mode,
+          "",
           originUTM,
           new Coord(destinationUTM.getX, destinationUTM.getY),
           vehicleType,
@@ -166,6 +170,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
 
           getSkimDefaultValue(
             mode,
+            "",
             origin.coord,
             adjustedDestCoord,
             vehicleType,
@@ -247,6 +252,7 @@ object ODSkims extends BeamHelper {
   def getSkimDefaultValue(
     beamConfig: BeamConfig,
     mode: BeamMode,
+    rideHailName: String,
     originUTM: Location,
     destinationUTM: Location,
     beamVehicleType: BeamVehicleType,
@@ -266,7 +272,7 @@ object ODSkims extends BeamHelper {
           fuelPrice
         )
       case RIDE_HAIL | RIDE_HAIL_POOLED =>
-        SkimsUtils.getRideHailCost(mode, travelDistance, travelTime, beamConfig)
+        SkimsUtils.getRideHailCost(mode, travelDistance, travelTime, rideHailName, beamConfig)
       case TRANSIT | WALK_TRANSIT | DRIVE_TRANSIT | RIDE_HAIL_TRANSIT | BIKE_TRANSIT => 0.25 * travelDistance / 1609
       case _                                                                         => 0.0
     }

--- a/src/main/scala/beam/router/skim/readonly/ODSkims.scala
+++ b/src/main/scala/beam/router/skim/readonly/ODSkims.scala
@@ -42,13 +42,14 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
     origin: Location,
     destination: Location,
     departureTime: Int,
+    rideHailName: String,
     beamServices: BeamServices
   ): (Double, Double) = {
     val tazTreeMap = beamServices.beamScenario.tazTreeMap
     val beamConfig = beamServices.beamConfig
     val origTaz = tazTreeMap.getTAZ(origin.getX, origin.getY).tazId
     val destTaz = tazTreeMap.getTAZ(destination.getX, destination.getY).tazId
-    val solo = getSkimValue(departureTime, RIDE_HAIL, origTaz, destTaz) match {
+    val solo = getSkimValue(departureTime, RIDE_HAIL, rideHailName, origTaz, destTaz) match {
       case Some(skimValue) if skimValue.observations > 5 =>
         skimValue
       case _ =>
@@ -67,7 +68,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
           iterations = beamServices.matsimServices.getIterationNumber
         )
     }
-    val pooled = getSkimValue(departureTime, RIDE_HAIL_POOLED, origTaz, destTaz) match {
+    val pooled = getSkimValue(departureTime, RIDE_HAIL_POOLED, rideHailName, origTaz, destTaz) match {
       case Some(skimValue) if skimValue.observations > 5 =>
         skimValue
       case _ =>
@@ -118,7 +119,8 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
     val destTaz = maybeDestTazForPerformanceImprovement.getOrElse(
       beamScenario.tazTreeMap.getTAZ(destinationUTM.getX, destinationUTM.getY).tazId
     )
-    getSkimValue(departureTime, mode, origTaz, destTaz) match {
+
+    getSkimValue(departureTime, mode, "", origTaz, destTaz) match {
       case Some(skimValue) =>
         beamScenario.vehicleTypes.get(vehicleTypeId) match {
           case Some(vehicleType) if vehicleType.automationLevel == 4 =>
@@ -148,7 +150,7 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
   ): ExcerptData = {
     val individualSkims = hoursIncluded.map { timeBin =>
       skim
-        .get(ODSkimmerKey(timeBin, mode, origin.tazId.toString, destination.tazId.toString))
+        .get(ODSkimmerKey(timeBin, mode, "", origin.tazId.toString, destination.tazId.toString))
         .map(_.toSkimExternal)
         .getOrElse {
           val adjustedDestCoord = if (origin.equals(destination)) {
@@ -215,11 +217,19 @@ class ODSkims(beamConfig: BeamConfig, beamScenario: BeamScenario) extends Abstra
     )
   }
 
-  private def getSkimValue(time: Int, mode: BeamMode, orig: Id[TAZ], dest: Id[TAZ]): Option[ODSkimmerInternal] = {
+  private def getSkimValue(
+    time: Int,
+    mode: BeamMode,
+    rideHailName: String,
+    orig: Id[TAZ],
+    dest: Id[TAZ]
+  ): Option[ODSkimmerInternal] = {
     val getSkimValue = pastSkims
       .get(currentIteration - 1)
-      .flatMap(_.get(ODSkimmerKey(timeToBin(time), mode, orig.toString, dest.toString)))
-      .orElse(aggregatedFromPastSkims.get(ODSkimmerKey(timeToBin(time), mode, orig.toString, dest.toString)))
+      .flatMap(_.get(ODSkimmerKey(timeToBin(time), mode, rideHailName, orig.toString, dest.toString)))
+      .orElse(
+        aggregatedFromPastSkims.get(ODSkimmerKey(timeToBin(time), mode, rideHailName, orig.toString, dest.toString))
+      )
       .asInstanceOf[Option[ODSkimmerInternal]]
 
     if (getSkimValue.nonEmpty) {

--- a/src/main/scala/beam/router/skim/urbansim/BackgroundSkimsCreator.scala
+++ b/src/main/scala/beam/router/skim/urbansim/BackgroundSkimsCreator.scala
@@ -264,7 +264,7 @@ object BackgroundSkimsCreator {
             .map(taz => GeoUnit.TAZ(taz.tazId.toString, taz.coord, taz.areaInSquareMeters))
             .toSeq
 
-          writeFullSkims(origins, origins, uniqueTimeBins, filePath)
+          writeFullSkims(origins, origins, uniqueTimeBins, Seq(""), filePath)
           logger.info(s"Written UrbanSim peak skims for hours $hours to $filePath")
         }
       }
@@ -289,7 +289,7 @@ object BackgroundSkimsCreator {
             GeoUnit.H3(h3Index.index.value, utmCenter, areaInSquareMeters)
           }
 
-          writeFullSkims(origins, origins, uniqueTimeBins, filePath)
+          writeFullSkims(origins, origins, uniqueTimeBins, Seq(""), filePath)
           logger.info(s"Written UrbanSim peak skims for hours $hours to $filePath")
         }
       }

--- a/src/main/scala/scripts/BackgroundSkimsCreatorApp.scala
+++ b/src/main/scala/scripts/BackgroundSkimsCreatorApp.scala
@@ -307,7 +307,7 @@ object BackgroundSkimsCreatorApp extends App with BeamHelper {
 
             rows.foreach { case ODRow(origin, destination) =>
               BeamMode.allModes.foreach { beamMode =>
-                writeSkimRow(writer, uniqueTimeBins, origin, destination, beamMode)
+                writeSkimRow(writer, uniqueTimeBins, origin, destination, beamMode, "")
               }
             }
           } catch {

--- a/src/test/scala/beam/router/skim/SkimmerSpec.scala
+++ b/src/test/scala/beam/router/skim/SkimmerSpec.scala
@@ -278,7 +278,7 @@ object SkimmerSpec extends LazyLogging {
         energy = Option(row("energy")).map(_.toDouble).getOrElse(0.0),
         level4CavTravelTimeScalingFactor =
           Option(row("level4CavTravelTimeScalingFactor")).map(_.toDouble).getOrElse(1.0),
-        failedTrips = 0,
+        failedTrips = row.get("failedTrips").map(_.toDouble).getOrElse(0.0),
         observations = row("observations").toInt,
         iterations = row("iterations").toInt
       )

--- a/src/test/scala/beam/router/skim/SkimmerSpec.scala
+++ b/src/test/scala/beam/router/skim/SkimmerSpec.scala
@@ -102,7 +102,10 @@ class SkimmerSpec extends AnyFlatSpec with Matchers with BeamHelper {
       s"${SkimType.OD_SKIMMER}: the written skim has a different size from memory"
     )
     odSkimsFromMem.foreach { case (key, value) =>
-      assume(value == odSkimsFromDisk(key), s"${SkimType.OD_SKIMMER}: the written skim is different from memory")
+      assume(
+        value == odSkimsFromDisk(key),
+        s"${SkimType.OD_SKIMMER}: the written skim is different from memory for key $key"
+      )
     }
   }
 
@@ -261,6 +264,7 @@ object SkimmerSpec extends LazyLogging {
       ODSkimmerKey(
         hour = row("hour").toInt,
         mode = BeamMode.fromString(row("mode").toLowerCase()).get,
+        rideHailName = Option(row.getOrElse("rideHailName", "")).getOrElse(""),
         origin = row("origTaz"),
         destination = row("destTaz")
       ),

--- a/src/test/scala/beam/sflight/BeamIncentiveSpec.scala
+++ b/src/test/scala/beam/sflight/BeamIncentiveSpec.scala
@@ -115,6 +115,7 @@ object BeamIncentiveSpec {
     allHourAvg.sum
   }
 
-  def isRideHail(value: String): Boolean = value.startsWith(BeamMode.RIDE_HAIL.value + ",")
+  def isRideHail(value: String): Boolean = rideHailLineStart.exists(value.startsWith)
 
+  private val rideHailLineStart = List(BeamMode.RIDE_HAIL, BeamMode.RIDE_HAIL_POOLED).map(_.value + ",")
 }

--- a/src/test/scala/beam/sim/RideHailUsageTests.scala
+++ b/src/test/scala/beam/sim/RideHailUsageTests.scala
@@ -96,7 +96,7 @@ class RideHailUsageTests extends AnyFlatSpec with Matchers with BeamHelper with 
       .getOrDefault(
         ModeChoiceEvent.ATTRIBUTE_MODE,
         ""
-      ) shouldBe "ride_hail" withClue ", expected RH usage after replanning"
+      ) should startWith("ride_hail") withClue ", expected RH usage after replanning"
   }
 
   it should "Use RH_BEV to transfer agents." in {


### PR DESCRIPTION
Changes in ODSkims
1. Differentiate RIDE_HAIL and RIDE_HAIL_POOLED modes by ridehail name.
2. Empty ridehail name ("") in skims means generic (all fleets) value
3. This data is also written to skim csv files.
4. skimsODExcerpt.csv contains only generic ridehail data
5. Background skim generator generates only generic skim data