### PR TITLE
Priority queue to handle hardest routes faster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,7 @@ dependencies {
     implementation "com.typesafe.scala-logging:scala-logging_${scalaBinaryVersion}:3.9.0"
     implementation "org.slf4j:log4j-over-slf4j:${slf4jVersion}"
 
-    implementation(group: 'com.github.LBNL-UCB-STI', name: 'r5', version: 'v4.9.0') {
+    implementation(group: 'com.github.LBNL-UCB-STI', name: 'r5', version: 'v4.10.3') {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }

--- a/src/main/scala/beam/router/BeamRouter.scala
+++ b/src/main/scala/beam/router/BeamRouter.scala
@@ -25,6 +25,7 @@ import beam.agentsim.infrastructure.taz.TAZ
 import beam.agentsim.scheduler.HasTriggerId
 import beam.router.BeamRouter._
 import beam.router.Modes.BeamMode
+import beam.router.Modes.BeamMode.{BIKE, CAR}
 import beam.router.gtfs.FareCalculator
 import beam.router.model._
 import beam.router.osm.TollCalculator
@@ -83,8 +84,22 @@ class BeamRouter(
   val secondsToWaitToClearRoutedOutstandingWork: Int =
     beamScenario.beamConfig.beam.debug.secondsToWaitToClearRoutedOutstandingWork
 
-  val availableWorkWithOriginalSender: mutable.Queue[WorkWithOriginalSender] =
-    mutable.Queue.empty[WorkWithOriginalSender]
+  val availableWorkWithOriginalSender: java.util.PriorityQueue[WorkWithOriginalSender] =
+    new java.util.PriorityQueue[WorkWithOriginalSender](
+      100, // initial capacity
+      (w1: WorkWithOriginalSender, w2: WorkWithOriginalSender) => {
+        val complexity1 = w1._1 match {
+          case req: RoutingRequest => req.routingComplexity
+          case _                   => 0 // Other work types get default priority
+        }
+        val complexity2 = w2._1 match {
+          case req: RoutingRequest => req.routingComplexity
+          case _                   => 0
+        }
+        // Higher complexity first (reverse order)
+        java.lang.Integer.compare(complexity2, complexity1)
+      }
+    )
   val availableWorkers: mutable.Set[Worker] = mutable.Set.empty[Worker]
 
   val outstandingWorkIdToOriginalSenderMap: mutable.Map[WorkId, OriginalSender] =
@@ -172,6 +187,11 @@ class BeamRouter(
     case `tick` =>
       if (isWorkAndNoAvailableWorkers) notifyWorkersOfAvailableWork()
       logExcessiveOutstandingWorkAndClearIfEnabledAndOver
+      log.info(
+        "Router queue depth: {}, available workers: {}",
+        availableWorkWithOriginalSender.size(),
+        availableWorkers.size
+      )
     case t: TryToSerialize =>
       if (log.isDebugEnabled) {
         val byteArray = kryoSerializer.toBinary(t)
@@ -236,7 +256,7 @@ class BeamRouter(
           worker
         ) //Request must have been delayed since no work, but will send when something comes in
       else {
-        val (work, originalSender) = availableWorkWithOriginalSender.dequeue()
+        val (work, originalSender) = availableWorkWithOriginalSender.poll()
         sendWorkTo(worker, work, originalSender, receivePath = "GimmeWork")
       }
     case odSkimmerReady: ODSkimmerReady =>
@@ -268,7 +288,7 @@ class BeamRouter(
       if (!isWorkAvailable) { //No existing work
         if (!isWorkerAvailable) {
           notifyWorkersOfAvailableWork()
-          availableWorkWithOriginalSender.enqueue((work, originalSender))
+          availableWorkWithOriginalSender.offer((work, originalSender))
         } else {
           val worker: Worker = removeAndReturnFirstAvailableWorker()
           sendWorkTo(worker, work, originalSender, "Receive CatchAll")
@@ -276,7 +296,7 @@ class BeamRouter(
       } else { //Use existing work first
         if (!isWorkerAvailable)
           notifyWorkersOfAvailableWork() //Shouldn't need this but it should be relatively idempotent
-        availableWorkWithOriginalSender.enqueue((work, originalSender))
+        availableWorkWithOriginalSender.offer((work, originalSender))
       }
   }
 
@@ -290,7 +310,7 @@ class BeamRouter(
     }
   }
 
-  private def isWorkAvailable: Boolean = availableWorkWithOriginalSender.nonEmpty
+  private def isWorkAvailable: Boolean = !availableWorkWithOriginalSender.isEmpty
 
   private def isWorkerAvailable: Boolean = availableWorkers.nonEmpty
 
@@ -512,6 +532,39 @@ object BeamRouter {
     ) // 360 seconds per Dollar, i.e. 10$/h value of travel time savings
 
     val initiatedFrom: String = s"${fileName.value}:${line.value} ${fullName.value}"
+
+    lazy val routingComplexity: Int = {
+      val dX = destinationUTM.getX - originUTM.getX
+      val dY = destinationUTM.getY - originUTM.getY
+      val distanceKm = Math.sqrt(dX * dX + dY * dY) / 1000.0
+
+      var complexity = 0
+
+      // Distance factor
+      if (distanceKm > 100) complexity += 200 // extralong: very significant
+      else if (distanceKm > 50) complexity += 100 // long: significant
+      else if (distanceKm > 10) complexity += 30 // medium
+      else complexity += 10 // short
+
+      if (streetVehicles.exists(_.mode == CAR)) {
+        if (withTransit) {
+          complexity += 120 // "drive_transit"
+        } else
+          complexity += 60 // "car"
+      } else if (streetVehicles.exists(_.mode == BIKE)) {
+        if (withTransit)
+          complexity += 100 // "bike_transit"
+        else
+          complexity += 40 // "bike"
+      } else {
+        if (withTransit)
+          complexity += 50 // "walk_transit"
+        else
+          complexity += 10 // "walk"
+      }
+
+      complexity
+    }
   }
 
   sealed trait IntermodalUse

--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -84,6 +84,120 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
   private val carWeightCalculator = new CarWeightCalculator(workerParams, travelTimeNoiseFraction)
   private val bikeLanesAdjustment = BikeLanesAdjustment(beamConfig)
 
+  // Create thread-local for each calculator type
+  private val turnCostCalculatorTL: ThreadLocal[TurnCostCalculator] =
+    ThreadLocal.withInitial(() =>
+      new TurnCostCalculator(transportNetwork.streetLayer, true) {
+        override def computeTurnCost(fromEdge: Int, toEdge: Int, streetMode: StreetMode): Int = 0
+      }
+    )
+
+  // Use a simpler approach: keep a small cache per thread
+  private val routerCache: ThreadLocal[java.util.ArrayDeque[StreetRouter]] =
+    ThreadLocal.withInitial(() => new java.util.ArrayDeque[StreetRouter](4))
+
+  private val routerPoolStats = new ThreadLocal[PoolStats]() {
+    override def initialValue(): PoolStats = new PoolStats()
+  }
+
+  private case class PoolStats(
+    var hits: Long = 0,
+    var misses: Long = 0,
+    var returns: Long = 0,
+    var discards: Long = 0,
+    var maxRouterPoolSize: Int = 0,
+    var maxStatePoolSize: Int = 0,
+    var maxStateInUse: Int = 0,
+    var totalStatePoolSize: Long = 0, // Sum for averaging
+    var statePoolSamples: Long = 0,
+    var lastLogTime: Long = System.currentTimeMillis()
+  )
+
+  private def returnRouter(router: StreetRouter): Unit = {
+    val cache = routerCache.get()
+    val stats = routerPoolStats.get()
+
+    // Parse the stats string (simple and effective)
+    val stateStats = router.getStatePoolStats()
+    // Regex to extract size=X
+    val sizePattern = "size=(\\d+)".r
+    val statePoolSize = sizePattern
+      .findFirstMatchIn(stateStats)
+      .map(_.group(1).toInt)
+      .getOrElse(0)
+
+    stats.maxStatePoolSize = Math.max(stats.maxStatePoolSize, statePoolSize)
+    stats.totalStatePoolSize += statePoolSize
+    stats.statePoolSamples += 1
+
+    if (cache.size() < 10) {
+      cache.offer(router)
+      stats.returns += 1
+      stats.maxRouterPoolSize = Math.max(stats.maxRouterPoolSize, cache.size())
+    } else {
+      stats.discards += 1
+    }
+  }
+
+  private def borrowRouter(
+    travelTimeCalc: TravelTimeCalculator,
+    travelCostCalc: TravelCostCalculator
+  ): StreetRouter = {
+    val cache = routerCache.get()
+    val stats = routerPoolStats.get()
+
+    val router = if (cache.isEmpty) {
+      stats.misses += 1
+      new StreetRouter(
+        transportNetwork.streetLayer,
+        travelTimeCalc,
+        turnCostCalculatorTL.get(),
+        travelCostCalc
+      )
+    } else {
+      stats.hits += 1
+      cache.poll()
+    }
+
+    router.reset()
+
+    // Log periodically
+    val now = System.currentTimeMillis()
+    val totalBorrows = stats.hits + stats.misses
+    if (totalBorrows % 1000 == 0 || (now - stats.lastLogTime) > 60000) {
+      val hitRate = if (totalBorrows > 0) (stats.hits * 100.0 / totalBorrows) else 0.0
+      val avgStatePoolSize =
+        if (stats.statePoolSamples > 0)
+          stats.totalStatePoolSize / stats.statePoolSamples
+        else 0
+
+      logger.info(
+        s"StreetRouter pool [thread=${Thread.currentThread().getId}]: " +
+        f"router_hit_rate=$hitRate%.1f%%, " +
+        f"router_pool=${cache.size()}/${stats.maxRouterPoolSize}, " +
+        f"state_pool_avg=$avgStatePoolSize, " +
+        f"state_pool_max=${stats.maxStatePoolSize}, " +
+        f"state_max_in_use=${stats.maxStateInUse}, " +
+        s"total_routes=$totalBorrows"
+      )
+      stats.lastLogTime = now
+    }
+
+    router
+  }
+
+  private def withRouter[T](
+    travelTimeCalc: TravelTimeCalculator,
+    travelCostCalc: TravelCostCalculator
+  )(f: StreetRouter => T): T = {
+    val router = borrowRouter(travelTimeCalc, travelCostCalc)
+    try {
+      f(router)
+    } finally {
+      returnRouter(router)
+    }
+  }
+
   def embodyWithCurrentTravelTime(
     leg: BeamLeg,
     vehicleId: Id[Vehicle],
@@ -162,33 +276,35 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
       val directOption = new ProfileOption
       profileRequest.reverseSearch = false
       for (mode <- profileRequest.directModes.asScala) {
-
-        val streetRouter = new StreetRouter(
-          transportNetwork.streetLayer,
+        withRouter(
           travelTimeCalculator(
             vehicleType,
             profileRequest.fromTime,
             shouldAddNoise = !profileRequest.hasTransit
-          ), // Add error if it is not transit
-          turnCostCalculator,
-          travelCostCalculator(vehicleType, request.timeValueOfMoney, profileRequest.fromTime)
-        )
-        if (request.accessMode == LegMode.BICYCLE) {
-          streetRouter.distanceLimitMeters = maxDistanceForBikeMeters
-        }
-        streetRouter.profileRequest = profileRequest
-        streetRouter.streetMode = toR5StreetMode(mode)
-        streetRouter.timeLimitSeconds = profileRequest.streetTime * 60
-        if (streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)) {
-          if (streetRouter.setDestination(profileRequest.toLat, profileRequest.toLon, linkRadiusMeters)) {
-            latency("route-transit-time", Metrics.VerboseLevel) {
-              streetRouter.route() // latency 1
-            }
-            val lastState = streetRouter.getState(streetRouter.getDestinationSplit)
-            if (lastState != null) {
-              val streetPath = new StreetPath(lastState, transportNetwork, false)
-              val streetSegment = new StreetSegment(streetPath, mode, transportNetwork.streetLayer)
-              directOption.addDirect(streetSegment, profileRequest.getFromTimeDateZD)
+          ),
+          travelCostCalculator(
+            vehicleType,
+            request.timeValueOfMoney,
+            profileRequest.fromTime
+          )
+        ) { streetRouter =>
+          if (request.accessMode == LegMode.BICYCLE) {
+            streetRouter.distanceLimitMeters = maxDistanceForBikeMeters
+          }
+          streetRouter.profileRequest = profileRequest
+          streetRouter.streetMode = toR5StreetMode(mode)
+          streetRouter.timeLimitSeconds = profileRequest.streetTime * 60
+          if (streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)) {
+            if (streetRouter.setDestination(profileRequest.toLat, profileRequest.toLon, linkRadiusMeters)) {
+              latency("route-transit-time", Metrics.VerboseLevel) {
+                streetRouter.route() // latency 1
+              }
+              val lastState = streetRouter.getState(streetRouter.getDestinationSplit)
+              if (lastState != null) {
+                val streetPath = new StreetPath(lastState, transportNetwork, false)
+                val streetSegment = new StreetSegment(streetPath, mode, transportNetwork.streetLayer)
+                directOption.addDirect(streetSegment, profileRequest.getFromTimeDateZD)
+              }
             }
           }
         }
@@ -495,7 +611,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
           profileRequest.fromTime,
           shouldAddNoise = !profileRequest.hasTransit
         ),
-        turnCostCalculator,
+        turnCostCalculatorTL.get(),
         travelCostCalculator(vehicleType, request.timeValueOfMoney, profileRequest.fromTime)
       )
       if (vehicle.mode == BeamMode.BIKE) {
@@ -542,31 +658,34 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
                 directOption.addDirect(streetSegment, profileRequest.getFromTimeDateZD)
               } else if (profileRequest.streetTime * 60 > streetRouter.timeLimitSeconds) {
                 val vehicleType = vehicleTypes(vehicle.vehicleTypeId)
-                val streetRouter = new StreetRouter(
-                  transportNetwork.streetLayer,
+                withRouter(
                   travelTimeCalculator(
                     vehicleType,
                     profileRequest.fromTime,
                     shouldAddNoise = !profileRequest.hasTransit
                   ),
-                  turnCostCalculator,
-                  travelCostCalculator(vehicleType, request.timeValueOfMoney, profileRequest.fromTime)
-                )
-                if (vehicle.mode == BeamMode.BIKE) {
-                  streetRouter.distanceLimitMeters = maxDistanceForBikeMeters
-                }
-                streetRouter.profileRequest = profileRequest
-                streetRouter.streetMode = toR5StreetMode(vehicle.mode)
-                streetRouter.timeLimitSeconds = profileRequest.streetTime * 60
-                streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)
-                streetRouter.setDestination(profileRequest.toLat, profileRequest.toLon, linkRadiusMeters)
-                streetRouter.route()
-                val lastState = streetRouter.getState(streetRouter.getDestinationSplit)
-                if (lastState != null) {
-                  val streetPath = new StreetPath(lastState, transportNetwork, false)
-                  val streetSegment =
-                    new StreetSegment(streetPath, legMode, transportNetwork.streetLayer)
-                  directOption.addDirect(streetSegment, profileRequest.getFromTimeDateZD)
+                  travelCostCalculator(
+                    vehicleType,
+                    request.timeValueOfMoney,
+                    profileRequest.fromTime
+                  )
+                ) { streetRouter =>
+                  if (vehicle.mode == BeamMode.BIKE) {
+                    streetRouter.distanceLimitMeters = maxDistanceForBikeMeters
+                  }
+                  streetRouter.profileRequest = profileRequest
+                  streetRouter.streetMode = toR5StreetMode(vehicle.mode)
+                  streetRouter.timeLimitSeconds = profileRequest.streetTime * 60
+                  streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)
+                  streetRouter.setDestination(profileRequest.toLat, profileRequest.toLon, linkRadiusMeters)
+                  streetRouter.route()
+                  val lastState = streetRouter.getState(streetRouter.getDestinationSplit)
+                  if (lastState != null) {
+                    val streetPath = new StreetPath(lastState, transportNetwork, false)
+                    val streetSegment =
+                      new StreetSegment(streetPath, legMode, transportNetwork.streetLayer)
+                    directOption.addDirect(streetSegment, profileRequest.getFromTimeDateZD)
+                  }
                 }
               }
             }
@@ -618,7 +737,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             profileRequest.fromTime,
             shouldAddNoise = !profileRequest.hasTransit
           ),
-          turnCostCalculator,
+          turnCostCalculatorTL.get(),
           travelCostCalculator(vehicleType, request.timeValueOfMoney, profileRequest.fromTime)
         )
         if (vehicle.mode == BeamMode.BIKE) {


### PR DESCRIPTION
# Priority Queue for Routing Requests

## Summary

1. Replaces FIFO queue in BeamRouter with a priority queue that processes complex/slow routing requests first.
2. Re-uses R5 `StreetRouter` objects rather than re-create one for each request. R5 has been separately modified (https://github.com/LBNL-UCB-STI/r5/pull/5) so that these objects re-use their internal "state" objects rather than creating and destroying thousands of them per route. This reduces GC pressure within BEAM by quite a bit.

## Problem
1. Routing requests have high variance in processing time (10ms for simple walk routes vs 600ms+ for long multimodal routes). With FIFO dispatching, workers would finish fast routes and sit idle waiting for slow routes to complete, leading to ~28% CPU idle time.
2. High GC pressure that causes most work to stop every few seconds. Most of the objects being cleaned up are "State" objects from within R5.

## Solution
- Calculate routing complexity based on distance and mode
- Dispatch complex routes first so they run in parallel with fast routes
- Complexity scoring:
  - **Distance:** extralong (>100km) = +200, long (>50km) = +100, medium (>10km) = +30, short = +10
  - **Mode:** drive_transit = +120, car = +60, bike_transit = +100, bike = +40, walk_transit = +50, walk = +10

## Impact
- **Laptop (10 cores):** 10-15% faster on average
- **Expected HPC (90 cores):** 25-35% faster due to better load balancing at scale

## Changes
- `BeamRouter.scala`: Replace `mutable.Queue` with `java.util.PriorityQueue`
- `RoutingRequest`: Add `routingComplexity` lazy val
- Queue operations: `enqueue` → `offer`, `dequeue` → `poll`
- Add queue depth logging for monitoring

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3921)
<!-- Reviewable:end -->
