### PR TITLE
Link based parking sampling

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/ChargingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingFunctions.scala
@@ -7,7 +7,7 @@ import beam.agentsim.infrastructure.ParkingInquiry.ParkingSearchMode
 import beam.agentsim.infrastructure.charging.ChargingPointType
 import beam.agentsim.infrastructure.parking.ParkingZoneSearch.{ParkingAlternative, ParkingZoneSearchResult}
 import beam.agentsim.infrastructure.parking._
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.router.Modes.BeamMode
 import beam.router.skim.{Skims, SkimsUtils}
 import beam.sim.config.BeamConfig
@@ -16,31 +16,15 @@ import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.utils.collections.QuadTree
 
 class ChargingFunctions(
-  geoQuadTree: QuadTree[TAZ],
-  idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
-  parkingZones: Map[Id[ParkingZoneId], ParkingZone],
-  distanceFunction: (Coord, Coord) => Double,
-  parkingConfig: BeamConfig.Beam.Agentsim.Agents.Parking,
-  boundingBox: Envelope,
-  seed: Int,
-  skims: Option[Skims],
-  fuelPrice: Map[FuelType, Double]
-) extends ParkingFunctions(
-      geoQuadTree,
-      idToGeoMapping,
-      parkingZones,
-      distanceFunction,
-      parkingConfig.minSearchRadius,
-      parkingConfig.maxSearchRadius,
-      parkingConfig.searchMaxDistanceRelativeToEllipseFoci,
-      parkingConfig.estimatedMinParkingDurationInSeconds,
-      parkingConfig.estimatedMeanEnRouteChargingDurationInSeconds,
-      parkingConfig.fractionOfSameTypeZones,
-      parkingConfig.minNumberOfSameTypeZones,
-      boundingBox,
-      seed,
-      parkingConfig.multinomialLogit
-    ) {
+                         tazTreeMap: TAZTreeMap,
+                         parkingZones: Map[Id[ParkingZoneId], ParkingZone],
+                         distanceFunction: (Coord, Coord) => Double,
+                         parkingConfig: BeamConfig.Beam.Agentsim.Agents.Parking,
+                         boundingBox: Envelope,
+                         seed: Int,
+                         skims: Option[Skims],
+                         fuelPrice: Map[FuelType, Double]
+) extends ParkingFunctions(tazTreeMap, parkingZones, distanceFunction, parkingConfig.minSearchRadius, parkingConfig.maxSearchRadius, parkingConfig.searchMaxDistanceRelativeToEllipseFoci, parkingConfig.estimatedMinParkingDurationInSeconds, parkingConfig.estimatedMeanEnRouteChargingDurationInSeconds, parkingConfig.fractionOfSameTypeZones, parkingConfig.minNumberOfSameTypeZones, boundingBox, seed, parkingConfig.multinomialLogit) {
 
   /**
     * function that verifies if RideHail Then Fast Charging Only

--- a/src/main/scala/beam/agentsim/infrastructure/ChargingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingFunctions.scala
@@ -16,15 +16,29 @@ import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.utils.collections.QuadTree
 
 class ChargingFunctions(
-                         tazTreeMap: TAZTreeMap,
-                         parkingZones: Map[Id[ParkingZoneId], ParkingZone],
-                         distanceFunction: (Coord, Coord) => Double,
-                         parkingConfig: BeamConfig.Beam.Agentsim.Agents.Parking,
-                         boundingBox: Envelope,
-                         seed: Int,
-                         skims: Option[Skims],
-                         fuelPrice: Map[FuelType, Double]
-) extends ParkingFunctions(tazTreeMap, parkingZones, distanceFunction, parkingConfig.minSearchRadius, parkingConfig.maxSearchRadius, parkingConfig.searchMaxDistanceRelativeToEllipseFoci, parkingConfig.estimatedMinParkingDurationInSeconds, parkingConfig.estimatedMeanEnRouteChargingDurationInSeconds, parkingConfig.fractionOfSameTypeZones, parkingConfig.minNumberOfSameTypeZones, boundingBox, seed, parkingConfig.multinomialLogit) {
+  tazTreeMap: TAZTreeMap,
+  parkingZones: Map[Id[ParkingZoneId], ParkingZone],
+  distanceFunction: (Coord, Coord) => Double,
+  parkingConfig: BeamConfig.Beam.Agentsim.Agents.Parking,
+  boundingBox: Envelope,
+  seed: Int,
+  skims: Option[Skims],
+  fuelPrice: Map[FuelType, Double]
+) extends ParkingFunctions(
+      tazTreeMap,
+      parkingZones,
+      distanceFunction,
+      parkingConfig.minSearchRadius,
+      parkingConfig.maxSearchRadius,
+      parkingConfig.searchMaxDistanceRelativeToEllipseFoci,
+      parkingConfig.estimatedMinParkingDurationInSeconds,
+      parkingConfig.estimatedMeanEnRouteChargingDurationInSeconds,
+      parkingConfig.fractionOfSameTypeZones,
+      parkingConfig.minNumberOfSameTypeZones,
+      boundingBox,
+      seed,
+      parkingConfig.multinomialLogit
+    ) {
 
   /**
     * function that verifies if RideHail Then Fast Charging Only

--- a/src/main/scala/beam/agentsim/infrastructure/ChargingNetwork.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingNetwork.scala
@@ -10,7 +10,7 @@ import beam.agentsim.infrastructure.ParkingInquiry.ParkingSearchMode.EnRouteChar
 import beam.agentsim.infrastructure.charging.ChargingPointType
 import beam.agentsim.infrastructure.parking._
 import beam.agentsim.infrastructure.power.PowerManager.PowerInKW
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.router.skim.Skims
 import beam.sim.BeamServices
 import beam.sim.config.BeamConfig
@@ -163,8 +163,7 @@ object ChargingNetwork extends LazyLogging {
 
   def apply(
     chargingZones: Map[Id[ParkingZoneId], ParkingZone],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    tazTreeMap: TAZTreeMap,
     envelopeInUTM: Envelope,
     beamConfig: BeamConfig,
     distanceFunction: (Coord, Coord) => Double,
@@ -174,8 +173,7 @@ object ChargingNetwork extends LazyLogging {
     new ChargingNetwork(chargingZones) {
       override val searchFunctions: Option[InfrastructureFunctions] = Some(
         new ChargingFunctions(
-          geoQuadTree,
-          idToGeoMapping,
+          tazTreeMap,
           chargingZones,
           distanceFunction,
           beamConfig.beam.agentsim.agents.parking,
@@ -190,8 +188,7 @@ object ChargingNetwork extends LazyLogging {
 
   def apply(
     parkingDescription: Iterator[String],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    TAZTreeMap: TAZTreeMap,
     envelopeInUTM: Envelope,
     beamConfig: BeamConfig,
     beamServicesMaybe: Option[BeamServices],
@@ -210,8 +207,7 @@ object ChargingNetwork extends LazyLogging {
     )
     ChargingNetwork(
       parking.zones.toMap,
-      geoQuadTree,
-      idToGeoMapping,
+      TAZTreeMap,
       envelopeInUTM,
       beamConfig,
       distanceFunction,
@@ -227,8 +223,7 @@ object ChargingNetwork extends LazyLogging {
   ): ChargingNetwork = {
     ChargingNetwork(
       chargingZones,
-      beamServices.beamScenario.tazTreeMap.tazQuadTree,
-      beamServices.beamScenario.tazTreeMap.idToTAZMapping,
+      beamServices.beamScenario.tazTreeMap,
       envelopeInUTM,
       beamServices.beamConfig,
       beamServices.geo.distUTMInMeters(_, _),

--- a/src/main/scala/beam/agentsim/infrastructure/HierarchicalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/HierarchicalParkingManager.scala
@@ -48,7 +48,21 @@ class HierarchicalParkingManager(
     )
 
   override protected val searchFunctions: Option[InfrastructureFunctions] = Some(
-    new ParkingFunctions(tazMap, tazParkingZones, distanceFunction, minSearchRadius, maxSearchRadius, 0.0, 0.0, estimatedMinParkingDurationInSeconds, 1.0, 1, boundingBox, seed, mnlParkingConfig)
+    new ParkingFunctions(
+      tazMap,
+      tazParkingZones,
+      distanceFunction,
+      minSearchRadius,
+      maxSearchRadius,
+      0.0,
+      0.0,
+      estimatedMinParkingDurationInSeconds,
+      1.0,
+      1,
+      boundingBox,
+      seed,
+      mnlParkingConfig
+    )
   )
 
   val DefaultParkingZone: ParkingZone =

--- a/src/main/scala/beam/agentsim/infrastructure/HierarchicalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/HierarchicalParkingManager.scala
@@ -48,22 +48,7 @@ class HierarchicalParkingManager(
     )
 
   override protected val searchFunctions: Option[InfrastructureFunctions] = Some(
-    new ParkingFunctions(
-      tazMap.tazQuadTree,
-      tazMap.idToTAZMapping,
-      tazParkingZones,
-      distanceFunction,
-      minSearchRadius,
-      maxSearchRadius,
-      0.0,
-      0.0,
-      estimatedMinParkingDurationInSeconds,
-      1.0,
-      1,
-      boundingBox,
-      seed,
-      mnlParkingConfig
-    )
+    new ParkingFunctions(tazMap, tazParkingZones, distanceFunction, minSearchRadius, maxSearchRadius, 0.0, 0.0, estimatedMinParkingDurationInSeconds, 1.0, 1, boundingBox, seed, mnlParkingConfig)
   )
 
   val DefaultParkingZone: ParkingZone =

--- a/src/main/scala/beam/agentsim/infrastructure/InfrastructureFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/InfrastructureFunctions.scala
@@ -12,7 +12,7 @@ import beam.agentsim.infrastructure.parking.ParkingZoneSearch.{
   ParkingZoneSearchResult
 }
 import beam.agentsim.infrastructure.parking._
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import com.typesafe.scalalogging.StrictLogging
 import com.vividsolutions.jts.geom.Envelope
 import org.matsim.api.core.v01.{Coord, Id}
@@ -21,8 +21,7 @@ import org.matsim.core.utils.collections.QuadTree
 import scala.util.Random
 
 abstract class InfrastructureFunctions(
-  geoQuadTree: QuadTree[TAZ],
-  idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+  tazTreeMap: TAZTreeMap,
   parkingZones: Map[Id[ParkingZoneId], ParkingZone],
   distanceFunction: (Coord, Coord) => Double,
   minSearchRadius: Double,
@@ -130,7 +129,7 @@ abstract class InfrastructureFunctions(
         mnlMultiplierParameters,
         zoneCollections,
         parkingZones,
-        geoQuadTree,
+        tazTreeMap.tazQuadTree,
         new Random(seed),
         inquiry.departureLocation,
         inquiry.reservedFor
@@ -155,7 +154,7 @@ abstract class InfrastructureFunctions(
     // generates a coordinate for an embodied ParkingStall from a ParkingZone
     val parkingZoneLocSamplingFunction: ParkingZone => Coord =
       (zone: ParkingZone) => {
-        idToGeoMapping.get(zone.tazId) match {
+        tazTreeMap.idToTAZMapping.get(zone.tazId) match {
           case None =>
             logger.error(
               s"somehow have a ParkingZone with tazId ${zone.tazId} which is not found in the idToGeoMapping"

--- a/src/main/scala/beam/agentsim/infrastructure/ParallelParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParallelParkingManager.scala
@@ -67,8 +67,7 @@ class ParallelParkingManager(
     val tazTreeMap = TAZTreeMap.fromSeq(cluster.tazes)
     val parkingNetwork = ZonalParkingManager(
       parkingZones,
-      tazTreeMap.tazQuadTree,
-      tazTreeMap.idToTAZMapping,
+      tazTreeMap,
       distanceFunction,
       boundingBox,
       minSearchRadius,

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
@@ -169,7 +169,7 @@ class ParkingFunctions(
       ParkingStallSampling.linkBasedSampling(
         new Random(seed),
         inquiry.destinationUtm.loc,
-        tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+        tazTreeMap.tazToLinkIdMapping.get(taz.tazId),
         distanceFunction,
         parkingZone.availability,
         taz,

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
@@ -5,8 +5,9 @@ import beam.agentsim.agents.vehicles.VehicleManager
 import beam.agentsim.infrastructure.ParkingInquiry.{ParkingActivityType, ParkingSearchMode}
 import beam.agentsim.infrastructure.parking.ParkingZoneSearch.{ParkingAlternative, ParkingZoneSearchResult}
 import beam.agentsim.infrastructure.parking._
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.sim.config.BeamConfig
+import beam.sim.config.BeamConfig.Beam.Agentsim.Agents.Parking
 import com.vividsolutions.jts.geom.Envelope
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.utils.collections.QuadTree
@@ -14,8 +15,7 @@ import org.matsim.core.utils.collections.QuadTree
 import scala.util.Random
 
 class ParkingFunctions(
-  geoQuadTree: QuadTree[TAZ],
-  idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+  tazTreeMap: TAZTreeMap,
   parkingZones: Map[Id[ParkingZoneId], ParkingZone],
   distanceFunction: (Coord, Coord) => Double,
   minSearchRadius: Double,
@@ -27,10 +27,9 @@ class ParkingFunctions(
   minNumberOfSameTypeZones: Int,
   boundingBox: Envelope,
   seed: Int,
-  mnlParkingConfig: BeamConfig.Beam.Agentsim.Agents.Parking.MultinomialLogit
+  mnlParkingConfig: Parking.MultinomialLogit
 ) extends InfrastructureFunctions(
-      geoQuadTree,
-      idToGeoMapping,
+      tazTreeMap,
       parkingZones,
       distanceFunction,
       minSearchRadius,
@@ -166,7 +165,15 @@ class ParkingFunctions(
       (inquiry.parkingActivityType == ParkingActivityType.Work && parkingZone.parkingType == ParkingType.Workplace)
     )
       inquiry.destinationUtm.loc
-    else
+    else if (tazTreeMap.tazListContainsGeoms) {
+      ParkingStallSampling.linkBasedSampling(
+        new Random(seed),
+        inquiry.destinationUtm.loc,
+        tazTreeMap.TAZtoLinkIdMapping(taz.tazId),
+        distanceFunction,
+        parkingZone.availability
+      )
+    } else {
       ParkingStallSampling.availabilityAwareSampling(
         new Random(seed),
         inquiry.destinationUtm.loc,
@@ -174,6 +181,7 @@ class ParkingFunctions(
         parkingZone.availability,
         inClosestZone
       )
+    }
   }
 
   /**

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
@@ -172,8 +172,9 @@ class ParkingFunctions(
         tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
         distanceFunction,
         parkingZone.availability,
-      taz,
-          inClosestZone)
+        taz,
+        inClosestZone
+      )
     } else {
       ParkingStallSampling.availabilityAwareSampling(
         new Random(seed),

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
@@ -169,7 +169,7 @@ class ParkingFunctions(
       ParkingStallSampling.linkBasedSampling(
         new Random(seed),
         inquiry.destinationUtm.loc,
-        tazTreeMap.TAZtoLinkIdMapping(taz.tazId),
+        tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
         distanceFunction,
         parkingZone.availability
       )

--- a/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ParkingFunctions.scala
@@ -171,8 +171,9 @@ class ParkingFunctions(
         inquiry.destinationUtm.loc,
         tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
         distanceFunction,
-        parkingZone.availability
-      )
+        parkingZone.availability,
+      taz,
+          inClosestZone)
     } else {
       ParkingStallSampling.availabilityAwareSampling(
         new Random(seed),

--- a/src/main/scala/beam/agentsim/infrastructure/RideHailDepotFunctions.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/RideHailDepotFunctions.scala
@@ -7,7 +7,7 @@ import beam.agentsim.infrastructure.RideHailDepotFunctions.mnlMultiplierParamete
 import beam.agentsim.infrastructure.charging.ChargingPointType
 import beam.agentsim.infrastructure.parking.ParkingZoneSearch.ParkingZoneSearchResult
 import beam.agentsim.infrastructure.parking._
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.router.Modes.BeamMode.CAR
 import beam.router.skim.Skims
 import beam.sim.config.BeamConfig
@@ -18,8 +18,7 @@ import org.matsim.core.utils.collections.QuadTree
 import scala.util.Random
 
 class RideHailDepotFunctions(
-  geoQuadTree: QuadTree[TAZ],
-  idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+  tazTreeMap: TAZTreeMap,
   parkingZones: Map[Id[ParkingZoneId], ParkingZone],
   distanceFunction: (Coord, Coord) => Double,
   minSearchRadius: Double,
@@ -34,8 +33,7 @@ class RideHailDepotFunctions(
   estimatedMinParkingDurationInSeconds: Double,
   depotFunction: Id[ParkingZoneId] => Option[ChargingStation]
 ) extends InfrastructureFunctions(
-      geoQuadTree,
-      idToGeoMapping,
+      tazTreeMap,
       parkingZones,
       distanceFunction,
       minSearchRadius,
@@ -223,7 +221,7 @@ class RideHailDepotFunctions(
   def getParkingZoneLocationUtm(parkingZoneId: Id[ParkingZoneId]): Coord = {
     val parkingZone = parkingZones(parkingZoneId)
     parkingZone.link.fold {
-      idToGeoMapping(parkingZone.tazId).coord
+      tazTreeMap.idToTAZMapping(parkingZone.tazId).coord
     } {
       _.getCoord
     }

--- a/src/main/scala/beam/agentsim/infrastructure/RideHailDepotNetwork.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/RideHailDepotNetwork.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.infrastructure
 
 import beam.agentsim.infrastructure.parking.{ParkingZone, ParkingZoneId}
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.sim.BeamServices
 import com.vividsolutions.jts.geom.Envelope
 import org.matsim.api.core.v01.Id
@@ -25,16 +25,14 @@ object RideHailDepotNetwork {
 
   def apply(
     parkingZones: Map[Id[ParkingZoneId], ParkingZone],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    tazTreeMap: TAZTreeMap,
     boundingBox: Envelope,
     beamServices: BeamServices
   ): RideHailDepotNetwork = {
     new RideHailDepotNetwork(parkingZones) {
       override val searchFunctions: Option[InfrastructureFunctions] = Some(
         new RideHailDepotFunctions(
-          geoQuadTree,
-          idToGeoMapping,
+          tazTreeMap,
           parkingZones,
           beamServices.geo.distUTMInMeters,
           SearchStartRadius,
@@ -60,8 +58,7 @@ object RideHailDepotNetwork {
   ): RideHailDepotNetwork = {
     RideHailDepotNetwork(
       parkingZones,
-      beamServices.beamScenario.tazTreeMap.tazQuadTree,
-      beamServices.beamScenario.tazTreeMap.idToTAZMapping,
+      beamServices.beamScenario.tazTreeMap,
       boundingBox,
       beamServices
     )

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.infrastructure
 
 import beam.agentsim.infrastructure.parking._
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
 import beam.sim.BeamServices
 import beam.sim.config.BeamConfig
 import com.typesafe.scalalogging.LazyLogging
@@ -31,8 +31,9 @@ object ZonalParkingManager extends LazyLogging {
     */
   def apply(
     parkingZones: Map[Id[ParkingZoneId], ParkingZone],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    tazTreeMap: TAZTreeMap,
+//    geoQuadTree: QuadTree[TAZ],
+//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     distanceFunction: (Coord, Coord) => Double,
     boundingBox: Envelope,
     minSearchRadius: Double,
@@ -51,8 +52,8 @@ object ZonalParkingManager extends LazyLogging {
       }
       override val searchFunctions: Option[InfrastructureFunctions] = Some(
         new ParkingFunctions(
-          geoQuadTree,
-          idToGeoMapping,
+          tazTreeMap.tazQuadTree,
+          tazTreeMap.idToTAZMapping,
           parkingZones,
           distanceFunction,
           minSearchRadius,
@@ -77,16 +78,16 @@ object ZonalParkingManager extends LazyLogging {
     */
   def apply(
     parkingZones: Map[Id[ParkingZoneId], ParkingZone],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    TAZTreeMap: TAZTreeMap,
+//    geoQuadTree: QuadTree[TAZ],
+//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     envelopeInUTM: Envelope,
     beamConfig: BeamConfig,
     distanceFunction: (Coord, Coord) => Double
   ): ZonalParkingManager = {
     ZonalParkingManager(
       parkingZones,
-      geoQuadTree,
-      idToGeoMapping,
+      TAZTreeMap,
       distanceFunction,
       envelopeInUTM,
       beamConfig.beam.agentsim.agents.parking.minSearchRadius,
@@ -107,8 +108,9 @@ object ZonalParkingManager extends LazyLogging {
     */
   def apply(
     parkingDescription: Iterator[String],
-    geoQuadTree: QuadTree[TAZ],
-    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
+    TAZTreeMap: TAZTreeMap,
+//    geoQuadTree: QuadTree[TAZ],
+//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     boundingBox: Envelope,
     distanceFunction: (Coord, Coord) => Double,
     minSearchRadius: Double,
@@ -126,8 +128,9 @@ object ZonalParkingManager extends LazyLogging {
     )
     ZonalParkingManager(
       parking.zones.filter(_._2.chargingPointType.isEmpty).toMap,
-      geoQuadTree,
-      idToGeoMapping,
+      TAZTreeMap,
+//      geoQuadTree,
+//      idToGeoMapping,
       distanceFunction,
       boundingBox,
       minSearchRadius,
@@ -152,8 +155,8 @@ object ZonalParkingManager extends LazyLogging {
   ): ZonalParkingManager = {
     ZonalParkingManager(
       parkingZones,
-      beamServices.beamScenario.tazTreeMap.tazQuadTree,
-      beamServices.beamScenario.tazTreeMap.idToTAZMapping,
+      beamServices.beamScenario.tazTreeMap, //.tazQuadTree,
+//      beamServices.beamScenario.tazTreeMap.idToTAZMapping,
       envelopeInUTM,
       beamServices.beamConfig,
       beamServices.geo.distUTMInMeters

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -32,8 +32,6 @@ object ZonalParkingManager extends LazyLogging {
   def apply(
     parkingZones: Map[Id[ParkingZoneId], ParkingZone],
     tazTreeMap: TAZTreeMap,
-//    geoQuadTree: QuadTree[TAZ],
-//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     distanceFunction: (Coord, Coord) => Double,
     boundingBox: Envelope,
     minSearchRadius: Double,
@@ -78,8 +76,6 @@ object ZonalParkingManager extends LazyLogging {
   def apply(
     parkingZones: Map[Id[ParkingZoneId], ParkingZone],
     TAZTreeMap: TAZTreeMap,
-//    geoQuadTree: QuadTree[TAZ],
-//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     envelopeInUTM: Envelope,
     beamConfig: BeamConfig,
     distanceFunction: (Coord, Coord) => Double
@@ -108,8 +104,6 @@ object ZonalParkingManager extends LazyLogging {
   def apply(
     parkingDescription: Iterator[String],
     TAZTreeMap: TAZTreeMap,
-//    geoQuadTree: QuadTree[TAZ],
-//    idToGeoMapping: scala.collection.Map[Id[TAZ], TAZ],
     boundingBox: Envelope,
     distanceFunction: (Coord, Coord) => Double,
     minSearchRadius: Double,
@@ -128,8 +122,6 @@ object ZonalParkingManager extends LazyLogging {
     ZonalParkingManager(
       parking.zones.filter(_._2.chargingPointType.isEmpty).toMap,
       TAZTreeMap,
-//      geoQuadTree,
-//      idToGeoMapping,
       distanceFunction,
       boundingBox,
       minSearchRadius,
@@ -154,8 +146,7 @@ object ZonalParkingManager extends LazyLogging {
   ): ZonalParkingManager = {
     ZonalParkingManager(
       parkingZones,
-      beamServices.beamScenario.tazTreeMap, //.tazQuadTree,
-//      beamServices.beamScenario.tazTreeMap.idToTAZMapping,
+      beamServices.beamScenario.tazTreeMap,
       envelopeInUTM,
       beamServices.beamConfig,
       beamServices.geo.distUTMInMeters

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -51,7 +51,21 @@ object ZonalParkingManager extends LazyLogging {
         )
       }
       override val searchFunctions: Option[InfrastructureFunctions] = Some(
-        new ParkingFunctions(tazTreeMap, parkingZones, distanceFunction, minSearchRadius, maxSearchRadius, 0.0, estimatedMinParkingDurationInSeconds, 0.0, fractionOfSameTypeZones, minNumberOfSameTypeZones, boundingBox, seed, mnlParkingConfig)
+        new ParkingFunctions(
+          tazTreeMap,
+          parkingZones,
+          distanceFunction,
+          minSearchRadius,
+          maxSearchRadius,
+          0.0,
+          estimatedMinParkingDurationInSeconds,
+          0.0,
+          fractionOfSameTypeZones,
+          minNumberOfSameTypeZones,
+          boundingBox,
+          seed,
+          mnlParkingConfig
+        )
       )
     }
   }

--- a/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ZonalParkingManager.scala
@@ -51,22 +51,7 @@ object ZonalParkingManager extends LazyLogging {
         )
       }
       override val searchFunctions: Option[InfrastructureFunctions] = Some(
-        new ParkingFunctions(
-          tazTreeMap.tazQuadTree,
-          tazTreeMap.idToTAZMapping,
-          parkingZones,
-          distanceFunction,
-          minSearchRadius,
-          maxSearchRadius,
-          0.0,
-          estimatedMinParkingDurationInSeconds,
-          0.0,
-          fractionOfSameTypeZones,
-          minNumberOfSameTypeZones,
-          boundingBox,
-          seed,
-          mnlParkingConfig
-        )
+        new ParkingFunctions(tazTreeMap, parkingZones, distanceFunction, minSearchRadius, maxSearchRadius, 0.0, estimatedMinParkingDurationInSeconds, 0.0, fractionOfSameTypeZones, minNumberOfSameTypeZones, boundingBox, seed, mnlParkingConfig)
       )
     }
   }

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
@@ -35,7 +35,7 @@ object ParkingStallSampling {
     Some(filteredLinks)
       .filter(_.nonEmpty)
       .map(
-        _.map(lnk => getClosestPointAlongLink(lnk, requestLocation)).minBy(loc =>
+        _.map(lnk => getClosestPointAlongLink(lnk, requestLocation, distanceFunction)).minBy(loc =>
           distanceFunction(loc, requestLocation)
         )
       )
@@ -47,19 +47,48 @@ object ParkingStallSampling {
 //      .getOrElse(requestLocation)
   }
 
-  private def getClosestPointAlongLink(link: Link, requestLocation: Location): Location = {
+  private def getClosestPointAlongLink(
+    link: Link,
+    requestLocation: Location,
+    distanceFunction: (Coord, Coord) => Double
+  ): Location = {
     val (p1, p2) = (link.getToNode.getCoord, link.getFromNode.getCoord)
-    val (dx, dy) = (p2.getX - p1.getX, p2.getY - p1.getY) // vector between p1 and p2
-    val (diffx, diffy) = (requestLocation.getX - p1.getX, requestLocation.getY - p1.getY) // vector between p1 and p3
-    val c1 = (dx * diffx + dy * diffy) / (pow(dx, 2) + pow(dy, 2)) // projection of w onto v
-    if (c1 < 0) { p1 }
-    else if (c1 > 1) { p2 }
-    else {
-      val x = p1.getX + c1 * dx // closest point on line to p3
-      val y = p1.getY + c1 * dy // closest point on line to p3
-      new Coord(x, y)
+    val (closestPointOption, closestDistance) = List(p1, p2).foldLeft(None: Option[Coord], Double.PositiveInfinity) {
+      (accumulator, endPoint) =>
+        val dist = distanceFunction(endPoint, requestLocation)
+        if (dist < accumulator._2) {
+          (Some(endPoint), dist)
+        } else {
+          accumulator
+        }
     }
 
+    closestPointOption match {
+      case Some(closestPoint) =>
+        if (closestDistance < 100) {
+          closestPoint
+        } else {
+          val (dx, dy) = (p2.getX - p1.getX, p2.getY - p1.getY) // vector between p1 and p2
+          val (diffx, diffy) =
+            (requestLocation.getX - p1.getX, requestLocation.getY - p1.getY) // vector between p1 and p3
+          val c1 = (dx * diffx + dy * diffy) / (pow(dx, 2) + pow(dy, 2)) // projection of w onto v
+          if (c1 < 0) {
+            p1
+          } else if (c1 > 1) {
+            p2
+          } else {
+            val x = p1.getX + c1 * dx // closest point on line to p3
+            val y = p1.getY + c1 * dy // closest point on line to p3
+            if ((!x.isNaN) && (!y.isNaN)) {
+              new Coord(x, y)
+            } else {
+              closestPoint
+            }
+          }
+        }
+      case None =>
+        requestLocation
+    }
   }
 
   /**

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
@@ -3,6 +3,7 @@ package beam.agentsim.infrastructure.parking
 import scala.util.Random
 import beam.agentsim.infrastructure.taz.TAZ
 import beam.router.BeamRouter.Location
+import com.typesafe.scalalogging.LazyLogging
 import org.matsim.api.core.v01.network.Link
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.utils.collections.QuadTree
@@ -13,7 +14,7 @@ import scala.math.pow
 /**
   * sampling methods for randomly generating stall locations from aggregate information
   */
-object ParkingStallSampling {
+object ParkingStallSampling extends LazyLogging {
 
   val maxOffsetDistance = 600.0 // TODO: Make this a config parameter
 
@@ -39,12 +40,10 @@ object ParkingStallSampling {
           distanceFunction(loc, requestLocation)
         )
       )
-      .getOrElse(requestLocation)
-
-//    Some(filteredLinks)
-//      .filter(_.nonEmpty)
-//      .map(_.minBy(lnk => distanceFunction(lnk.getCoord, requestLocation)).getCoord)
-//      .getOrElse(requestLocation)
+      .getOrElse {
+        logger.warn(s"Could not find a link for parking request at location: $requestLocation")
+        requestLocation
+      }
   }
 
   private def getClosestPointAlongLink(
@@ -87,7 +86,7 @@ object ParkingStallSampling {
           }
         }
       case None =>
-        requestLocation
+        p1
     }
   }
 

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
@@ -32,26 +32,25 @@ object ParkingStallSampling extends ExponentialLazyLogging {
       case Some(linkQuadTree) =>
         val allLinks = linkQuadTree.getDisk(requestLocation.getX, requestLocation.getY, maxDist).asScala
         val totalLength = allLinks.foldRight(0.0)(_.getLength + _)
-    var currentLength = 0.0
-    val filteredLinks = rand.shuffle(allLinks).takeWhile { lnk =>
-      currentLength += lnk.getLength
-      currentLength <= totalLength * availabilityRatio
-    }
-    Some(filteredLinks)
-      .filter(_.nonEmpty)
-      .map(
-        _.map(lnk => getClosestPointAlongLink(lnk, requestLocation, distanceFunction)).minBy(loc =>
-          distanceFunction(loc, requestLocation)
-        )
-      )
-      .getOrElse {
-        logger.warn(s"Could not find a link for parking request at location: $requestLocation")
-        availabilityAwareSampling(rand, requestLocation, taz, availabilityRatio, inClosestZone)
-            }
+        var currentLength = 0.0
+        val filteredLinks = rand.shuffle(allLinks).takeWhile { lnk =>
+          currentLength += lnk.getLength
+          currentLength <= totalLength * availabilityRatio
         }
+        Some(filteredLinks)
+          .filter(_.nonEmpty)
+          .map(
+            _.map(lnk => getClosestPointAlongLink(lnk, requestLocation, distanceFunction)).minBy(loc =>
+              distanceFunction(loc, requestLocation)
+            )
+          )
+          .getOrElse {
+            logger.warn(s"Could not find a link for parking request at location: $requestLocation")
+            availabilityAwareSampling(rand, requestLocation, taz, availabilityRatio, inClosestZone)
+          }
       case _ =>
         availabilityAwareSampling(rand, requestLocation, taz, availabilityRatio, inClosestZone)
-      }
+    }
   }
 
   private def getClosestPointAlongLink(

--- a/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/parking/ParkingStallSampling.scala
@@ -3,7 +3,7 @@ package beam.agentsim.infrastructure.parking
 import scala.util.Random
 import beam.agentsim.infrastructure.taz.TAZ
 import beam.router.BeamRouter.Location
-import com.typesafe.scalalogging.LazyLogging
+import beam.utils.logging.ExponentialLazyLogging
 import org.matsim.api.core.v01.network.Link
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.core.utils.collections.QuadTree
@@ -14,7 +14,7 @@ import scala.math.pow
 /**
   * sampling methods for randomly generating stall locations from aggregate information
   */
-object ParkingStallSampling extends LazyLogging {
+object ParkingStallSampling extends ExponentialLazyLogging {
 
   val maxOffsetDistance = 600.0 // TODO: Make this a config parameter
 
@@ -24,6 +24,8 @@ object ParkingStallSampling extends LazyLogging {
     maybeLinkQuadTree: Option[QuadTree[Link]],
     distanceFunction: (Coord, Coord) => Double,
     availabilityRatio: Double,
+    taz: TAZ,
+    inClosestZone: Boolean,
     maxDist: Double = maxOffsetDistance
   ): Location = {
     maybeLinkQuadTree match {

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -154,7 +154,7 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
             else None
           }
           foundTaz match {
-            case Some(taz) =>
+            case Some(taz) if link.getAllowedModes.contains("car") & link.getAllowedModes.contains("walk") =>
               try {
                 tazToLinkIdMapping(taz.tazId).put(linkMidpoint.getX, linkMidpoint.getY, link)
               } catch {
@@ -163,8 +163,9 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
                   logger.warn(e.toString)
               }
               linkIdToTAZMapping += (id -> taz.tazId)
-            case _ =>
+            case None =>
               unmatchedLinkIds += id
+            case _ =>
           }
         case _ =>
       }

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -41,6 +41,9 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
   val idToTAZMapping: mutable.HashMap[Id[TAZ], TAZ] = mutable.HashMap()
   private val cache: TrieMap[(Double, Double), TAZ] = TrieMap()
   private val linkIdToTAZMapping: mutable.HashMap[Id[Link], Id[TAZ]] = mutable.HashMap.empty[Id[Link], Id[TAZ]]
+
+  val TAZtoLinkIdMapping: mutable.HashMap[Id[TAZ], QuadTree[Link]] =
+    mutable.HashMap.empty[Id[TAZ], QuadTree[Link]]
   private val unmatchedLinkIds: mutable.ListBuffer[Id[Link]] = mutable.ListBuffer.empty[Id[Link]]
   lazy val tazListContainsGeoms: Boolean = tazQuadTree.values().asScala.headOption.exists(_.geometry.isDefined)
   private val failedLinkLookups: mutable.ListBuffer[Id[Link]] = mutable.ListBuffer.empty[Id[Link]]
@@ -125,6 +128,15 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
 
   def mapNetworkToTAZs(network: Network): Unit = {
     if (tazListContainsGeoms) {
+      val extent =
+        (tazQuadTree.getMinEasting, tazQuadTree.getMinNorthing, tazQuadTree.getMaxEasting, tazQuadTree.getMaxNorthing)
+      idToTAZMapping.toList.foreach { case (id, taz) =>
+        val (minX, minY, maxX, maxY) = taz.geometry.map(_.getEnvelope.getEnvelopeInternal) match {
+          case Some(env) => (env.getMinX, env.getMinY, env.getMaxX, env.getMaxY)
+          case _         => extent
+        }
+        TAZtoLinkIdMapping(id) = new QuadTree[Link](minX, minY, maxX, maxY)
+      }
       network.getLinks.asScala.foreach {
         case (id, link) =>
           val linkEndCoord = link.getToNode.getCoord
@@ -140,6 +152,7 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
           }
           foundTaz match {
             case Some(taz) =>
+              TAZtoLinkIdMapping(taz.tazId).put(linkEndCoord.getX, linkEndCoord.getY, link)
               linkIdToTAZMapping += (id -> taz.tazId)
             case _ =>
               unmatchedLinkIds += id

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -156,11 +156,12 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
           }
           foundTaz match {
             case Some(taz) =>
-              TAZtoLinkIdMapping(taz.tazId).put(linkEndCoord.getX, linkEndCoord.getY, link)
               try {
                 TAZtoLinkIdMapping(taz.tazId).put(linkMidpoint.getX, linkMidpoint.getY, link)
               } catch {
-                case e: Throwable => logger.warn(e.toString)
+                case e: Throwable =>
+                  unmatchedLinkIds += id
+                  logger.warn(e.toString)
               }
               linkIdToTAZMapping += (id -> taz.tazId)
             case _ =>

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -168,6 +168,14 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
           }
         case _ =>
       }
+      val linksToTazMapping = TAZtoLinkIdMapping
+        .map { case (x, y) => (x, y.size()) }
+        .groupBy(x => Math.min(x._2, 10))
+        .map { case (x, y) =>
+          (x, y.keys.map(_.toString))
+        }
+        .toSeq
+        .sortBy(_._1)
       logger.info(
         "Completed mapping links to TAZs. Matched "
         + linkIdToTAZMapping.size.toString +
@@ -175,6 +183,7 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
         + unmatchedLinkIds.size.toString +
         " links"
       )
+      logger.info(s"Mapping of links to TAZs: $linksToTazMapping")
     }
   }
 }

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -130,10 +130,10 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
 
   def mapNetworkToTAZs(network: Network): Unit = {
     if (tazListContainsGeoms) {
-      val extent =
+      val extentOfEntireRegion =
         (tazQuadTree.getMinEasting, tazQuadTree.getMinNorthing, tazQuadTree.getMaxEasting, tazQuadTree.getMaxNorthing)
       idToTAZMapping.toList.foreach { case (id, taz) =>
-        val (minX, minY, maxX, maxY) = taz.geometry.map(_.getEnvelope.getEnvelopeInternal) match {
+        val (minXofTAZ, minYofTAZ, maxXofTAZ, maxYofTAZ) = taz.geometry.map(_.getEnvelope.getEnvelopeInternal) match {
           case Some(env) =>
             (
               env.getMinX - tazBoundingBoxBufferMeters,
@@ -141,9 +141,9 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
               env.getMaxX + tazBoundingBoxBufferMeters,
               env.getMaxY + tazBoundingBoxBufferMeters
             )
-          case _ => extent
+          case _ => extentOfEntireRegion
         }
-        tazToLinkIdMapping(id) = new QuadTree[Link](minX, minY, maxX, maxY)
+        tazToLinkIdMapping(id) = new QuadTree[Link](minXofTAZ, minYofTAZ, maxXofTAZ, maxYofTAZ)
       }
       network.getLinks.asScala.foreach {
         case (id, link) =>

--- a/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/taz/TAZTreeMap.scala
@@ -135,11 +135,15 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
           case Some(env) => (env.getMinX, env.getMinY, env.getMaxX, env.getMaxY)
           case _         => extent
         }
-        TAZtoLinkIdMapping(id) = new QuadTree[Link](minX, minY, maxX, maxY)
+        TAZtoLinkIdMapping(id) = new QuadTree[Link](minX - 2e3, minY - 2e3, maxX + 2e3, maxY + 2e3)
       }
       network.getLinks.asScala.foreach {
         case (id, link) =>
           val linkEndCoord = link.getToNode.getCoord
+          val linkMidpoint = new Coord(
+            0.5 * (link.getToNode.getCoord.getX + link.getFromNode.getCoord.getX),
+            0.5 * (link.getToNode.getCoord.getY + link.getFromNode.getCoord.getY)
+          )
           val foundTaz = TAZTreeMap.ringSearch(
             tazQuadTree,
             linkEndCoord,
@@ -153,6 +157,11 @@ class TAZTreeMap(val tazQuadTree: QuadTree[TAZ], val useCache: Boolean = false)
           foundTaz match {
             case Some(taz) =>
               TAZtoLinkIdMapping(taz.tazId).put(linkEndCoord.getX, linkEndCoord.getY, link)
+              try {
+                TAZtoLinkIdMapping(taz.tazId).put(linkMidpoint.getX, linkMidpoint.getY, link)
+              } catch {
+                case e: Throwable => logger.warn(e.toString)
+              }
               linkIdToTAZMapping += (id -> taz.tazId)
             case _ =>
               unmatchedLinkIds += id
@@ -190,10 +199,10 @@ object TAZTreeMap {
     val quadTreeBounds: QuadTreeBounds = quadTreeExtentFromShapeFile(features)
 
     val tazQuadTree: QuadTree[TAZ] = new QuadTree[TAZ](
-      quadTreeBounds.minx,
-      quadTreeBounds.miny,
-      quadTreeBounds.maxx,
-      quadTreeBounds.maxy
+      quadTreeBounds.minx - 2e4,
+      quadTreeBounds.miny - 2e4,
+      quadTreeBounds.maxx + 2e4,
+      quadTreeBounds.maxy + 2e4
     )
 
     for (f <- features.asScala) {

--- a/src/main/scala/scripts/ParkingManagerBenchmark.scala
+++ b/src/main/scala/scripts/ParkingManagerBenchmark.scala
@@ -162,8 +162,7 @@ object ParkingManagerBenchmark extends StrictLogging {
         val zones = loadZones(tazTreeMap.tazQuadTree, pathToTazParking, beamConfig)
         val parkingNetwork = ZonalParkingManager(
           zones,
-          tazTreeMap.tazQuadTree,
-          tazTreeMap.idToTAZMapping,
+          tazTreeMap,
           boundingBox,
           beamConfig,
           geoUtils.distUTMInMeters(_, _)

--- a/src/test/scala/beam/agentsim/infrastructure/ChargingNetworkSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/ChargingNetworkSpec.scala
@@ -146,8 +146,7 @@ object ChargingNetworkSpec {
   ): ChargingNetwork = {
     ChargingNetwork(
       parkingDescription,
-      tazTreeMap.tazQuadTree,
-      tazTreeMap.idToTAZMapping,
+      tazTreeMap,
       boundingBox,
       beamConfig,
       None,

--- a/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
@@ -364,8 +364,7 @@ class ZonalParkingManagerSpec
       val maxSearchRadius = 16093.4 // meters, aka 10 miles
       val zpm = ZonalParkingManager(
         parkingDescription,
-        tazMap.tazQuadTree,
-        tazMap.idToTAZMapping,
+        tazMap,
         boundingBox,
         geo.distUTMInMeters(_, _),
         minSearchRadius,
@@ -417,8 +416,7 @@ class ZonalParkingManagerSpec
       val parkingZones = InfrastructureUtils.loadParkingStalls(stalls)
       val zonesMap = ZonalParkingManager(
         parkingZones,
-        tazMap.tazQuadTree,
-        tazMap.idToTAZMapping,
+        tazMap,
         geo.distUTMInMeters(_, _),
         boundingBox,
         beamConfig.beam.agentsim.agents.parking.minSearchRadius,
@@ -533,8 +531,7 @@ object ZonalParkingManagerSpec {
     val maxSearchRadius = 16093.4 // meters, aka 10 miles
     ZonalParkingManager(
       parkingDescription,
-      tazTreeMap.tazQuadTree,
-      tazTreeMap.idToTAZMapping,
+      tazTreeMap,
       boundingBox,
       geo.distUTMInMeters(_, _),
       minSearchRadius,

--- a/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/ZonalParkingManagerSpec.scala
@@ -306,8 +306,7 @@ class ZonalParkingManagerSpec
       val maxSearchRadius = 16093.4 // meters, aka 10 miles
       val zpm = ZonalParkingManager(
         parkingDescription,
-        tazMap.tazQuadTree,
-        tazMap.idToTAZMapping,
+        tazMap,
         boundingBox,
         geo.distUTMInMeters(_, _),
         minSearchRadius,

--- a/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
@@ -9,7 +9,7 @@ import org.matsim.core.network.{LinkFactory, NetworkUtils}
 import org.matsim.core.utils.collections.QuadTree
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
@@ -51,6 +51,9 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
           numberOfTimesAtClosestLink should be >= 50
           val numberOfTimesAtFartherLinks = distances.count(x => (x != 100.0) & (x != 150.0))
           numberOfTimesAtFartherLinks should be <= 30
+          // There is a highway link that runs closest to the query point. This should not be available for parking
+          val numberOfTimesOnHighway = distances.count(x => x < 100.0)
+          numberOfTimesOnHighway shouldBe 0
         }
       }
       "30% availability" should {
@@ -252,6 +255,14 @@ object ParkingStallSamplingTestSpec {
     val link34 = network.getFactory.createLink(Id.createLinkId("34"), n3, n4)
     val link65 = network.getFactory.createLink(Id.createLinkId("65"), n6, n5)
     val link78 = network.getFactory.createLink(Id.createLinkId("78"), n8, n7)
+    val link13 = network.getFactory.createLink(Id.createLinkId("13"), n1, n7)
+    link12.setAllowedModes(scala.collection.immutable.Set("car", "walk").asJava)
+    link34.setAllowedModes(scala.collection.immutable.Set("car", "walk").asJava)
+    link65.setAllowedModes(scala.collection.immutable.Set("car", "walk").asJava)
+    link78.setAllowedModes(scala.collection.immutable.Set("car", "walk").asJava)
+
+    // This (highway) link doesn't allow walk so shouldn't allow parking
+    link13.setAllowedModes(scala.collection.immutable.Set("car").asJava)
 
     network.addNode(n1)
     network.addNode(n2)
@@ -265,6 +276,7 @@ object ParkingStallSamplingTestSpec {
     network.addLink(link34)
     network.addLink(link65)
     network.addLink(link78)
+    network.addLink(link13)
 
     val taz: TAZ = new TAZ(
       Id.create("taz", classOf[TAZ]),

--- a/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
@@ -22,7 +22,7 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
           val result: Coord = ParkingStallSampling.linkBasedSampling(
             random,
             agent,
-            tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+            tazTreeMap.tazToLinkIdMapping.get(taz.tazId),
             distance,
             availabilityRatio,
             taz,
@@ -38,7 +38,7 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
             val result: Coord = ParkingStallSampling.linkBasedSampling(
               random,
               agent,
-              tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+              tazTreeMap.tazToLinkIdMapping.get(taz.tazId),
               distance,
               availabilityRatio,
               taz,
@@ -60,7 +60,7 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
             val result: Coord = ParkingStallSampling.linkBasedSampling(
               random,
               agent,
-              tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+              tazTreeMap.tazToLinkIdMapping.get(taz.tazId),
               distance,
               availabilityRatio,
               taz,

--- a/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
@@ -1,13 +1,83 @@
 package beam.agentsim.infrastructure.parking
 
 import scala.util.Random
-import beam.agentsim.infrastructure.taz.TAZ
+import beam.agentsim.infrastructure.taz.{TAZ, TAZTreeMap}
+import com.vividsolutions.jts.geom.{Coordinate, Geometry, GeometryFactory, PrecisionModel}
+import org.matsim.api.core.v01.network.{Link, NetworkFactory, Node}
 import org.matsim.api.core.v01.{Coord, Id}
+import org.matsim.core.network.{LinkFactory, NetworkUtils}
+import org.matsim.core.utils.collections.QuadTree
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.collection.mutable
+
 class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
   val trialsPerTest: Int = 100
+  "testLinkBasedSampling" when {
+    "square TAZ with agent destination near corner" when {
+      "100% availability" should {
+        "place parking stall as close as possible to agent location" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
+          val availabilityRatio: Double = 1.0
+          val result: Coord = ParkingStallSampling.linkBasedSampling(
+            random,
+            agent,
+            tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+            distance,
+            availabilityRatio,
+            taz,
+            true
+          )
+          distance(agent, result) should equal(100.0) // Request at 100, 100 gets snapped to point at line on y=200
+        }
+      }
+      "80% availability" should {
+        "place closest parking stall each link roughly 50% of the time" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
+          val availabilityRatio: Double = 0.8
+          val distances = (1 to 100).map { x =>
+            val result: Coord = ParkingStallSampling.linkBasedSampling(
+              random,
+              agent,
+              tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+              distance,
+              availabilityRatio,
+              taz,
+              true
+            )
+            distance(agent, result)
+          }
+          // Should create a stall on the closest point (100m away) most of the time, rarely create one really far away
+          val numberOfTimesAtClosestLink = distances.count(_ == 100.0)
+          numberOfTimesAtClosestLink should be >= 50
+          val numberOfTimesAtFartherLinks = distances.count(x => (x != 100.0) & (x != 150.0))
+          numberOfTimesAtFartherLinks should be <= 30
+        }
+      }
+      "30% availability" should {
+        "place closest parking stall each link roughly 50% of the time" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
+          val availabilityRatio: Double = 0.3
+          val distances = (1 to 100).map { x =>
+            val result: Coord = ParkingStallSampling.linkBasedSampling(
+              random,
+              agent,
+              tazTreeMap.TAZtoLinkIdMapping.get(taz.tazId),
+              distance,
+              availabilityRatio,
+              taz,
+              true
+            )
+            distance(agent, result)
+          }
+          // Should be more likely to create a stall farther away
+          val numberOfTimesAtClosestLink = distances.count(_ == 100.0)
+          numberOfTimesAtClosestLink should be <= 50
+          val numberOfTimesAtFartherLinks = distances.count(x => (x != 100.0) & (x != 150.0))
+          numberOfTimesAtFartherLinks should be > 20
+        }
+      }
+    }
+  }
+
   "testAvailabilityAwareSampling" when {
     "square TAZ with agent destination near corner" when {
       "100% availability" should {
@@ -135,12 +205,79 @@ object ParkingStallSamplingTestSpec {
     val tazD: Double = 1000.0
     val tazArea: Double = tazD * tazD
 
+    private val projection: Int = 4326
+    private val geometryFactory: GeometryFactory = new GeometryFactory(new PrecisionModel(), projection)
+
+    val geometry = geometryFactory.createPolygon(
+      Array[Coordinate](
+        new Coordinate(0.0, 0.0),
+        new Coordinate(500.0, 0.0),
+        new Coordinate(500.0, 500.0),
+        new Coordinate(0.0, 500.0),
+        new Coordinate(0.0, 0.0)
+      )
+    )
+
+    val TAZtoLinkIdMapping: mutable.HashMap[Id[TAZ], QuadTree[Link]] =
+      mutable.HashMap.empty[Id[TAZ], QuadTree[Link]]
+    val network = NetworkUtils.createNetwork()
+
+    // Setup: Four links in the TAZ, one (horizontal) passes within 100m of the point at (100, 200) and one passes
+    // within 150m of the point at (250, 100). The other two links are farther away (350,100) and (100, 300).
+    // Those are the four potential places where stalls should be created. If there's 100% availability the stall
+    // should always be at the closer option, if there's less availability then  it's more likely the stall is
+    // farther away
+
+    /////////////////////////////////////
+    //                 |               |
+    //                 |               |
+    //-----X-----------+---------------+-
+    //                 |               |
+    //                 |               |
+    //-----X-----------+---------------+-
+    //                 |               |
+    //     *           X               X
+    //                 |               |
+    //////////////////////////////////////
+
+    val n1: Node = network.getFactory.createNode(Id.createNodeId("1"), new Coord(1.0, 200.0))
+    val n2: Node = network.getFactory.createNode(Id.createNodeId("2"), new Coord(499.0, 200.0))
+    val n3: Node = network.getFactory.createNode(Id.createNodeId("3"), new Coord(250.0, 1.0))
+    val n4: Node = network.getFactory.createNode(Id.createNodeId("4"), new Coord(250.0, 499.0))
+    val n5: Node = network.getFactory.createNode(Id.createNodeId("5"), new Coord(1.0, 300.0))
+    val n6: Node = network.getFactory.createNode(Id.createNodeId("6"), new Coord(499.0, 300.0))
+    val n7: Node = network.getFactory.createNode(Id.createNodeId("7"), new Coord(350.0, 1.0))
+    val n8: Node = network.getFactory.createNode(Id.createNodeId("8"), new Coord(350.0, 499.0))
+    val link12 = network.getFactory.createLink(Id.createLinkId("12"), n1, n2)
+    val link34 = network.getFactory.createLink(Id.createLinkId("34"), n3, n4)
+    val link65 = network.getFactory.createLink(Id.createLinkId("65"), n6, n5)
+    val link78 = network.getFactory.createLink(Id.createLinkId("78"), n8, n7)
+
+    network.addNode(n1)
+    network.addNode(n2)
+    network.addNode(n3)
+    network.addNode(n4)
+    network.addNode(n5)
+    network.addNode(n6)
+    network.addNode(n7)
+    network.addNode(n8)
+    network.addLink(link12)
+    network.addLink(link34)
+    network.addLink(link65)
+    network.addLink(link78)
+
     val taz: TAZ = new TAZ(
       Id.create("taz", classOf[TAZ]),
       new Coord(tazX, tazY),
       tazArea,
-      None
+      Some(geometry)
     )
+
+    val tazQuadTree = new QuadTree[TAZ](0.0, 0.0, 500.0, 500.0)
+    tazQuadTree.put(geometry.getCentroid.getX, geometry.getCentroid.getY, taz)
+    val tazTreeMap = new TAZTreeMap(tazQuadTree)
+
+    tazTreeMap.mapNetworkToTAZs(network)
 
     val agent: Coord = new Coord(100.0, 100.0)
 

--- a/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
+++ b/src/test/scala/beam/agentsim/infrastructure/parking/ParkingStallSamplingTestSpec.scala
@@ -32,7 +32,7 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
         }
       }
       "80% availability" should {
-        "place closest parking stall each link roughly 50% of the time" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
+        "place stall on the closest link most of the time" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
           val availabilityRatio: Double = 0.8
           val distances = (1 to 100).map { x =>
             val result: Coord = ParkingStallSampling.linkBasedSampling(
@@ -54,7 +54,7 @@ class ParkingStallSamplingTestSpec extends AnyWordSpec with Matchers {
         }
       }
       "30% availability" should {
-        "place closest parking stall each link roughly 50% of the time" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
+        "place stall farther away more often" in new ParkingStallSamplingTestSpec.SquareTAZWorld {
           val availabilityRatio: Double = 0.3
           val distances = (1 to 100).map { x =>
             val result: Coord = ParkingStallSampling.linkBasedSampling(


### PR DESCRIPTION
Rather then generating parking stall locations randomly within a TAZ, this PR adds the functionality of sampling road links (weighted by length) within a TAZ and then generating a stall along one of those. If there is high parking availability in a TAZ, a stall gets created along the nearest link as close as possible to the request point. If there is low parking availability, only a random subsample of links are considered as available, and then a stall is created as close as possible along the closest available link.

This has been partially tested in some of the PILATES and tour mode choice runs -- consolidating all of the changes here and adding tests.