### PR TITLE
Payload ids and total vehicle weight in the PathTraversal events

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -5,7 +5,8 @@ import akka.actor.{ActorRef, FSM, Props, Stash, Status}
 import beam.agentsim.Resource._
 import beam.agentsim.agents.BeamAgent._
 import beam.agentsim.agents.PersonAgent._
-import beam.agentsim.agents.freight.input.FreightReader.PAYLOAD_WEIGHT_IN_KG
+import beam.agentsim.agents.freight.PayloadPlan
+import beam.agentsim.agents.freight.input.FreightReader.{PAYLOAD_IDS, PAYLOAD_WEIGHT_IN_KG}
 import beam.agentsim.agents.household.HouseholdActor.ReleaseVehicle
 import beam.agentsim.agents.household.HouseholdCAVDriverAgent
 import beam.agentsim.agents.modalbehaviors.ChoosesMode.ChoosesModeData
@@ -369,11 +370,13 @@ class PersonAgent(
   var totFuelConsumed: FuelConsumed = FuelConsumed(0.0, 0.0)
   var curFuelConsumed: FuelConsumed = FuelConsumed(0.0, 0.0)
 
-  override def payloadInKgForLeg(leg: BeamLeg, drivingData: DrivingData): Option[Double] = {
-    drivingData match {
-      case data: BasePersonData => getPayloadWeightFromLeg(data.currentActivityIndex)
-      case _                    => None
-    }
+  override def payloadDataForLeg(
+    beamLeg: BeamLeg,
+    drivingData: DrivingData
+  ): Option[(IndexedSeq[Id[PayloadPlan]], Double)] = drivingData match {
+    case data: BasePersonData if beamLeg.mode == BeamMode.CAR =>
+      getPayloadDataFromPlan(data.currentActivityIndex)
+    case _ => None
   }
 
   def wheelchairUser: Boolean = {
@@ -1596,6 +1599,15 @@ class PersonAgent(
     eventsManager.processEvent(asSkimmerEvent)
   }
 
+  /**
+    * Generates skim data for the finished trip.
+    * @param tick The current tick
+    * @param trip The accomplished trip
+    * @param failedTrip indicaytes if the trips is failed
+    * @param currentActivityIndex the index of activity where this trip starts from
+    * @param currentActivity the activity where this trip started from
+    * @param nextActivity the next activity
+    */
   def generateSkimData(
     tick: Int,
     trip: EmbodiedBeamTrip,
@@ -1607,7 +1619,7 @@ class PersonAgent(
     val correctedTrip = correctTripEndTime(trip, tick, body.id, body.beamVehicleType.id)
     val generalizedTime = modeChoiceCalculator.getGeneralizedTimeOfTrip(correctedTrip, Some(attributes), nextActivity)
     val generalizedCost = modeChoiceCalculator.getNonTimeCost(correctedTrip) + attributes.getVOT(generalizedTime)
-    val maybePayloadWeightInKg = getPayloadWeightFromLeg(currentActivityIndex)
+    val maybePayloadWeightInKg = getPayloadDataFromPlan(currentActivityIndex).map(_._2)
 
     if (maybePayloadWeightInKg.isDefined && correctedTrip.tripClassifier != BeamMode.CAR) {
       logger.error("Wrong trip classifier ({}) for freight {}", correctedTrip.tripClassifier, id)
@@ -1668,7 +1680,7 @@ class PersonAgent(
     val trip = EmbodiedBeamTrip(legs)
     val generalizedTime = modeChoiceCalculator.getGeneralizedTimeOfTrip(trip, Some(attributes), nextActivity)
     val generalizedCost = modeChoiceCalculator.getNonTimeCost(trip) + attributes.getVOT(generalizedTime)
-    val maybePayloadWeightInKg = getPayloadWeightFromLeg(currentActivityIndex)
+    val maybePayloadWeightInKg = getPayloadDataFromPlan(currentActivityIndex).map(_._2)
     val odVehicleTypeEvent = ODVehicleTypeSkimmerEvent(
       tick,
       beamServices,
@@ -1682,12 +1694,17 @@ class PersonAgent(
     eventsManager.processEvent(odVehicleTypeEvent)
   }
 
-  private def getPayloadWeightFromLeg(currentActivityIndex: Int): Option[Double] = {
-    val currentLegIndex = currentActivityIndex * 2 + 1
-    if (currentLegIndex < matsimPlan.getPlanElements.size()) {
-      val accomplishedLeg = matsimPlan.getPlanElements.get(currentLegIndex)
-      Option(accomplishedLeg.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG)).asInstanceOf[Option[Double]]
-    } else None
+  private def getPayloadDataFromPlan(
+    startingActivityIndex: Int
+  ): Option[(IndexedSeq[Id[PayloadPlan]], Double)] = {
+    val currentLegIndex = startingActivityIndex * 2 + 1
+    if (currentLegIndex < matsimPlan.getPlanElements.size()) { // matsim plan may contain only activities
+      val planElement: PlanElement = matsimPlan.getPlanElements.get(currentLegIndex)
+      val payloadIds = planElement.getAttributes.getAttribute(PAYLOAD_IDS).asInstanceOf[IndexedSeq[Id[PayloadPlan]]]
+      val payloadWeight = planElement.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG).asInstanceOf[Double]
+      if (payloadIds != null) Some(payloadIds, payloadWeight) else None
+    } else
+      None
   }
 
   def getReplanningReasonFrom(data: BasePersonData, prefix: String): String = {

--- a/src/main/scala/beam/agentsim/agents/TransitDriverAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/TransitDriverAgent.scala
@@ -114,8 +114,6 @@ class TransitDriverAgent(
 
   override val id: Id[TransitDriverAgent] = transitDriverId
 
-  override def payloadInKgForLeg(leg: BeamLeg, drivingData: DrivingData): Option[Double] = None
-
   val myUnhandled: StateFunction = {
     case Event(TransitReservationRequest(fromIdx, toIdx, passenger, triggerId), data) =>
       val slice = legs.slice(fromIdx, toIdx)

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -45,11 +45,11 @@ trait FreightReader {
   def calculatePayloadWeights(plans: IndexedSeq[PayloadPlan]): IndexedSeq[(Set[Id[PayloadPlan]], Double)] = {
     plans.foldLeft(IndexedSeq((Set.empty[Id[PayloadPlan]], 0.0))) {
       case (acc, PayloadPlan(payloadId, _, _, _, weight, Unloading, _, _, _, _, _, _, _)) =>
-        val (payloads, paloadWeight) = acc.last
-        acc :+ (payloads - payloadId, paloadWeight - weight)
+        val (payloads, payloadWeight) = acc.last
+        acc :+ (payloads - payloadId, payloadWeight - weight)
       case (acc, PayloadPlan(payloadId, _, _, _, weight, Loading, _, _, _, _, _, _, _)) =>
-        val (payloads, paloadWeight) = acc.last
-        acc :+ (payloads + payloadId, paloadWeight + weight)
+        val (payloads, payloadWeight) = acc.last
+        acc :+ (payloads + payloadId, payloadWeight + weight)
     }
   }
 

--- a/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
+++ b/src/main/scala/beam/agentsim/agents/freight/input/FreightReader.scala
@@ -1,7 +1,7 @@
 package beam.agentsim.agents.freight.input
 
 import beam.agentsim.agents.freight.FreightRequestType.{Loading, Unloading}
-import beam.agentsim.agents.freight.input.FreightReader.{FREIGHT_REQUEST_TYPE, PAYLOAD_WEIGHT_IN_KG}
+import beam.agentsim.agents.freight.input.FreightReader.{FREIGHT_REQUEST_TYPE, PAYLOAD_IDS, PAYLOAD_WEIGHT_IN_KG}
 import beam.agentsim.agents.freight.{FreightCarrier, FreightRequestType, FreightTour, PayloadPlan}
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.{BeamVehicle, BeamVehicleType, VehicleManager}
@@ -42,11 +42,14 @@ trait FreightReader {
     vehicleTypes: Map[Id[BeamVehicleType], BeamVehicleType]
   ): IndexedSeq[FreightCarrier]
 
-  def calculatePayloadWeights(plans: IndexedSeq[PayloadPlan]): IndexedSeq[Double] = {
-    val initialWeight = 0.0
-    plans.foldLeft(IndexedSeq(initialWeight)) {
-      case (acc, PayloadPlan(_, _, _, _, weight, Unloading, _, _, _, _, _, _, _)) => acc :+ acc.last - weight
-      case (acc, PayloadPlan(_, _, _, _, weight, Loading, _, _, _, _, _, _, _))   => acc :+ acc.last + weight
+  def calculatePayloadWeights(plans: IndexedSeq[PayloadPlan]): IndexedSeq[(Set[Id[PayloadPlan]], Double)] = {
+    plans.foldLeft(IndexedSeq((Set.empty[Id[PayloadPlan]], 0.0))) {
+      case (acc, PayloadPlan(payloadId, _, _, _, weight, Unloading, _, _, _, _, _, _, _)) =>
+        val (payloads, paloadWeight) = acc.last
+        acc :+ (payloads - payloadId, paloadWeight - weight)
+      case (acc, PayloadPlan(payloadId, _, _, _, weight, Loading, _, _, _, _, _, _, _)) =>
+        val (payloads, paloadWeight) = acc.last
+        acc :+ (payloads + payloadId, paloadWeight + weight)
     }
   }
 
@@ -75,11 +78,12 @@ trait FreightReader {
       }
 
       val elements = tourInitialActivity +: firstLeg +: planElements
-      val weightsToCarry: IndexedSeq[Double] = calculatePayloadWeights(plans)
+      val weightsToCarry: IndexedSeq[(Set[Id[PayloadPlan]], Double)] = calculatePayloadWeights(plans)
       elements
         .collect { case leg: Leg => leg }
         .zip(weightsToCarry)
-        .foreach { case (leg, payloadWeight) =>
+        .foreach { case (leg, (payloadIds, payloadWeight)) =>
+          leg.getAttributes.putAttribute(PAYLOAD_IDS, payloadIds.toIndexedSeq)
           leg.getAttributes.putAttribute(PAYLOAD_WEIGHT_IN_KG, payloadWeight)
         }
       elements
@@ -168,6 +172,7 @@ object FreightReader {
   val FREIGHT_ID_PREFIX = "freight"
   val FREIGHT_REQUEST_TYPE = "FreightRequestType"
   val PAYLOAD_WEIGHT_IN_KG = "PayloadWeightInKg"
+  val PAYLOAD_IDS = "PayloadIds"
 
   def apply(
     beamConfig: BeamConfig,

--- a/src/main/scala/beam/agentsim/agents/household/HouseholdCAVDriverAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/household/HouseholdCAVDriverAgent.scala
@@ -42,8 +42,6 @@ class HouseholdCAVDriverAgent(
 
   override val id: Id[HouseholdCAVDriverAgent] = driverId
 
-  override def payloadInKgForLeg(leg: BeamLeg, drivingData: DrivingData): Option[Double] = None
-
   val myUnhandled: StateFunction = {
     case Event(IllegalTriggerGoToError(reason), _) =>
       stop(Failure(reason))

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/DrivesVehicle.scala
@@ -4,6 +4,7 @@ import akka.actor.FSM.Failure
 import akka.actor.{ActorRef, Stash}
 import beam.agentsim.Resource.{NotifyVehicleIdle, ReleaseParkingStall}
 import beam.agentsim.agents.PersonAgent._
+import beam.agentsim.agents.freight.PayloadPlan
 import beam.agentsim.agents.modalbehaviors.DrivesVehicle._
 import beam.agentsim.agents.parking.ChoosesParking.{handleUseParkingSpot, ConnectingToChargingPoint}
 import beam.agentsim.agents.ridehail.RideHailAgent._
@@ -40,7 +41,6 @@ import org.matsim.api.core.v01.events.{
 }
 import org.matsim.api.core.v01.population.Person
 import org.matsim.core.api.experimental.events.EventsManager
-import org.matsim.core.utils.misc.Time
 import org.matsim.vehicles.Vehicle
 
 import scala.collection.{immutable, mutable}
@@ -184,8 +184,14 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
   protected val beamServices: BeamServices
   protected val networkHelper: NetworkHelper
   protected val geo: GeoUtils
-  //we may want to rename this method and make it return more data in the future if we want to improve energy rate calc
-  def payloadInKgForLeg(leg: BeamLeg, drivingData: DrivingData): Option[Double]
+
+  /**
+    * This method is supposed to be implemented only for Freight agents. It's called at the end of each leg.
+    * @param drivingData the driving data
+    * @return list of payload ids and total payload weight in case this vehicle carry any payloads.
+    */
+  def payloadDataForLeg(beamLeg: BeamLeg, drivingData: DrivingData): Option[(IndexedSeq[Id[PayloadPlan]], Double)] =
+    None
   private var tollsAccumulated = 0.0
   protected val beamVehicles: mutable.Map[Id[BeamVehicle], VehicleOrToken] = mutable.Map()
   protected val potentiallyChargingBeamVehicles: mutable.Map[Id[BeamVehicle], VehicleOrToken] = mutable.Map()
@@ -247,11 +253,11 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
       val currentVehicleUnderControl = data.currentVehicle.headOption
         .getOrElse(throw new RuntimeException("Current Vehicle is not available."))
       val isLastLeg = data.currentLegPassengerScheduleIndex + 1 == data.passengerSchedule.schedule.size
-      val payloadInKg = payloadInKgForLeg(currentLeg, data)
+      val payloadData = payloadDataForLeg(currentLeg, data)
       val fuelConsumed =
         currentBeamVehicle.useFuel(
           currentLeg,
-          payloadInKg,
+          payloadData.map { case (_, payloadWeight) => payloadWeight },
           beamScenario,
           networkHelper,
           eventsManager,
@@ -336,6 +342,7 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
 
       val numberOfPassengers: Int = calculateNumberOfPassengersBasedOnCurrentTourMode(data, currentLeg, riders)
       val currentTourMode: Option[String] = getCurrentTourMode(data)
+      val (payloadIds, payloadWeight) = payloadData.getOrElse((IndexedSeq.empty, 0.0))
       val pte = PathTraversalEvent(
         tick,
         currentVehicleUnderControl,
@@ -349,6 +356,8 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
         currentBeamVehicle.primaryFuelLevelInJoules,
         currentBeamVehicle.secondaryFuelLevelInJoules,
         tollOnCurrentLeg,
+        payloadIds,
+        currentBeamVehicle.beamVehicleType.curbWeightInKg + payloadWeight,
         riders
       )
 
@@ -545,13 +554,13 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
       val updatedStopTick = math.max(stopTick, currentLeg.startTime)
       val partiallyCompletedBeamLeg = currentLeg.subLegThrough(updatedStopTick, networkHelper, geo)
       val riders = data.passengerSchedule.schedule(currentLeg).riders.toIndexedSeq.map(_.personId)
-      val payloadInKg = payloadInKgForLeg(currentLeg, data)
+      val payloadData = payloadDataForLeg(currentLeg, data)
 
       val currentLocation = if (updatedStopTick > currentLeg.startTime) {
         val fuelConsumed =
           currentBeamVehicle.useFuel(
             partiallyCompletedBeamLeg,
-            payloadInKg,
+            payloadData.map { case (_, payloadWeight) => payloadWeight },
             beamScenario,
             networkHelper,
             eventsManager,
@@ -564,6 +573,7 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
         val numberOfPassengers: Int =
           calculateNumberOfPassengersBasedOnCurrentTourMode(data, partiallyCompletedBeamLeg, riders)
         val currentTourMode: Option[String] = getCurrentTourMode(data)
+        val (payloadIds, payloadWeight) = payloadData.getOrElse((IndexedSeq.empty, 0.0))
         val pte = PathTraversalEvent(
           updatedStopTick,
           currentVehicleUnderControl,
@@ -577,6 +587,8 @@ trait DrivesVehicle[T <: DrivingData] extends BeamAgent[T] with Stash with Expon
           currentBeamVehicle.primaryFuelLevelInJoules,
           currentBeamVehicle.secondaryFuelLevelInJoules,
           tollOnCurrentLeg,
+          payloadIds,
+          currentBeamVehicle.beamVehicleType.curbWeightInKg + payloadWeight,
           riders
         )
         eventsManager.processEvent(pte)

--- a/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/ridehail/RideHailAgent.scala
@@ -228,8 +228,6 @@ class RideHailAgent(
     1
   )
 
-  override def payloadInKgForLeg(leg: BeamLeg, drivingData: DrivingData): Option[Double] = None
-
   val myUnhandled: StateFunction = {
     case ev @ Event(TriggerWithId(StartShiftTrigger(tick), triggerId), _) =>
       // Wait five minutes

--- a/src/main/scala/beam/agentsim/events/PathTraversalEvent.scala
+++ b/src/main/scala/beam/agentsim/events/PathTraversalEvent.scala
@@ -229,10 +229,7 @@ object PathTraversalEvent {
     val endLegPrimaryFuelLevel: Double = attr(ATTRIBUTE_END_LEG_PRIMARY_FUEL_LEVEL).toDouble
     val endLegSecondaryFuelLevel: Double = attr(ATTRIBUTE_END_LEG_SECONDARY_FUEL_LEVEL).toDouble
     val amountPaid: Double = attr(ATTRIBUTE_TOLL_PAID).toDouble
-    val payloadIds: IndexedSeq[Id[PayloadPlan]] = attr
-      .getOrElse(ATTRIBUTE_PAYLOAD_IDS, "")
-      .split(',')
-      .map(_.createId[PayloadPlan])
+    val payloadIds: IndexedSeq[Id[PayloadPlan]] = payloadsFromStr(attr.getOrElse(ATTRIBUTE_PAYLOAD_IDS, ""))
     val weight: Double = attr.get(ATTRIBUTE_WEIGHT).fold(0.0)(_.toDouble)
     val riders: IndexedSeq[Id[Person]] = ridersFromStr(attr.getOrElse(ATTRIBUTE_RIDERS, ""))
     val fromStopIndex: Option[Int] =
@@ -281,6 +278,11 @@ object PathTraversalEvent {
     } else {
       ridersStr.split(":").toIndexedSeq.map(Id.create(_, classOf[Person]))
     }
+  }
+
+  def payloadsFromStr(str: String): IndexedSeq[Id[PayloadPlan]] = {
+    if (str.isEmpty) IndexedSeq.empty
+    else str.split(',').map(_.createId[PayloadPlan])
   }
 
   def ridersToStr(riders: IndexedSeq[Id[Person]]): String = {

--- a/src/main/scala/beam/utils/matsim_conversion/MatsimPlanConversion.scala
+++ b/src/main/scala/beam/utils/matsim_conversion/MatsimPlanConversion.scala
@@ -1,6 +1,7 @@
 package beam.utils.matsim_conversion
 
 import org.matsim.api.core.v01.Id
+import org.matsim.utils.objectattributes.attributable.Attributes
 
 import java.io.{FileOutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
@@ -214,6 +215,10 @@ object MatsimPlanConversion {
   implicit class IdOps(val id: String) extends AnyVal {
     import scala.reflect.classTag
     def createId[T: ClassTag]: Id[T] = Id.create(id, classTag[T].runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  implicit class AttributesOps(val attributes: Attributes) extends AnyVal {
+    def typedValue[T: ClassTag](attribute: String): T = attributes.getAttribute(attribute).asInstanceOf[T]
   }
 
 }

--- a/src/main/scala/beam/utils/matsim_conversion/MatsimPlanConversion.scala
+++ b/src/main/scala/beam/utils/matsim_conversion/MatsimPlanConversion.scala
@@ -218,7 +218,7 @@ object MatsimPlanConversion {
   }
 
   implicit class AttributesOps(val attributes: Attributes) extends AnyVal {
-    def typedValue[T: ClassTag](attribute: String): T = attributes.getAttribute(attribute).asInstanceOf[T]
+    def typedValue[T](attribute: String): T = attributes.getAttribute(attribute).asInstanceOf[T]
   }
 
 }

--- a/src/test/scala/beam/agentsim/agents/freight/WeightAndPayloadIdsSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/freight/WeightAndPayloadIdsSpec.scala
@@ -1,0 +1,77 @@
+package beam.agentsim.agents.freight
+
+import beam.agentsim.events.PathTraversalEvent
+import beam.sim.BeamHelper
+import beam.utils.EventReader
+import beam.utils.TestConfigUtils.testConfig
+import beam.utils.matsim_conversion.MatsimPlanConversion.IdOps
+import com.typesafe.config.ConfigFactory
+import org.scalatest.AppendedClues.convertToClueful
+import org.scalatest.Inspectors.forAll
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class WeightAndPayloadIdsSpec extends AnyWordSpecLike with Matchers with BeamHelper {
+
+  private val baseConf = ConfigFactory
+    .parseString("""
+        beam.agentsim.lastIteration = 0
+        beam.agentsim.agents.freight.plansFilePath = "test/test-resources/beam/agentsim/freight/payload-plans.csv"
+        beam.agentsim.agents.freight.toursFilePath = "test/test-resources/beam/agentsim/freight/freight-tours.csv"
+        beam.agentsim.agents.freight.carriersFilePath = "test/test-resources/beam/agentsim/freight/freight-carriers.csv"
+          """)
+    .withFallback(testConfig("test/input/beamville/beam-freight.conf"))
+    .resolve()
+
+  val (matsimConfig, _, _) = runBeamWithConfig(baseConf)
+  "Beam" when {
+    "simulates freight with payload plans " must {
+      "put payload ids and weights to PTE events" in {
+
+        val filePath = EventReader.getEventsFilePath(matsimConfig, "events", "xml").getAbsolutePath
+        val events = EventReader.fromXmlFile(filePath)
+        val freight1: IndexedSeq[PathTraversalEvent] = events.collect {
+          case pte: PathTraversalEvent if pte.driverId == "freightDriver-1" => pte
+        }
+        // freight 1 has 2 tours: 2 and 3
+        // tour-2: 2 payloads (3, 4) of 1300 kg
+        // tour-3: 3 payloads (5, 6, 7) of 1300, 1500 kg
+        // the curb weight of the vehicle is 2200 kg
+
+        // make sure that no walk pte carries a payload
+        val walkPtes = freight1.filter(_.vehicleType == "BODY-TYPE-DEFAULT")
+        walkPtes should have size 14
+        forAll(walkPtes) { pte =>
+          pte.weight shouldBe 70
+        } withClue "weight of person body defined in vehicleTypes.csv is 70 kg"
+        forAll(walkPtes) { pte => pte.payloadIds shouldBe empty } withClue "person should not carry any payloads"
+
+        //make sure each freight leg has 2 pte with the same payloads
+        val freightPtes = freight1.filter(_.vehicleType == "FREIGHT-1")
+        freightPtes should have size 14
+        forAll(freightPtes.grouped(2).toList) { case Seq(pte1, pte2) =>
+          pte1.payloadIds shouldBe pte2.payloadIds
+          pte1.weight shouldBe pte2.weight
+        }
+        freightPtes(0).payloadIds shouldBe empty
+        freightPtes(0).weight shouldBe 2200
+        freightPtes(2).payloadIds shouldBe IndexedSeq("payload-3").map(_.createId[PayloadPlan])
+        freightPtes(2).weight shouldBe 2200 + 1300
+        freightPtes(4).payloadIds shouldBe IndexedSeq("payload-3", "payload-4").map(_.createId[PayloadPlan])
+        freightPtes(4).weight shouldBe 2200 + 2 * 1300
+        freightPtes(6).payloadIds shouldBe empty
+        freightPtes(6).weight shouldBe 2200
+        freightPtes(8).payloadIds shouldBe IndexedSeq("payload-5").map(_.createId[PayloadPlan])
+        freightPtes(8).weight shouldBe 2200 + 1300
+        freightPtes(10).payloadIds shouldBe IndexedSeq("payload-5", "payload-6").map(_.createId[PayloadPlan])
+        freightPtes(10).weight shouldBe 2200 + 1300 + 1500
+        freightPtes(12).payloadIds shouldBe IndexedSeq("payload-5", "payload-6", "payload-7").map(
+          _.createId[PayloadPlan]
+        )
+        freightPtes(12).weight shouldBe 2200 + 1300 + 2 * 1500
+      }
+    }
+  }
+
+}

--- a/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/freight/input/GenericFreightReaderSpec.scala
@@ -1,19 +1,21 @@
 package beam.agentsim.agents.freight.input
 
 import beam.agentsim.agents.freight._
+import beam.agentsim.agents.freight.input.FreightReader.{PAYLOAD_IDS, PAYLOAD_WEIGHT_IN_KG}
 import beam.agentsim.infrastructure.taz.TAZTreeMap
 import beam.sim.BeamHelper
 import beam.sim.common.GeoUtils
 import beam.sim.config.BeamConfig.Beam.Agentsim.Agents.Freight
 import beam.utils.BeamVehicleUtils
 import beam.utils.SnapCoordinateUtils.SnapLocationHelper
-import beam.utils.matsim_conversion.MatsimPlanConversion.IdOps
-import org.matsim.api.core.v01.population.{Activity, Person, Plan, PopulationFactory}
+import beam.utils.matsim_conversion.MatsimPlanConversion.{AttributesOps, IdOps}
+import org.matsim.api.core.v01.population.{Activity, Leg, Person, Plan, PopulationFactory}
 import org.matsim.api.core.v01.{Coord, Id}
 import org.matsim.households.{Household, HouseholdImpl, HouseholdsFactory}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.when
+import org.scalatest.LoneElement.convertToCollectionLoneElementWrapper
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -186,6 +188,23 @@ class GenericFreightReaderSpec extends AnyWordSpecLike with Matchers with BeamHe
       plan1.getPlanElements.get(2).asInstanceOf[Activity].getCoord should be(
         new Coord(169567.3017564815, 836.6518909569604)
       )
+      val leg1 = plan1.getPlanElements.get(1).asInstanceOf[Leg]
+      leg1.getAttributes.typedValue[Seq[Id[PayloadPlan]]](PAYLOAD_IDS) shouldBe empty
+      leg1.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG) shouldBe 0.0
+      val leg2 = plan1.getPlanElements.get(3).asInstanceOf[Leg]
+      leg2.getAttributes.typedValue[Seq[Id[PayloadPlan]]](PAYLOAD_IDS).loneElement shouldBe "payload-3"
+        .createId[PayloadPlan]
+      leg2.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG) shouldBe 1300.0
+      val leg7 = plan1.getPlanElements.get(7).asInstanceOf[Leg]
+      leg7.getAttributes.typedValue[Seq[Id[PayloadPlan]]](PAYLOAD_IDS) shouldBe empty
+      leg7.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG) shouldBe 0.0
+      val leg13 = plan1.getPlanElements.get(13).asInstanceOf[Leg]
+      leg13.getAttributes.typedValue[Seq[Id[PayloadPlan]]](PAYLOAD_IDS) should contain theSameElementsInOrderAs Seq(
+        "payload-5",
+        "payload-6",
+        "payload-7"
+      ).map(_.createId[PayloadPlan])
+      leg13.getAttributes.getAttribute(PAYLOAD_WEIGHT_IN_KG) shouldBe 4300.0
       plan1.getPlanElements.get(12).asInstanceOf[Activity].getCoord should be(
         new Coord(169576.80444138843, 3380.0075111142937)
       )

--- a/src/test/scala/beam/analysis/SimpleRideHailUtilizationTest.scala
+++ b/src/test/scala/beam/analysis/SimpleRideHailUtilizationTest.scala
@@ -36,6 +36,8 @@ class SimpleRideHailUtilizationTest extends AnyFunSuite with Matchers {
     None,
     None,
     None,
+    IndexedSeq.empty,
+    0.0,
     riders = Vector()
   )
 

--- a/src/test/scala/beam/analysis/cartraveltime/StudyAreaTripFilterTest.scala
+++ b/src/test/scala/beam/analysis/cartraveltime/StudyAreaTripFilterTest.scala
@@ -59,6 +59,8 @@ class StudyAreaTripFilterTest extends AnyFunSuite with Matchers {
     endLegPrimaryFuelLevel = 1.0,
     endLegSecondaryFuelLevel = 0.0,
     amountPaid = 0,
+    IndexedSeq.empty,
+    0.0,
     Vector.empty
   )
 

--- a/src/test/scala/beam/sim/output/IterationsPassengerPerTripTests.scala
+++ b/src/test/scala/beam/sim/output/IterationsPassengerPerTripTests.scala
@@ -272,6 +272,8 @@ class IterationsPassengerPerTripTests extends AnyWordSpecLike with Matchers with
       None,
       None,
       None,
+      IndexedSeq.empty,
+      0.0,
       null
     )
   }


### PR DESCRIPTION
Freight reader puts payload ids and weight to the person plan basing on the payload plans.
Then this data gets to PathTraversal events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3902)
<!-- Reviewable:end -->
