### PR TITLE
Fix: charging stalls not reused after ReleaseStall (ChargingNetwork.scala)

### DIFF
--- a/src/main/scala/beam/agentsim/infrastructure/ChargingNetwork.scala
+++ b/src/main/scala/beam/agentsim/infrastructure/ChargingNetwork.scala
@@ -110,10 +110,19 @@ class ChargingNetwork(val parkingZones: Map[Id[ParkingZoneId], ParkingZone]) ext
     * @return a tuple of the status of the charging vehicle and the connection status
     */
   def disconnectVehicle(vehicleId: Id[BeamVehicle], tick: Int): Option[ChargingVehicle] = {
-    beamVehicleIdToChargingVehicleMap.get(vehicleId) map { chargingVehicle =>
+    beamVehicleIdToChargingVehicleMap.get(vehicleId).map { chargingVehicle =>
       beamVehicleIdToChargingVehicleMap.remove(vehicleId)
       chargingVehicle.chargingStation.disconnect(chargingVehicle.vehicle.id, tick)
-    } getOrElse {
+
+      //
+      val stall = chargingVehicle.stall
+      if (stall.parkingZoneId != ParkingZone.DefaultParkingZoneId) {
+        searchFunctions.foreach(_.releaseStall(parkingZones(stall.parkingZoneId)))
+      }
+
+      //
+      chargingVehicle
+    } orElse {
       logger.debug(s"Vehicle $vehicleId is already disconnected")
       None
     }


### PR DESCRIPTION
After debugging, I found that disconnectVehicle in ChargingNetwork.scala did not properly call releaseStall. I added logic to release the stall so it can be reused.
number of charging vehicle in a scenario has only 4 chargers.
Fixes #3918 

before debug:
<img width="800" height="600" alt="Image" src="https://github.com/user-attachments/assets/bbb1241e-e3dd-4c8a-81a5-5e403bdfcd6b" />

after debug:
<img width="800" height="600" alt="Image" src="https://github.com/user-attachments/assets/812474dd-f629-412a-a1ca-3fddc6765375" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3919)
<!-- Reviewable:end -->
