### PR TITLE
Router performance improvements

### DIFF
--- a/src/main/java/beam/utils/TravelTimeCalculatorHelper.java
+++ b/src/main/java/beam/utils/TravelTimeCalculatorHelper.java
@@ -1,5 +1,6 @@
 package beam.utils;
 
+import beam.router.BeamTravelTime;
 import beam.utils.logging.ExponentialLoggerWrapperImpl;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -12,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 public class TravelTimeCalculatorHelper {
-    public static class TravelTimePerHour implements TravelTime {
+    public static class TravelTimePerHour implements BeamTravelTime {
         private final Logger log = LoggerFactory.getLogger(TravelTimePerHour.class);
 
         private final double[][] _linkIdToTravelTimeArray;
@@ -25,13 +26,12 @@ public class TravelTimeCalculatorHelper {
         }
 
         @Override
-        public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
-            final int linkId = Integer.parseInt(link.getId().toString());
+        public double getLinkTravelTime(int linkId, double time) {
             if (linkId < 0 || linkId >= _linkIdToTravelTimeArray.length || _linkIdToTravelTimeArray[linkId] == null) {
                 if (ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)) {
                     log.warn("Invalid linkId {} or missing travel time data", linkId);
                 }
-                return link.getLength() / link.getFreespeed(); // Calculate travel time directly
+                return 0d; // Calculate travel time directly
             }
             double[] timePerHour = _linkIdToTravelTimeArray[linkId];
             int idx = getOffset(time);
@@ -40,9 +40,15 @@ public class TravelTimeCalculatorHelper {
                     log.warn("Got offset which is out of array for the link {}. Something wrong. idx: {}, time: {},  _timeBinSizeInSeconds: '{}'",
                             linkId, idx, time, _timeBinSizeInSeconds);
                 }
-                return link.getLength() / link.getFreespeed();
+                return 0d;
             }
             return timePerHour[idx];
+        }
+
+        @Override
+        public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
+            final int linkId = Integer.parseInt(link.getId().toString());
+            return getLinkTravelTime(linkId, time);
         }
 
         private int getOffset(double time) {
@@ -64,6 +70,11 @@ public class TravelTimeCalculatorHelper {
                 linkIdToTravelTimeArray[idx] = value.clone();
             });
             return linkIdToTravelTimeArray;
+        }
+
+        @Override
+        public double getLinkTravelTime(int linkId, double time, double linkLengthMeters) {
+            return getLinkTravelTime(linkId, time);
         }
     }
 
@@ -117,7 +128,7 @@ public class TravelTimeCalculatorHelper {
         return result;
     }
 
-    public static TravelTime CreateTravelTimeCalculator(int timeBinSizeInSeconds, Map<String, double[]> linkIdToTravelTimeData) {
+    public static BeamTravelTime CreateTravelTimeCalculator(int timeBinSizeInSeconds, Map<String, double[]> linkIdToTravelTimeData) {
         return new TravelTimePerHour(timeBinSizeInSeconds, linkIdToTravelTimeData);
     }
 }

--- a/src/main/java/beam/utils/TravelTimeCalculatorHelper.java
+++ b/src/main/java/beam/utils/TravelTimeCalculatorHelper.java
@@ -23,35 +23,30 @@ public class TravelTimeCalculatorHelper {
             _timeBinSizeInSeconds = timeBinSizeInSeconds;
             _linkIdToTravelTimeArray = initTravelTime(linkIdToTravelTimeData);
         }
+
         @Override
         public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
             final int linkId = Integer.parseInt(link.getId().toString());
-            if (linkId >= _linkIdToTravelTimeArray.length) {
-                if(ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)){
-                    log.warn("Got linkId {} which is out of `_linkIdToTravelTimeArray` array with length {}", linkId, _linkIdToTravelTimeArray.length);
+            if (linkId < 0 || linkId >= _linkIdToTravelTimeArray.length || _linkIdToTravelTimeArray[linkId] == null) {
+                if (ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)) {
+                    log.warn("Invalid linkId {} or missing travel time data", linkId);
                 }
-                return link.getFreespeed();
+                return link.getLength() / link.getFreespeed(); // Calculate travel time directly
             }
-
             double[] timePerHour = _linkIdToTravelTimeArray[linkId];
-            if (null == timePerHour){
-                if(ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)){
-                    log.warn("Can't find travel times for link '{}'", linkId);
-                }
-                return link.getFreespeed();
-            }
             int idx = getOffset(time);
             if (idx >= timePerHour.length) {
-                if(ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)) {
+                if (ExponentialLoggerWrapperImpl.isNumberPowerOfTwo(++numWarnings)) {
                     log.warn("Got offset which is out of array for the link {}. Something wrong. idx: {}, time: {},  _timeBinSizeInSeconds: '{}'",
                             linkId, idx, time, _timeBinSizeInSeconds);
                 }
-                return link.getFreespeed();
+                return link.getLength() / link.getFreespeed();
             }
             return timePerHour[idx];
         }
