### PR TITLE
Fix to EntitiesTransformStrategy

### DIFF
--- a/src/main/scala/scripts/transit/GtfsUtils.scala
+++ b/src/main/scala/scripts/transit/GtfsUtils.scala
@@ -204,7 +204,7 @@ object GtfsUtils {
     scale: Double,
     timeFrame: TimeFrame = TimeFrame.WholeDay
   ): GtfsTransformStrategy = {
-    val strategy = new EntitiesTransformStrategy
+    val strategy = new ParallelizedEntitiesTransformStrategy
 
     findTrips(tripsWithStopTimes, timeFrame)
       .foreach { trips =>

--- a/src/main/scala/scripts/transit/ParallelizedEntitiesTransformStrategy.scala
+++ b/src/main/scala/scripts/transit/ParallelizedEntitiesTransformStrategy.scala
@@ -1,0 +1,62 @@
+package scripts.transit
+
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao
+import org.onebusaway.gtfs_transformer.`match`.{EntityMatch, TypedEntityMatch}
+import org.onebusaway.gtfs_transformer.collections.{IdKey, IdKeyMatch}
+import org.onebusaway.gtfs_transformer.factory.EntitiesTransformStrategy
+import org.onebusaway.gtfs_transformer.services.{EntityTransformStrategy, TransformContext}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+class ParallelizedEntitiesTransformStrategy extends EntitiesTransformStrategy {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val _modificationsByType: collection.mutable.Map[Class[_], ArrayBuffer[MatchAndTransform]] =
+    new collection.mutable.HashMap[Class[_], ArrayBuffer[MatchAndTransform]]
+
+  override def addModification(entityMatch: TypedEntityMatch, modification: EntityTransformStrategy): Unit = {
+    val modifications = getModificationsForType(entityMatch.getType, _modificationsByType)
+    modifications += new MatchAndTransform(entityMatch.getPropertyMatches, modification)
+  }
+
+//  override def getTransformsForType(entityType: Class[_]): ArrayBuffer[MatchAndTransform] = {
+//    _modificationsByType.getOrElse(entityType, ArrayBuffer.empty[MatchAndTransform])
+//  }
+
+  override def run(context: TransformContext, dao: GtfsMutableRelationalDao): Unit = {
+    _modificationsByType.foreach { case (entityType, modifications) =>
+      if (classOf[IdKey].isAssignableFrom(entityType)) {
+        modifications.foreach { pair =>
+          val entityMatch = pair.entityMatch.asInstanceOf[IdKeyMatch]
+          pair.transform.run(context, dao, entityMatch.getKey)
+        }
+      } else {
+        val entities = dao.getAllEntitiesForType(entityType).asScala
+        val futures = entities.map { entity =>
+          Future {
+            modifications.foreach { pair =>
+              if (pair.entityMatch.isApplicableToObject(entity)) {
+                pair.transform.run(context, dao, entity)
+              }
+            }
+          }
+        }
+        Future.sequence(futures).onComplete {
+          case Success(_)         => println("All transformations completed successfully.")
+          case Failure(exception) => println(s"Error occurred: ${exception.getMessage}")
+        }
+      }
+    }
+  }
+
+  private def getModificationsForType(
+    classType: Class[_],
+    m: collection.mutable.Map[Class[_], ArrayBuffer[MatchAndTransform]]
+  ): ArrayBuffer[MatchAndTransform] = m.getOrElseUpdate(classType, new ArrayBuffer[MatchAndTransform]())
+
+  class MatchAndTransform(val entityMatch: EntityMatch, val transform: EntityTransformStrategy)
+}


### PR DESCRIPTION
EntitiesTransformStrategy has two nested loops that generates billions of instructions sequentially upon processing GTFS files. To fix this problem I created ParallelizedEntitiesTransformStrategy that processes the billions of instruction simultaneously, driving down the runtime to few seconds to couple of minutes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3809)
<!-- Reviewable:end -->
