### PR TITLE
Hl/jl/restrict road access by freespeed

### DIFF
--- a/src/main/resources/beam-template.conf
+++ b/src/main/resources/beam-template.conf
@@ -210,6 +210,7 @@ beam.agentsim.agents.rideHail.managers = [{
   initialization.procedural.fractionOfInitialVehicleFleet = "double | 0.1"
   initialization.procedural.initialLocation.name = "HOME"
   initialization.procedural.initialLocation.home.radiusInMeters = "double | 10000"
+  initialization.procedural.vehicleAdjustmentMethod = ""
   rideHailManager.radiusInMeters = "double | 5000"
   allocationManager.maxWaitingTimeInSec = "int | 900"
   allocationManager.maxExcessRideTime = "double | 0.5" # up to +50%
@@ -467,6 +468,7 @@ beam.agentsim.agents.rideHail.surgePricing.surgeLevelAdaptionStep = "double | 0.
 beam.agentsim.agents.rideHail.surgePricing.minimumSurgeLevel = "double | 0.1"
 beam.agentsim.agents.rideHail.surgePricing.priceAdjustmentStrategy = "KEEP_PRICE_LEVEL_FIXED_AT_ONE"
 beam.agentsim.agents.rideHail.surgePricing.numberOfCategories = "int | 6"
+beam.agentsim.agents.rideHail.freeSpeedLinkWeightMultiplier = "double | 2.0"
 # Scaling and Tuning Params
 beam.agentsim.tuning.fuelCapacityInJoules = "double | 86400000"
 beam.agentsim.tuning.transitCapacity = "Double?"

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -314,7 +314,6 @@ class RideHailManager(
       this
     )
 
-
   private val defaultBaseCost = managerConfig.defaultBaseCost
   private val defaultCostPerMile = managerConfig.defaultCostPerMile
   private val defaultCostPerMinute = managerConfig.defaultCostPerMinute

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailManager.scala
@@ -314,6 +314,7 @@ class RideHailManager(
       this
     )
 
+
   private val defaultBaseCost = managerConfig.defaultBaseCost
   private val defaultCostPerMile = managerConfig.defaultCostPerMile
   private val defaultCostPerMinute = managerConfig.defaultCostPerMinute

--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
@@ -30,7 +30,8 @@ case class BeamVehicleType(
   sampleProbabilityString: Option[String] = None,
   chargingCapability: Option[ChargingPointType] = None,
   payloadCapacityInKg: Option[Double] = None,
-  wheelchairAccessible: Option[Boolean] = None
+  wheelchairAccessible: Option[Boolean] = None,
+  restrictRoadsByMaxVelocity: Option[Boolean] = None
 ) {
   def isSharedVehicle: Boolean = id.toString.startsWith("sharedVehicle")
 
@@ -40,6 +41,12 @@ case class BeamVehicleType(
 
   def isWheelchairAccessible: Boolean = {
     wheelchairAccessible.getOrElse(true)
+  }
+
+  def restrictRoadsByVelocity: Boolean = {
+    if (maxVelocity.getOrElse(0.0)>0.0){restrictRoadsByMaxVelocity.getOrElse(false)}
+    else false
+
   }
 
   def getTotalRange: Double = {

--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
@@ -31,7 +31,7 @@ case class BeamVehicleType(
   chargingCapability: Option[ChargingPointType] = None,
   payloadCapacityInKg: Option[Double] = None,
   wheelchairAccessible: Option[Boolean] = None,
-  restrictRoadsByMaxVelocity: Option[Boolean] = None
+  restrictRoadsByFreeSpeedInMeterPerSecond: Option[Double] = None
 ) {
   def isSharedVehicle: Boolean = id.toString.startsWith("sharedVehicle")
 
@@ -41,12 +41,6 @@ case class BeamVehicleType(
 
   def isWheelchairAccessible: Boolean = {
     wheelchairAccessible.getOrElse(true)
-  }
-
-  def restrictRoadsByVelocity: Boolean = {
-    if (maxVelocity.getOrElse(0.0)>0.0){restrictRoadsByMaxVelocity.getOrElse(false)}
-    else false
-
   }
 
   def getTotalRange: Double = {

--- a/src/main/scala/beam/sim/RideHailFleetInitializer.scala
+++ b/src/main/scala/beam/sim/RideHailFleetInitializer.scala
@@ -616,7 +616,7 @@ class ProceduralRideHailFleetInitializer(
         }
     }
 
-    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(beamScenario, managerConfig.initialization.procedural.vehicleTypeId)
+    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(beamScenario, managerConfig.initialization.procedural.vehicleAdjustmentMethod, Option(managerConfig.initialization.procedural.vehicleTypeId))
 
     val rideHailAgentInitializers: ArrayBuffer[RideHailFleetInitializer.RideHailAgentInitializer] = new ArrayBuffer()
     var idx = 0

--- a/src/main/scala/beam/sim/RideHailFleetInitializer.scala
+++ b/src/main/scala/beam/sim/RideHailFleetInitializer.scala
@@ -616,7 +616,11 @@ class ProceduralRideHailFleetInitializer(
         }
     }
 
-    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(beamScenario, managerConfig.initialization.procedural.vehicleAdjustmentMethod, Option(managerConfig.initialization.procedural.vehicleTypeId))
+    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(
+      beamScenario,
+      managerConfig.initialization.procedural.vehicleAdjustmentMethod,
+      Option(managerConfig.initialization.procedural.vehicleTypeId)
+    )
 
     val rideHailAgentInitializers: ArrayBuffer[RideHailFleetInitializer.RideHailAgentInitializer] = new ArrayBuffer()
     var idx = 0

--- a/src/main/scala/beam/sim/RideHailFleetInitializer.scala
+++ b/src/main/scala/beam/sim/RideHailFleetInitializer.scala
@@ -616,7 +616,7 @@ class ProceduralRideHailFleetInitializer(
         }
     }
 
-    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(beamScenario)
+    val vehiclesAdjustment = VehiclesAdjustment.getVehicleAdjustment(beamScenario, managerConfig.initialization.procedural.vehicleTypeId)
 
     val rideHailAgentInitializers: ArrayBuffer[RideHailFleetInitializer.RideHailAgentInitializer] = new ArrayBuffer()
     var idx = 0

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -967,13 +967,13 @@ object BeamConfig {
         case class RideHail(
           cav: BeamConfig.Beam.Agentsim.Agents.RideHail.Cav,
           charging: BeamConfig.Beam.Agentsim.Agents.RideHail.Charging,
+          freeSpeedLinkWeightMultiplier: scala.Double,
           human: BeamConfig.Beam.Agentsim.Agents.RideHail.Human,
           iterationStats: BeamConfig.Beam.Agentsim.Agents.RideHail.IterationStats,
           linkFleetStateAcrossIterations: scala.Boolean,
           managers: scala.List[BeamConfig.Beam.Agentsim.Agents.RideHail.Managers$Elm],
           rangeBufferForDispatchInMeters: scala.Int,
-          surgePricing: BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing,
-          maxVelocityLinkWeightMultiplier: scala.Double
+          surgePricing: BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing
         )
 
         object RideHail {
@@ -1256,9 +1256,9 @@ object BeamConfig {
               case class Procedural(
                 fractionOfInitialVehicleFleet: scala.Double,
                 initialLocation: BeamConfig.Beam.Agentsim.Agents.RideHail.Managers$Elm.Initialization.Procedural.InitialLocation,
+                vehicleAdjustmentMethod: java.lang.String,
                 vehicleTypeId: java.lang.String,
-                vehicleTypePrefix: java.lang.String,
-                vehicleAdjustmentMethod: java.lang.String
+                vehicleTypePrefix: java.lang.String
               )
 
               object Procedural {
@@ -1314,10 +1314,11 @@ object BeamConfig {
                         if (c.hasPathOrNull("initialLocation")) c.getConfig("initialLocation")
                         else com.typesafe.config.ConfigFactory.parseString("initialLocation{}")
                       ),
+                    vehicleAdjustmentMethod =
+                      if (c.hasPathOrNull("vehicleAdjustmentMethod")) c.getString("vehicleAdjustmentMethod") else "",
                     vehicleTypeId = if (c.hasPathOrNull("vehicleTypeId")) c.getString("vehicleTypeId") else "Car",
                     vehicleTypePrefix =
-                      if (c.hasPathOrNull("vehicleTypePrefix")) c.getString("vehicleTypePrefix") else "RH",
-                    vehicleAdjustmentMethod = if (c.hasPathOrNull("vehicleAdjustmentMethod")) c.getString("vehicleAdjustmentMethod") else ""
+                      if (c.hasPathOrNull("vehicleTypePrefix")) c.getString("vehicleTypePrefix") else "RH"
                   )
                 }
               }
@@ -1514,6 +1515,9 @@ object BeamConfig {
                 if (c.hasPathOrNull("charging")) c.getConfig("charging")
                 else com.typesafe.config.ConfigFactory.parseString("charging{}")
               ),
+              freeSpeedLinkWeightMultiplier =
+                if (c.hasPathOrNull("freeSpeedLinkWeightMultiplier")) c.getDouble("freeSpeedLinkWeightMultiplier")
+                else 2.0,
               human = BeamConfig.Beam.Agentsim.Agents.RideHail.Human(
                 if (c.hasPathOrNull("human")) c.getConfig("human")
                 else com.typesafe.config.ConfigFactory.parseString("human{}")
@@ -1531,10 +1535,7 @@ object BeamConfig {
               surgePricing = BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing(
                 if (c.hasPathOrNull("surgePricing")) c.getConfig("surgePricing")
                 else com.typesafe.config.ConfigFactory.parseString("surgePricing{}")
-              ),
-              maxVelocityLinkWeightMultiplier =
-                if (c.hasPathOrNull("maxVelocityLinkWeightMultiplier")) c.getDouble("maxVelocityLinkWeightMultiplier")
-                else 10.0
+              )
             )
           }
 

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -1257,7 +1257,8 @@ object BeamConfig {
                 fractionOfInitialVehicleFleet: scala.Double,
                 initialLocation: BeamConfig.Beam.Agentsim.Agents.RideHail.Managers$Elm.Initialization.Procedural.InitialLocation,
                 vehicleTypeId: java.lang.String,
-                vehicleTypePrefix: java.lang.String
+                vehicleTypePrefix: java.lang.String,
+                vehicleAdjustmentMethod: java.lang.String
               )
 
               object Procedural {
@@ -1315,7 +1316,8 @@ object BeamConfig {
                       ),
                     vehicleTypeId = if (c.hasPathOrNull("vehicleTypeId")) c.getString("vehicleTypeId") else "Car",
                     vehicleTypePrefix =
-                      if (c.hasPathOrNull("vehicleTypePrefix")) c.getString("vehicleTypePrefix") else "RH"
+                      if (c.hasPathOrNull("vehicleTypePrefix")) c.getString("vehicleTypePrefix") else "RH",
+                    vehicleAdjustmentMethod = if (c.hasPathOrNull("vehicleAdjustmentMethod")) c.getString("vehicleAdjustmentMethod") else ""
                   )
                 }
               }

--- a/src/main/scala/beam/sim/config/BeamConfig.scala
+++ b/src/main/scala/beam/sim/config/BeamConfig.scala
@@ -972,7 +972,8 @@ object BeamConfig {
           linkFleetStateAcrossIterations: scala.Boolean,
           managers: scala.List[BeamConfig.Beam.Agentsim.Agents.RideHail.Managers$Elm],
           rangeBufferForDispatchInMeters: scala.Int,
-          surgePricing: BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing
+          surgePricing: BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing,
+          maxVelocityLinkWeightMultiplier: scala.Double
         )
 
         object RideHail {
@@ -1528,7 +1529,10 @@ object BeamConfig {
               surgePricing = BeamConfig.Beam.Agentsim.Agents.RideHail.SurgePricing(
                 if (c.hasPathOrNull("surgePricing")) c.getConfig("surgePricing")
                 else com.typesafe.config.ConfigFactory.parseString("surgePricing{}")
-              )
+              ),
+              maxVelocityLinkWeightMultiplier =
+                if (c.hasPathOrNull("maxVelocityLinkWeightMultiplier")) c.getDouble("maxVelocityLinkWeightMultiplier")
+                else 10.0
             )
           }
 

--- a/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
@@ -7,9 +7,12 @@ import beam.sim.{BeamScenario, BeamServices}
 import org.apache.commons.math3.distribution.UniformRealDistribution
 import org.matsim.api.core.v01.{Coord, Id}
 
-case class SingleTypeVehiclesAdjustment(beamScenario: BeamScenario, vehicleType: String)
+case class SingleTypeVehiclesAdjustment(beamScenario: BeamScenario, vehicleType: Option[String])
   extends VehiclesAdjustment {
-  val vehicleId: Id[BeamVehicleType] = Id.create(vehicleType, classOf[BeamVehicleType])
+  val vehicleId: Id[BeamVehicleType] = vehicleType match {
+    case Some(vehType) => Id.create(vehType, classOf[BeamVehicleType])
+    case None => Id.create("Car", classOf[BeamVehicleType])
+  }
   val vehicleTypesByCategory: BeamVehicleType = beamScenario.vehicleTypes.values.find(vt => vt.id == vehicleId).get
 
   override def sampleVehicleTypes(numVehicles: Int,vehicleCategory: VehicleCategory,realDistribution: UniformRealDistribution): List[BeamVehicleType] = {

--- a/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
@@ -1,0 +1,32 @@
+package beam.sim.vehicles
+
+import beam.agentsim.agents.Population
+import beam.agentsim.agents.vehicles.{BeamVehicleType, VehicleCategory}
+import beam.agentsim.agents.vehicles.VehicleCategory.VehicleCategory
+import beam.sim.{BeamScenario, BeamServices}
+import org.apache.commons.math3.distribution.UniformRealDistribution
+import org.matsim.api.core.v01.{Coord, Id}
+
+case class SingleTypeVehiclesAdjustment(beamScenario: BeamScenario, vehicleType: String)
+  extends VehiclesAdjustment {
+  val vehicleId: Id[BeamVehicleType] = Id.create(vehicleType, classOf[BeamVehicleType])
+  val vehicleTypesByCategory: BeamVehicleType = beamScenario.vehicleTypes.values.find(vt => vt.id == vehicleId).get
+
+  override def sampleVehicleTypes(numVehicles: Int,vehicleCategory: VehicleCategory,realDistribution: UniformRealDistribution): List[BeamVehicleType] = {
+    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory) throw new NotImplementedError(vehicleCategory.toString)
+    List.fill(numVehicles)(vehicleTypesByCategory)
+  }
+
+  override def sampleVehicleTypesForHousehold(
+                                               numVehicles: Int,
+                                               vehicleCategory: VehicleCategory,
+                                               householdIncome: Double,
+                                               householdSize: Int,
+                                               householdPopulation: Population,
+                                               householdLocation: Coord,
+                                               realDistribution: UniformRealDistribution
+                                             ): List[BeamVehicleType] = {
+    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory) throw new NotImplementedError(vehicleCategory.toString)
+    List.fill(numVehicles)(vehicleTypesByCategory)
+  }
+}

--- a/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/SingleTypeVehiclesAdjustment.scala
@@ -8,28 +8,35 @@ import org.apache.commons.math3.distribution.UniformRealDistribution
 import org.matsim.api.core.v01.{Coord, Id}
 
 case class SingleTypeVehiclesAdjustment(beamScenario: BeamScenario, vehicleType: Option[String])
-  extends VehiclesAdjustment {
+    extends VehiclesAdjustment {
+
   val vehicleId: Id[BeamVehicleType] = vehicleType match {
     case Some(vehType) => Id.create(vehType, classOf[BeamVehicleType])
-    case None => Id.create("Car", classOf[BeamVehicleType])
+    case None          => Id.create("Car", classOf[BeamVehicleType])
   }
   val vehicleTypesByCategory: BeamVehicleType = beamScenario.vehicleTypes.values.find(vt => vt.id == vehicleId).get
 
-  override def sampleVehicleTypes(numVehicles: Int,vehicleCategory: VehicleCategory,realDistribution: UniformRealDistribution): List[BeamVehicleType] = {
-    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory) throw new NotImplementedError(vehicleCategory.toString)
+  override def sampleVehicleTypes(
+    numVehicles: Int,
+    vehicleCategory: VehicleCategory,
+    realDistribution: UniformRealDistribution
+  ): List[BeamVehicleType] = {
+    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory)
+      throw new NotImplementedError(vehicleCategory.toString)
     List.fill(numVehicles)(vehicleTypesByCategory)
   }
 
   override def sampleVehicleTypesForHousehold(
-                                               numVehicles: Int,
-                                               vehicleCategory: VehicleCategory,
-                                               householdIncome: Double,
-                                               householdSize: Int,
-                                               householdPopulation: Population,
-                                               householdLocation: Coord,
-                                               realDistribution: UniformRealDistribution
-                                             ): List[BeamVehicleType] = {
-    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory) throw new NotImplementedError(vehicleCategory.toString)
+    numVehicles: Int,
+    vehicleCategory: VehicleCategory,
+    householdIncome: Double,
+    householdSize: Int,
+    householdPopulation: Population,
+    householdLocation: Coord,
+    realDistribution: UniformRealDistribution
+  ): List[BeamVehicleType] = {
+    if (vehicleCategory != vehicleTypesByCategory.vehicleCategory)
+      throw new NotImplementedError(vehicleCategory.toString)
     List.fill(numVehicles)(vehicleTypesByCategory)
   }
 }

--- a/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
@@ -33,10 +33,14 @@ object VehiclesAdjustment {
   val INCOME_BASED_ADJUSTMENT = "INCOME_BASED"
   val SINGLE_TYPE = "SINGLE_TYPE"
 
-  def getVehicleAdjustment(beamScenario: BeamScenario, adjustmentType: String = "", vehicleType: Option[String] = None): VehiclesAdjustment = {
-    val adjustmentMethod = adjustmentType match{
+  def getVehicleAdjustment(
+    beamScenario: BeamScenario,
+    adjustmentType: String = "",
+    vehicleType: Option[String] = None
+  ): VehiclesAdjustment = {
+    val adjustmentMethod = adjustmentType match {
       case "" => beamScenario.beamConfig.beam.agentsim.agents.vehicles.vehicleAdjustmentMethod
-      case _ => adjustmentType
+      case _  => adjustmentType
     }
 
     adjustmentMethod match {

--- a/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
@@ -33,8 +33,13 @@ object VehiclesAdjustment {
   val INCOME_BASED_ADJUSTMENT = "INCOME_BASED"
   val SINGLE_TYPE = "SINGLE_TYPE"
 
-  def getVehicleAdjustment(beamScenario: BeamScenario, vehicleType: String): VehiclesAdjustment = {
-    beamScenario.beamConfig.beam.agentsim.agents.vehicles.vehicleAdjustmentMethod match {
+  def getVehicleAdjustment(beamScenario: BeamScenario, adjustmentType: String = "", vehicleType: Option[String] = None): VehiclesAdjustment = {
+    val adjustmentMethod = adjustmentType match{
+      case "" => beamScenario.beamConfig.beam.agentsim.agents.vehicles.vehicleAdjustmentMethod
+      case _ => adjustmentType
+    }
+
+    adjustmentMethod match {
       case UNIFORM_ADJUSTMENT      => UniformVehiclesAdjustment(beamScenario)
       case INCOME_BASED_ADJUSTMENT => IncomeBasedVehiclesAdjustment(beamScenario)
       case SINGLE_TYPE             => SingleTypeVehiclesAdjustment(beamScenario, vehicleType)

--- a/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
+++ b/src/main/scala/beam/sim/vehicles/VehiclesAdjustment.scala
@@ -31,11 +31,13 @@ trait VehiclesAdjustment extends ExponentialLazyLogging {
 object VehiclesAdjustment {
   val UNIFORM_ADJUSTMENT = "UNIFORM"
   val INCOME_BASED_ADJUSTMENT = "INCOME_BASED"
+  val SINGLE_TYPE = "SINGLE_TYPE"
 
-  def getVehicleAdjustment(beamScenario: BeamScenario): VehiclesAdjustment = {
+  def getVehicleAdjustment(beamScenario: BeamScenario, vehicleType: String): VehiclesAdjustment = {
     beamScenario.beamConfig.beam.agentsim.agents.vehicles.vehicleAdjustmentMethod match {
       case UNIFORM_ADJUSTMENT      => UniformVehiclesAdjustment(beamScenario)
       case INCOME_BASED_ADJUSTMENT => IncomeBasedVehiclesAdjustment(beamScenario)
+      case SINGLE_TYPE             => SingleTypeVehiclesAdjustment(beamScenario, vehicleType)
       case _                       => UniformVehiclesAdjustment(beamScenario)
     }
 

--- a/src/main/scala/beam/utils/BeamVehicleUtils.scala
+++ b/src/main/scala/beam/utils/BeamVehicleUtils.scala
@@ -91,7 +91,7 @@ object BeamVehicleUtils {
         val chargingCapability = Option(line.get("chargingCapability")).flatMap(ChargingPointType(_))
         val payloadCapacity = Option(line.get("payloadCapacityInKg")).map(_.toDouble)
         val wheelchairAccessible = Option(line.get("wheelchairAccessible")).map(_.toBoolean)
-        val restrictRoadsByMaxVelocity = Option(line.get("restrictRoadsByMaxVelocity")).map(_.toBoolean)
+        val restrictRoadsByFreeSpeed = Option(line.get("restrictRoadsByFreeSpeedInMeterPerSecond")).map(_.toDouble)
 
         val bvt = BeamVehicleType(
           vehicleTypeId,
@@ -119,7 +119,7 @@ object BeamVehicleUtils {
           chargingCapability,
           payloadCapacity,
           wheelchairAccessible,
-          restrictRoadsByMaxVelocity
+          restrictRoadsByFreeSpeed
         )
         z += ((vehicleTypeId, bvt))
     }.toMap

--- a/src/main/scala/beam/utils/BeamVehicleUtils.scala
+++ b/src/main/scala/beam/utils/BeamVehicleUtils.scala
@@ -91,6 +91,7 @@ object BeamVehicleUtils {
         val chargingCapability = Option(line.get("chargingCapability")).flatMap(ChargingPointType(_))
         val payloadCapacity = Option(line.get("payloadCapacityInKg")).map(_.toDouble)
         val wheelchairAccessible = Option(line.get("wheelchairAccessible")).map(_.toBoolean)
+        val restrictRoadsByMaxVelocity = Option(line.get("restrictRoadsByMaxVelocity")).map(_.toBoolean)
 
         val bvt = BeamVehicleType(
           vehicleTypeId,
@@ -117,7 +118,8 @@ object BeamVehicleUtils {
           sampleProbabilityString,
           chargingCapability,
           payloadCapacity,
-          wheelchairAccessible
+          wheelchairAccessible,
+          restrictRoadsByMaxVelocity
         )
         z += ((vehicleTypeId, bvt))
     }.toMap

--- a/test/input/sf-light/sf-light-road-constraints.conf
+++ b/test/input/sf-light/sf-light-road-constraints.conf
@@ -1,0 +1,16 @@
+include "sf-light.conf"
+
+beam.agentsim.simulationName = "sf-light-speed-constraints"
+
+beam.agentsim.firstIteration = 0
+beam.agentsim.lastIteration = 1
+beam.agentsim.agents.vehicles.vehicleTypesFilePath = ${beam.inputDirectory}"/vehicleTypes-with-road-restrictions.csv"
+
+
+beam.agentsim.agents.rideHail.freeSpeedLinkWeightMultiplier = 10000
+
+beam.physsim.flowCapacityFactor = 0.001
+beam.warmStart.type = "disabled"
+
+beam.router.skim.writeSkimsInterval = 1
+beam.router.skim.writeAggregatedSkimsInterval = 1

--- a/test/input/sf-light/vehicleTypes-with-road-restrictions.csv
+++ b/test/input/sf-light/vehicleTypes-with-road-restrictions.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0536ab63c42cdd41d7cc1b4d6cb5dcdf0e70b97ae2528d808ff5515b151255e3
+size 5158


### PR DESCRIPTION
Restricts ridehail vehicles from using links with freespeed above a defined speed limit using a link weight multiplier in r5Wrapper. Has been tested using urbansim-1k.