-        private int getOffset(double time){
-            return (int)Math.round(Math.floor(time / _timeBinSizeInSeconds));
+
+        private int getOffset(double time) {
+            return (int) (time / _timeBinSizeInSeconds);
         }
 
         public static double[][] initTravelTime(final Map<String, double[]> linkIdToTravelTimeData) {
@@ -71,6 +66,7 @@ public class TravelTimeCalculatorHelper {
             return linkIdToTravelTimeArray;
         }
     }
+
     private static final Logger log = LoggerFactory.getLogger(TravelTimeCalculatorHelper.class);
 
     public static Map<String, double[]> GetLinkIdToTravelTimeArray(Collection<? extends Link> links, TravelTime travelTime, int maxHour) {

--- a/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
+++ b/src/main/scala/beam/agentsim/agents/vehicles/BeamVehicleType.scala
@@ -91,17 +91,18 @@ object VehicleCategory {
       case exception: Exception => throw new RuntimeException(f"Can not parse vehicle category: '$value'.", exception)
     }
 
+  val values: Vector[VehicleCategory] = Vector(
+    Body,
+    Bike,
+    Car,
+    MediumDutyPassenger,
+    Class2b3Vocational,
+    Class456Vocational,
+    Class78Vocational,
+    Class78Tractor
+  )
+
   private def fromStringOptional(value: String): Option[VehicleCategory] = {
-    Vector(
-      Body,
-      Bike,
-      Car,
-      MediumDutyPassenger,
-      Class2b3Vocational,
-      Class456Vocational,
-      Class78Vocational,
-      Class78Tractor
-    )
-      .find(_.toString.equalsIgnoreCase(value))
+    values.find(_.toString.equalsIgnoreCase(value))
   }
 }

--- a/src/main/scala/beam/router/BeamTravelTime.scala
+++ b/src/main/scala/beam/router/BeamTravelTime.scala
@@ -1,0 +1,71 @@
+package beam.router
+
+import beam.utils.NetworkHelper
+import org.matsim.api.core.v01.network.Link
+import org.matsim.api.core.v01.population.Person
+import org.matsim.core.router.util.TravelTime
+import org.matsim.vehicles.Vehicle
+
+/**
+  * Extension of MATSim's TravelTime interface that adds methods for more efficient
+  * travel time lookups using integer link IDs directly.
+  */
+trait BeamTravelTime extends TravelTime {
+
+  /**
+    * Get travel time using integer link ID directly.
+    * This avoids the overhead of Link object lookups and string parsing.
+    */
+  def getLinkTravelTime(linkId: Int, time: Double): Double
+
+  /**
+    * Optional method that can also accept pre-computed link length for further optimization.
+    */
+  def getLinkTravelTime(linkId: Int, time: Double, linkLengthMeters: Double): Double =
+    getLinkTravelTime(linkId, time)
+}
+
+/**
+  * Free flow travel time implementation optimized for direct integer ID access.
+  */
+class BeamFreeFlowTravelTime(networkHelper: NetworkHelper) extends BeamTravelTime {
+
+  // Cache link lengths for faster access
+  private val linkLengths: Array[Double] = {
+    val maxLinkId = networkHelper.allLinks.map(link => Integer.parseInt(link.getId.toString)).max
+
+    val lengths = new Array[Double](maxLinkId + 1)
+    networkHelper.allLinks.foreach { link =>
+      val id = Integer.parseInt(link.getId.toString)
+      lengths(id) = link.getLength
+    }
+    lengths
+  }
+
+  // Cache link free speeds for faster access
+  private val linkFreeSpeeds: Array[Double] = {
+    val maxLinkId = networkHelper.allLinks.map(link => Integer.parseInt(link.getId.toString)).max
+
+    val speeds = new Array[Double](maxLinkId + 1)
+    networkHelper.allLinks.foreach { link =>
+      val id = Integer.parseInt(link.getId.toString)
+      speeds(id) = link.getFreespeed
+    }
+    speeds
+  }
+
+  // Original MATSim interface method
+  override def getLinkTravelTime(link: Link, time: Double, person: Person, vehicle: Vehicle): Double = {
+    link.getLength / link.getFreespeed
+  }
+
+  // Optimized method using integer ID
+  override def getLinkTravelTime(linkId: Int, time: Double): Double = {
+    linkLengths(linkId) / linkFreeSpeeds(linkId)
+  }
+
+  // Further optimized method with pre-computed length
+  override def getLinkTravelTime(linkId: Int, time: Double, linkLengthMeters: Double): Double = {
+    linkLengthMeters / linkFreeSpeeds(linkId)
+  }
+}

--- a/src/main/scala/beam/router/LinkTravelTimeContainer.scala
+++ b/src/main/scala/beam/router/LinkTravelTimeContainer.scala
@@ -14,13 +14,13 @@ import scala.collection.mutable
 import scala.util.Try
 
 class LinkTravelTimeContainer(fileName: String, timeBinSizeInSeconds: Int, maxHour: Int)
-    extends TravelTime
+    extends BeamTravelTime
     with LazyLogging {
 
-  private val travelTimeCalculator: TravelTime =
+  private val travelTimeCalculator: BeamTravelTime =
     TravelTimeCalculatorHelper.CreateTravelTimeCalculator(timeBinSizeInSeconds, loadLinkStats().asJava)
 
-  def loadLinkStats(): scala.collection.Map[String, Array[Double]] = {
+  private def loadLinkStats(): scala.collection.Map[String, Array[Double]] = {
     val start = System.currentTimeMillis()
     val linkTravelTimeMap: mutable.HashMap[String, Array[Double]] = mutable.HashMap()
     logger.info(s"Stats fileName [$fileName] is being loaded")
@@ -58,4 +58,11 @@ class LinkTravelTimeContainer(fileName: String, timeBinSizeInSeconds: Int, maxHo
     travelTimeCalculator.getLinkTravelTime(link, time, person, vehicle)
   }
 
+  /**
+    * Get travel time using integer link ID directly.
+    * This avoids the overhead of Link object lookups and string parsing.
+    */
+  def getLinkTravelTime(linkId: Int, time: Double): Double = {
+    travelTimeCalculator.getLinkTravelTime(linkId, time)
+  }
 }

--- a/src/main/scala/beam/router/RoutingWorker.scala
+++ b/src/main/scala/beam/router/RoutingWorker.scala
@@ -83,17 +83,20 @@ class RoutingWorker(workerParams: R5Parameters, networks2: Option[(TransportNetw
 
   private var r5: R5Wrapper = new R5Wrapper(
     workerParams,
-    new FreeFlowTravelTime,
+    new BeamFreeFlowTravelTime(networkHelper = workerParams.networkHelper),
     workerParams.beamConfig.beam.routing.r5.travelTimeNoiseFraction
   )
 
   private var secondR5: Option[R5Wrapper] = for {
     (transportNetwork, network) <- networks2
-  } yield new R5Wrapper(
-    workerParams.copy(transportNetwork = transportNetwork, networkHelper = new NetworkHelperImpl(network)),
-    new FreeFlowTravelTime,
-    workerParams.beamConfig.beam.routing.r5.travelTimeNoiseFraction
-  )
+  } yield {
+    val networkHelperImpl = new NetworkHelperImpl(network)
+    new R5Wrapper(
+      workerParams.copy(transportNetwork = transportNetwork, networkHelper = networkHelperImpl),
+      new BeamFreeFlowTravelTime(networkHelperImpl),
+      workerParams.beamConfig.beam.routing.r5.travelTimeNoiseFraction
+    )
+  }
 
   private val graphHopperDir: String = Paths.get(workerParams.beamConfig.beam.inputDirectory, "graphhopper").toString
   private val carGraphHopperDir: String = Paths.get(graphHopperDir, "car").toString

--- a/src/main/scala/beam/router/r5/BikeLanesAdjustment.scala
+++ b/src/main/scala/beam/router/r5/BikeLanesAdjustment.scala
@@ -26,6 +26,10 @@ class BikeLanesAdjustment @Inject() (bikeLanesData: BikeLanesData) {
     }
   }
 
+  def bikeScaleFactor(linkId: LinkId): Double = {
+    scaleFactor(linkId)
+  }
+
   def scaleFactor(vehicleType: BeamVehicleType, linkId: LinkId): Double = {
     if (vehicleType.vehicleCategory == VehicleCategory.Bike) {
       scaleFactor(linkId)

--- a/src/main/scala/beam/router/r5/CarWeightCalculator.scala
+++ b/src/main/scala/beam/router/r5/CarWeightCalculator.scala
@@ -1,6 +1,8 @@
 package beam.router.r5
 
+import beam.router.BeamTravelTime
 import org.matsim.core.router.util.TravelTime
+
 import java.util.concurrent.ThreadLocalRandom
 
 class CarWeightCalculator(workerParams: R5Parameters, travelTimeNoiseFraction: Double = 0d) {
@@ -32,14 +34,27 @@ class CarWeightCalculator(workerParams: R5Parameters, travelTimeNoiseFraction: D
     val lengthM =
       if (edgeLength > 0) edgeLength
       else {
-        transportNetwork.streetLayer.edgeStore.getCursor(linkId).getLengthM
+        transportNetwork.streetLayer.edgeStore.lengths_mm.get(linkId / 2) / 1000.0
       }
 
     // Pre-compute these values once
     val maxTravelTime = lengthM / minSpeed
     val minTravelTime = lengthM / maxSpeed
 
-    val physSimTravelTime = travelTime.getLinkTravelTime(link, time, null, null)
+    // Get travel time - use optimized method if available
+    val physSimTravelTime = travelTime match {
+      case beamTT: BeamTravelTime =>
+        // Use the optimized method with pre-computed length
+        beamTT.getLinkTravelTime(linkId, time, lengthM)
+      case _ =>
+        // Fall back to the original method
+        val link = networkHelper.getLinkUnsafe(linkId)
+        if (link == null) {
+          lengthM / maxSpeed // Default to free flow if link not found
+        } else {
+          travelTime.getLinkTravelTime(link, time, null, null)
+        }
+    }
 
     // Generate noise only if needed
     val physSimTravelTimeWithNoise =

--- a/src/main/scala/beam/router/r5/CarWeightCalculator.scala
+++ b/src/main/scala/beam/router/r5/CarWeightCalculator.scala
@@ -1,11 +1,7 @@
 package beam.router.r5
 
-import beam.agentsim.agents.vehicles.BeamVehicleType
 import org.matsim.core.router.util.TravelTime
-
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicInteger
-import scala.util.Try
 
 class CarWeightCalculator(workerParams: R5Parameters, travelTimeNoiseFraction: Double = 0d) {
   private val networkHelper = workerParams.networkHelper
@@ -14,49 +10,47 @@ class CarWeightCalculator(workerParams: R5Parameters, travelTimeNoiseFraction: D
   val maxFreeSpeed: Double = networkHelper.allLinks.map(_.getFreespeed).max
   private val minSpeed = workerParams.beamConfig.beam.physsim.minCarSpeedInMetersPerSecond
 
-  private val noiseIdx: AtomicInteger = new AtomicInteger(0)
-
-  private val travelTimeNoises: Array[Double] = if (travelTimeNoiseFraction.equals(0d)) {
-    Array.empty
-  } else {
-    Array.fill(1000000) {
-      ThreadLocalRandom.current().nextDouble(1 - travelTimeNoiseFraction, 1 + travelTimeNoiseFraction)
-    }
-  }
+  // Pre-compute noise bounds for faster generation
+  private val noiseLowerBound = 1 - travelTimeNoiseFraction
+  private val noiseUpperBound = 1 + travelTimeNoiseFraction
 
   def calcTravelTime(linkId: Int, travelTime: TravelTime, time: Double): Double = {
-    calcTravelTime(linkId, travelTime, None, time, shouldAddNoise = false)
+    calcTravelTime(linkId, travelTime, maxFreeSpeed, time, shouldAddNoise = false)
   }
 
   def calcTravelTime(
     linkId: Int,
     travelTime: TravelTime,
-    vehicleType: Option[BeamVehicleType],
+    maxSpeed: Double,
     time: Double,
-    shouldAddNoise: Boolean
+    shouldAddNoise: Boolean,
+    edgeLength: Double = -1 // Allow passing pre-computed edge length
   ): Double = {
     val link = networkHelper.getLinkUnsafe(linkId)
     assert(link != null)
-    val edge = transportNetwork.streetLayer.edgeStore.getCursor(linkId)
-    val maxTravelTime = edge.getLengthM / minSpeed
-    val maxSpeed: Double = vehicleType match {
-      case Some(vType) => vType.maxVelocity.getOrElse(maxFreeSpeed)
-      case None        => maxFreeSpeed
-    }
+    // Use provided edge length if available, otherwise look it up
+    val lengthM =
+      if (edgeLength > 0) edgeLength
+      else {
+        transportNetwork.streetLayer.edgeStore.getCursor(linkId).getLengthM
+      }
 
-    val minTravelTime = edge.getLengthM / maxSpeed
+    // Pre-compute these values once
+    val maxTravelTime = lengthM / minSpeed
+    val minTravelTime = lengthM / maxSpeed
 
     val physSimTravelTime = travelTime.getLinkTravelTime(link, time, null, null)
-    val physSimTravelTimeWithNoise =
-      if (travelTimeNoiseFraction.equals(0d) || !shouldAddNoise) {
-        physSimTravelTime
-      } else {
-        val idx = Math.abs(noiseIdx.getAndIncrement() % travelTimeNoises.length)
-        physSimTravelTime * travelTimeNoises(idx)
-      }
-    val linkTravelTime = Math.max(physSimTravelTimeWithNoise, minTravelTime)
-    val result = Math.min(linkTravelTime, maxTravelTime)
 
-    result
+    // Generate noise only if needed
+    val physSimTravelTimeWithNoise =
+      if (travelTimeNoiseFraction > 0d && shouldAddNoise) {
+        // Generate a value between 0 and 1, scale it to the noise range, then shift it
+        physSimTravelTime * ThreadLocalRandom.current().nextDouble(noiseLowerBound, noiseUpperBound)
+      } else {
+        physSimTravelTime
+      }
+
+    // Use Math.min/max for cleaner clamping
+    Math.min(Math.max(physSimTravelTimeWithNoise, minTravelTime), maxTravelTime)
   }
 }

--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -29,6 +29,7 @@ import org.matsim.vehicles.Vehicle
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.IntFunction
 import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
@@ -77,6 +78,19 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
       Try(link.getFreespeed).getOrElse(0.0)
     )
   }.toMap
+
+  private lazy val precomputedRestrictions: Map[RoutingVehicleCategory, Map[Long, Boolean]] = {
+    val categories = RoutingVehicleCategory.values
+    categories.map { category =>
+      val categoryRestrictions = osmIdToRoadRestriction.map { case (osmId, restrictions) =>
+        osmId -> restrictions.isRestricted(
+          category,
+          Double.MaxValue
+        )
+      }
+      category -> categoryRestrictions
+    }.toMap
+  }
 
   private val linkRadiusMeters: Double =
     beamConfig.beam.routing.r5.linkRadiusMeters
@@ -1202,7 +1216,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         streetMode: StreetMode,
         req: ProfileRequest
       ): Float = {
-        ttc(startTime + durationSeconds, edge.getEdgeIndex, streetMode).floatValue().ceil
+        math.ceil(ttc(startTime + durationSeconds, edge.getEdgeIndex, streetMode).toFloat).toFloat
       }
     }
   }
@@ -1213,14 +1227,46 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
     shouldApplyBicycleScaleFactor: Boolean = false
   ): TravelTimeByLinkCalculator = {
     val profileRequest = createProfileRequest
+
+    // Cache the maximum velocity for this vehicle type
+    val vehicleMaxSpeed = vehicleType.maxVelocity.getOrElse(Double.MaxValue)
+
+    // Create a cache for edge length to avoid repeated lookups
+    val edgeLengthCache = new ConcurrentHashMap[Int, Double]()
+
+    // Create a cache for bicycle scale factors if needed
+    val bikeScaleFactorCache = if (shouldApplyBicycleScaleFactor) {
+      new ConcurrentHashMap[Int, Double]()
+    } else null
+
     (time: Double, linkId: Int, streetMode: StreetMode) => {
-      val edge = transportNetwork.streetLayer.edgeStore.getCursor(linkId)
-      val maxSpeed: Double = vehicleType.maxVelocity.getOrElse(profileRequest.getSpeedForMode(streetMode))
-      val minTravelTime = edge.getLengthM / maxSpeed
+      // Get the edge length, using the cache
+      val edgeLength = edgeLengthCache.computeIfAbsent(
+        linkId,
+        id => {
+          transportNetwork.streetLayer.edgeStore.getCursor(id).getLengthM
+        }
+      )
+
+      // Calculate the mode-specific speed
+      val maxSpeed: Double = if (streetMode == StreetMode.CAR) {
+        Math.min(vehicleMaxSpeed, profileRequest.getSpeedForMode(streetMode))
+      } else {
+        profileRequest.getSpeedForMode(streetMode)
+      }
+
+      val minTravelTime = edgeLength / maxSpeed
+
       if (streetMode == StreetMode.CAR) {
-        carWeightCalculator.calcTravelTime(linkId, travelTime, Some(vehicleType), time, shouldAddNoise)
+        carWeightCalculator.calcTravelTime(linkId, travelTime, maxSpeed, time, shouldAddNoise, edgeLength)
       } else if (streetMode == StreetMode.BICYCLE && shouldApplyBicycleScaleFactor) {
-        val scaleFactor = bikeLanesAdjustment.scaleFactor(vehicleType, linkId)
+        // Use the cache for bike scale factors
+        val scaleFactor = bikeScaleFactorCache.computeIfAbsent(
+          linkId,
+          id => {
+            bikeLanesAdjustment.scaleFactor(vehicleType, id)
+          }
+        )
         minTravelTime * scaleFactor
       } else {
         minTravelTime
@@ -1239,19 +1285,20 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
     startTime: Int
   ): TravelCostCalculator = { (edge: EdgeStore#Edge, legDurationSeconds: Int, traversalTimeSeconds: Float) =>
     {
+      val osmId = edge.getOSMID
+      val category = RoutingVehicleCategory.fromCategory(vehicleType.vehicleCategory)
       val roadRestrictionWeightMultiplier: Float =
-        if (
-          osmIdToRoadRestriction
-            .get(edge.getOSMID)
-            .exists(
-              _.isRestricted(
-                vehicleType.vehicleCategory,
-                vehicleType.restrictRoadsByFreeSpeedInMeterPerSecond.getOrElse(Double.MaxValue)
-              )
-            )
-        )
+        if (precomputedRestrictions.getOrElse(category, Map.empty).getOrElse(osmId, false)) {
           workerParams.beamConfig.beam.agentsim.agents.vehicles.roadRestrictionWeightMultiplier.toFloat
-        else 1f
+        } else {
+          vehicleType.restrictRoadsByFreeSpeedInMeterPerSecond.map(maxSpeed =>
+            osmIdToRoadRestriction.get(osmId).exists(_.isRestricted(vehicleType.vehicleCategory, maxSpeed))
+          ) match {
+            case Some(true) =>
+              workerParams.beamConfig.beam.agentsim.agents.vehicles.roadRestrictionWeightMultiplier.toFloat
+            case _ => 1f
+          }
+        }
 
       (traversalTimeSeconds + (timeValueOfMoney * tollCalculator.calcTollByLinkId(
         edge.getEdgeIndex,
@@ -1273,16 +1320,46 @@ object R5Wrapper {
   private val HeavyHeavyDutyTruckTag = "hgv"
   private val LightAndMediumHeavyDutyTruckTag = "mdv"
 
+  sealed trait RoutingVehicleCategory
+
+  object RoutingVehicleCategory {
+    case object HeavyDuty extends RoutingVehicleCategory
+    case object MediumDuty extends RoutingVehicleCategory
+    case object Other extends RoutingVehicleCategory
+
+    val values: Set[RoutingVehicleCategory] = Set(HeavyDuty, MediumDuty, Other)
+
+    def fromCategory(category: VehicleCategory.VehicleCategory): RoutingVehicleCategory = category match {
+      case VehicleCategory.Class78Tractor | VehicleCategory.Class78Vocational      => HeavyDuty
+      case VehicleCategory.Class456Vocational | VehicleCategory.Class2b3Vocational => MediumDuty
+      case _                                                                       => Other
+    }
+  }
+
   private case class RoadRestrictions(hhdt: Boolean, lmhdt: Boolean, freeSpeed: Double) {
 
-    def isRestricted(category: VehicleCategory.VehicleCategory, speedThreshold: Double): Boolean = {
+    def isRestricted(category: RoutingVehicleCategory, speedThreshold: Double): Boolean = {
       category match {
-        case VehicleCategory.Class78Tractor     => !hhdt
-        case VehicleCategory.Class78Vocational  => !hhdt
-        case VehicleCategory.Class456Vocational => !lmhdt
-        case VehicleCategory.Class2b3Vocational => !lmhdt
-        case _                                  => freeSpeed > speedThreshold
+        case RoutingVehicleCategory.HeavyDuty  => !hhdt
+        case RoutingVehicleCategory.MediumDuty => !lmhdt
+        case RoutingVehicleCategory.Other      => freeSpeed > speedThreshold
       }
+    }
+
+    def isRestricted(category: VehicleCategory.VehicleCategory, speedThreshold: Double): Boolean = {
+      isRestricted(RoutingVehicleCategory.fromCategory(category), speedThreshold)
+    }
+
+    def validFor: Vector[RoutingVehicleCategory] = {
+      RoutingVehicleCategory.values
+        .filter(category =>
+          category match {
+            case RoutingVehicleCategory.HeavyDuty  => !hhdt
+            case RoutingVehicleCategory.MediumDuty => !lmhdt
+            case RoutingVehicleCategory.Other      => false
+          }
+        )
+        .toVector
     }
   }
 }

--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -1231,22 +1231,9 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
     // Cache the maximum velocity for this vehicle type
     val vehicleMaxSpeed = vehicleType.maxVelocity.getOrElse(Double.MaxValue)
 
-    // Create a cache for edge length to avoid repeated lookups
-    val edgeLengthCache = new ConcurrentHashMap[Int, Double]()
-
-    // Create a cache for bicycle scale factors if needed
-    val bikeScaleFactorCache = if (shouldApplyBicycleScaleFactor) {
-      new ConcurrentHashMap[Int, Double]()
-    } else null
-
     (time: Double, linkId: Int, streetMode: StreetMode) => {
       // Get the edge length, using the cache
-      val edgeLength = edgeLengthCache.computeIfAbsent(
-        linkId,
-        id => {
-          transportNetwork.streetLayer.edgeStore.getCursor(id).getLengthM
-        }
-      )
+      val edgeLength = transportNetwork.streetLayer.edgeStore.lengths_mm.get(linkId / 2) / 1000.0
 
       // Calculate the mode-specific speed
       val maxSpeed: Double = if (streetMode == StreetMode.CAR) {
@@ -1257,17 +1244,11 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
 
       val minTravelTime = edgeLength / maxSpeed
 
-      if (streetMode == StreetMode.CAR) {
+      if (streetMode == StreetMode.BICYCLE && shouldApplyBicycleScaleFactor) {
+        //note we're not explicitly checking that it is a Bike VehicleType
+        minTravelTime * bikeLanesAdjustment.bikeScaleFactor(linkId)
+      } else if (streetMode == StreetMode.CAR) {
         carWeightCalculator.calcTravelTime(linkId, travelTime, maxSpeed, time, shouldAddNoise, edgeLength)
-      } else if (streetMode == StreetMode.BICYCLE && shouldApplyBicycleScaleFactor) {
-        // Use the cache for bike scale factors
-        val scaleFactor = bikeScaleFactorCache.computeIfAbsent(
-          linkId,
-          id => {
-            bikeLanesAdjustment.scaleFactor(vehicleType, id)
-          }
-        )
-        minTravelTime * scaleFactor
       } else {
         minTravelTime
       }
@@ -1322,7 +1303,7 @@ object R5Wrapper {
 
   sealed trait RoutingVehicleCategory
 
-  object RoutingVehicleCategory {
+  private object RoutingVehicleCategory {
     case object HeavyDuty extends RoutingVehicleCategory
     case object MediumDuty extends RoutingVehicleCategory
     case object Other extends RoutingVehicleCategory
@@ -1348,18 +1329,6 @@ object R5Wrapper {
 
     def isRestricted(category: VehicleCategory.VehicleCategory, speedThreshold: Double): Boolean = {
       isRestricted(RoutingVehicleCategory.fromCategory(category), speedThreshold)
-    }
-
-    def validFor: Vector[RoutingVehicleCategory] = {
-      RoutingVehicleCategory.values
-        .filter(category =>
-          category match {
-            case RoutingVehicleCategory.HeavyDuty  => !hhdt
-            case RoutingVehicleCategory.MediumDuty => !lmhdt
-            case RoutingVehicleCategory.Other      => false
-          }
-        )
-        .toVector
     }
   }
 }

--- a/src/main/scala/beam/sim/common/GeoUtils.scala
+++ b/src/main/scala/beam/sim/common/GeoUtils.scala
@@ -29,6 +29,7 @@ trait GeoUtils extends ExponentialLazyLogging {
   def localCRS: String
   val defaultMaxRadiusForMapSearch = 10000
   private lazy val notExponentialLogger = Logger(LoggerFactory.getLogger(getClass.getName))
+  private var cachedEdges: Option[Array[(EdgeWithCoord, GpxPoint)]] = None
 
   lazy val utm2Wgs: GeotoolsTransformation =
     new GeotoolsTransformation(localCRS, "EPSG:4326")
@@ -149,25 +150,27 @@ trait GeoUtils extends ExponentialLazyLogging {
   }
 
   def getEdgesCloseToBoundingBox(streetLayer: StreetLayer): Array[(EdgeWithCoord, GpxPoint)] = {
-    val cursor = streetLayer.edgeStore.getCursor()
-    val iter = new Iterator[EdgeStore#Edge] {
-      override def hasNext: Boolean = cursor.advance()
+    cachedEdges.getOrElse {
 
-      override def next(): EdgeStore#Edge = cursor
-    }
+      val cursor = streetLayer.edgeStore.getCursor()
+      val iter = new Iterator[EdgeStore#Edge] {
+        override def hasNext: Boolean = cursor.advance()
 
-    val boundingBox = streetLayer.envelope
-
-    val insideBoundingBox = iter
-      .flatMap { edge =>
-        Option(edge.getGeometry.getBoundary.getCoordinate).map { coord =>
-          EdgeWithCoord(edge.getEdgeIndex, coord)
-        }
+        override def next(): EdgeStore#Edge = cursor
       }
-      .withFilter(x => boundingBox.contains(x.wgsCoord))
-      .toArray
 
-    /*
+      val boundingBox = streetLayer.envelope
+
+      val insideBoundingBox = iter
+        .flatMap { edge =>
+          Option(edge.getGeometry.getBoundary.getCoordinate).map { coord =>
+            EdgeWithCoord(edge.getEdgeIndex, coord)
+          }
+        }
+        .withFilter(x => boundingBox.contains(x.wgsCoord))
+        .toArray
+
+      /*
     min => x0,y0
     max => x1,y1
 x0,y1 (TOP LEFT)    ._____._____. x1,y1 (TOP RIGHT)
@@ -177,37 +180,39 @@ x0,y1 (TOP LEFT)    ._____._____. x1,y1 (TOP RIGHT)
                     |           |
                     |           |
 x0,y0 (BOTTOM LEFT) ._____._____. x1, y0 (BOTTOM RIGHT)
-     */
+       */
 
-    val bottomLeft = new Coord(boundingBox.getMinX, boundingBox.getMinY)
-    val topLeft = new Coord(boundingBox.getMinX, boundingBox.getMaxY)
-    val topRight = new Coord(boundingBox.getMaxX, boundingBox.getMaxY)
-    val bottomRight = new Coord(boundingBox.getMaxX, boundingBox.getMinY)
-    val midLeft = new Coord((bottomLeft.getX + topLeft.getX) / 2, (bottomLeft.getY + topLeft.getY) / 2)
-    val midTop = new Coord((topLeft.getX + topRight.getX) / 2, (topLeft.getY + topRight.getY) / 2)
-    val midRight = new Coord((topRight.getX + bottomRight.getX) / 2, (topRight.getY + bottomRight.getY) / 2)
-    val midBottom = new Coord((bottomLeft.getX + bottomRight.getX) / 2, (bottomLeft.getY + bottomRight.getY) / 2)
+      val bottomLeft = new Coord(boundingBox.getMinX, boundingBox.getMinY)
+      val topLeft = new Coord(boundingBox.getMinX, boundingBox.getMaxY)
+      val topRight = new Coord(boundingBox.getMaxX, boundingBox.getMaxY)
+      val bottomRight = new Coord(boundingBox.getMaxX, boundingBox.getMinY)
+      val midLeft = new Coord((bottomLeft.getX + topLeft.getX) / 2, (bottomLeft.getY + topLeft.getY) / 2)
+      val midTop = new Coord((topLeft.getX + topRight.getX) / 2, (topLeft.getY + topRight.getY) / 2)
+      val midRight = new Coord((topRight.getX + bottomRight.getX) / 2, (topRight.getY + bottomRight.getY) / 2)
+      val midBottom = new Coord((bottomLeft.getX + bottomRight.getX) / 2, (bottomLeft.getY + bottomRight.getY) / 2)
 
-    val corners = Array(
-      GpxPoint("BottomLeft", bottomLeft),
-      GpxPoint("TopLeft", topLeft),
-      GpxPoint("TopRight", topRight),
-      GpxPoint("BottomRight", bottomRight),
-      GpxPoint("MidLeft", midLeft),
-      GpxPoint("MidTop", midTop),
-      GpxPoint("MidRight", midRight),
-      GpxPoint("MidBottom", midBottom)
-    )
+      val corners = Array(
+        GpxPoint("BottomLeft", bottomLeft),
+        GpxPoint("TopLeft", topLeft),
+        GpxPoint("TopRight", topRight),
+        GpxPoint("BottomRight", bottomRight),
+        GpxPoint("MidLeft", midLeft),
+        GpxPoint("MidTop", midTop),
+        GpxPoint("MidRight", midRight),
+        GpxPoint("MidBottom", midBottom)
+      )
 
-    val closestEdges = corners.map { gpxPoint =>
-      val utmCornerCoord = wgs2Utm(gpxPoint.wgsCoord)
-      val closestEdge: EdgeWithCoord = insideBoundingBox.minBy { x =>
-        val utmCoord = wgs2Utm(new Coord(x.wgsCoord.x, x.wgsCoord.y))
-        distUTMInMeters(utmCornerCoord, utmCoord)
+      val closestEdges = corners.map { gpxPoint =>
+        val utmCornerCoord = wgs2Utm(gpxPoint.wgsCoord)
+        val closestEdge: EdgeWithCoord = insideBoundingBox.minBy { x =>
+          val utmCoord = wgs2Utm(new Coord(x.wgsCoord.x, x.wgsCoord.y))
+          distUTMInMeters(utmCornerCoord, utmCoord)
+        }
+        (closestEdge, gpxPoint)
       }
-      (closestEdge, gpxPoint)
+      cachedEdges = Some(closestEdges)
+      closestEdges
     }
-    closestEdges
   }
 }
 

--- a/src/main/scala/scripts/R5Requester.scala
+++ b/src/main/scala/scripts/R5Requester.scala
@@ -7,6 +7,7 @@ import beam.router.BeamRouter.{Location, RoutingRequest}
 import beam.router.Modes.BeamMode
 import beam.router.r5.{R5Parameters, R5Wrapper}
 import beam.router.{BeamRouter, FreeFlowTravelTime}
+import beam.router.BeamTravelTime
 import beam.sim.BeamHelper
 import beam.sim.common.GeoUtils
 import beam.sim.population.{AttributesOfIndividual, HouseholdAttributes}


### PR DESCRIPTION
This is intended to remove some inefficiency in the router, particularly in the overriding methods that are used to look up link travel times (which get called a *lot*). The main goals are to remove as many hash map lookups as possible by:

1) Pre-computing which links have access restrictions so that we don't need to search over all of them every time, and
2) Using array lookups for link travel times rather than hashmap queries

For 2, R5 has done a lot of work to already assign links integer ids that start at 0 and increase sequentially because it stores stuff in arrays, so we go through an inefficient step of converting these int ids back to strings (for MATSim) and then looking up link properties via this string, and then using that to find the travel times that we already store in an array. This adds the option of skipping the conversion to string and just looking up travel times from the array directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3914)
<!-- Reviewable:end -->
