### PR TITLE
Allow emergency vehicles for HOV modes

### DIFF
--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -209,7 +209,7 @@ trait ChoosesMode {
           ) if data.currentTourMode.isEmpty || data.currentTourModeIsIn(CAR, BIKE, DRIVE_TRANSIT, BIKE_TRANSIT) =>
         implicit val executionContext: ExecutionContext = context.system.dispatcher
         data.currentTourMode match {
-          case Some(CAR | DRIVE_TRANSIT) =>
+          case Some(CAR | DRIVE_TRANSIT | CAR_HOV2 | CAR_HOV3) => // TODO: Add HOV modes here too
             requestAvailableVehicles(
               vehicleFleets,
               currentLocation,


### PR DESCRIPTION
When agents are drivers for HOV2 or HOV3 trips, we should also be able to create an emergency vehicle for them if none other are available

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3815)
<!-- Reviewable:end -->
