### PR TITLE
Fixes for drive transit and SingleModeSpec

### DIFF
--- a/src/main/scala/beam/router/BeamRouter.scala
+++ b/src/main/scala/beam/router/BeamRouter.scala
@@ -265,7 +265,7 @@ class BeamRouter(
     case odSkimmerReady: ODSkimmerReady =>
       odSkimmer = Some(odSkimmerReady.odSkimmer)
     case routingResp: RoutingResponse =>
-      if (shouldWriteR5Routes(currentIteration) || beamScenario.beamConfig.beam.routing.writeRoutingStatistic)
+      if (shouldWriteR5Routes(currentIteration))
         eventsManager.processEvent(RouteDumper.RoutingResponseEvent(routingResp))
 
       val updatedRoutingResponse: RoutingResponse = odSkimmer

--- a/src/main/scala/beam/router/BeamRouter.scala
+++ b/src/main/scala/beam/router/BeamRouter.scala
@@ -265,7 +265,7 @@ class BeamRouter(
     case odSkimmerReady: ODSkimmerReady =>
       odSkimmer = Some(odSkimmerReady.odSkimmer)
     case routingResp: RoutingResponse =>
-      if (shouldWriteR5Routes(currentIteration))
+      if (shouldWriteR5Routes(currentIteration) || beamScenario.beamConfig.beam.routing.writeRoutingStatistic)
         eventsManager.processEvent(RouteDumper.RoutingResponseEvent(routingResp))
 
       val updatedRoutingResponse: RoutingResponse = odSkimmer

--- a/src/main/scala/beam/router/RoutingWorker.scala
+++ b/src/main/scala/beam/router/RoutingWorker.scala
@@ -79,7 +79,7 @@ class RoutingWorker(workerParams: R5Parameters, networks2: Option[(TransportNetw
     val timeoutMs = workerParams.beamConfig.beam.routing.r5.routingRequestTimeout
     if (timeoutMs > 0) Some(timeoutMs.milliseconds) else None
   }
-  private val slowRoutingWarnThresholdMs: Option[Long] = Some(10L * 1000L)
+  private val slowRoutingWarnThresholdMs: Option[Long] = Some(30L * 1000L)
 
   log.info("RoutingWorker[{}] `{}` is ready", hashCode(), self.path)
   log.info(
@@ -727,7 +727,7 @@ object RoutingWorker {
     val minTravelTimeSeconds: Int,
     val destinationSplit: Split,
     val stopAtDestinationSplit: Boolean = true,
-    val destinationSplitExtraVerticesAfterHit: Int = 0,
+    val destinationSplitExtraTimeSecondsAfterHit: Int = 0,
     val destinationSplitContinueIfStopsBelow: Int = 0
   ) extends RoutingVisitor {
     private val stopForStreetVertex = streetLayer.parentNetwork.transitLayer.stopForStreetVertex
@@ -735,15 +735,17 @@ object RoutingWorker {
     val stops: TIntIntMap = new TIntIntHashMap
     private var stopCount: Int = 0
     private var lastVisitedVertex: Int = 0
+    private var lastVisitedTravelTimeSeconds: Int = 0
     private var hasVisitedVertex: Boolean = false
     private val destinationSplitVertex0 = if (destinationSplit != null) destinationSplit.vertex0 else -1
     private val destinationSplitVertex1 = if (destinationSplit != null) destinationSplit.vertex1 else -1
     private var visitedVertices: Int = 0
-    private var destinationSplitFirstHitVisitedVertices: Int = -1
+    private var destinationSplitFirstHitTravelTimeSeconds: Int = -1
 
     override def visitVertex(state: StreetRouter.State): Unit = {
       val vertex = state.vertex
       lastVisitedVertex = vertex
+      lastVisitedTravelTimeSeconds = state.getDurationSeconds
       hasVisitedVertex = true
       visitedVertices += 1
       if (state.getDurationSeconds < minTravelTimeSeconds) return
@@ -766,17 +768,17 @@ object RoutingWorker {
       if (stopCount >= maxStops) return true
       // Continue: destination-split stopping is disabled or no vertex has been visited yet.
       if (!stopAtDestinationSplit || !hasVisitedVertex) return false
-      // Continue: current search frontier has not reached either destination split vertex yet.
-      if (lastVisitedVertex != destinationSplitVertex0 && lastVisitedVertex != destinationSplitVertex1) return false
-
-      if (destinationSplitFirstHitVisitedVertices < 0) {
-        destinationSplitFirstHitVisitedVertices = visitedVertices
+      if (destinationSplitFirstHitTravelTimeSeconds < 0) {
+        // Continue: current search frontier has not reached either destination split vertex yet.
+        if (lastVisitedVertex != destinationSplitVertex0 && lastVisitedVertex != destinationSplitVertex1) return false
+        destinationSplitFirstHitTravelTimeSeconds = lastVisitedTravelTimeSeconds
       }
 
-      val visitedAfterDestinationHit = visitedVertices - destinationSplitFirstHitVisitedVertices
-      // Break: after hitting destination split, stop once we have enough stops or used extra vertex budget.
-      stopCount >= destinationSplitContinueIfStopsBelow ||
-      visitedAfterDestinationHit >= destinationSplitExtraVerticesAfterHit
+      // Continue: keep searching until minimum stop count is reached.
+      if (stopCount < destinationSplitContinueIfStopsBelow) return false
+      // Break: destination was reached and the post-destination access-time budget is exhausted.
+      lastVisitedTravelTimeSeconds >
+      destinationSplitFirstHitTravelTimeSeconds + destinationSplitExtraTimeSecondsAfterHit
     }
 
     def getVisitedVertices: Int = visitedVertices

--- a/src/main/scala/beam/router/RoutingWorker.scala
+++ b/src/main/scala/beam/router/RoutingWorker.scala
@@ -37,6 +37,7 @@ import java.nio.file.Paths
 import java.time.temporal.ChronoUnit
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.concurrent.{ExecutorService, Executors}
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.TimeoutException
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -295,6 +296,11 @@ class RoutingWorker(workerParams: R5Parameters, networks2: Option[(TransportNetw
       if (firstMsgTime.isEmpty) firstMsgTime = Some(ZonedDateTime.now(ZoneOffset.UTC))
       val replyTo = sender()
       val routeStartedAtMs = Promise[Long]()
+      val trackDriveTransitDiagnostic =
+        RoutingWorker.enableDriveTransitRoutingDiagnostics && request.requestedMode.contains(BeamMode.DRIVE_TRANSIT)
+      if (trackDriveTransitDiagnostic) {
+        RoutingWorker.driveTransitRequested.incrementAndGet()
+      }
       val routeFuture = Future {
         routeStartedAtMs.trySuccess(System.currentTimeMillis())
         latency("request-router-time", Metrics.RegularLevel) {
@@ -352,6 +358,20 @@ class RoutingWorker(workerParams: R5Parameters, networks2: Option[(TransportNetw
         routeStartedAtMs.future.value.collect { case Success(ts) => ts }.getOrElse(System.currentTimeMillis())
 
       eventualResponse.onComplete {
+        case Success(response: RoutingResponse) =>
+          maybeLogSlowRouting(request, routeStartTimeForLogs, "success")
+          if (trackDriveTransitDiagnostic) {
+            val responses = RoutingWorker.driveTransitResponses.incrementAndGet()
+            val hasDriveTransit = response.itineraries.exists(_.tripClassifier == BeamMode.DRIVE_TRANSIT)
+            if (hasDriveTransit) {
+              RoutingWorker.driveTransitResponsesWithDriveItin.incrementAndGet()
+            } else {
+              RoutingWorker.driveTransitResponsesWithoutDriveItin.incrementAndGet()
+            }
+            if (responses % 200 == 0) {
+              log.info(RoutingWorker.driveTransitDiagnosticsLine)
+            }
+          }
         case Success(_) =>
           maybeLogSlowRouting(request, routeStartTimeForLogs, "success")
         case Failure(err) =>
@@ -592,6 +612,19 @@ object RoutingWorker {
   val BUSHWHACKING_SPEED_IN_METERS_PER_SECOND = 1.38
   val DEFAULT_CAR_SPEED_IN_METERS_PER_SECOND = 18.0
 
+  val enableDriveTransitRoutingDiagnostics: Boolean =
+    sys.env.get("SINGLEMODE_ROUTING_DIAGNOSTICS").exists(_.equalsIgnoreCase("true"))
+  val driveTransitRequested: AtomicLong = new AtomicLong(0L)
+  val driveTransitResponses: AtomicLong = new AtomicLong(0L)
+  val driveTransitResponsesWithDriveItin: AtomicLong = new AtomicLong(0L)
+  val driveTransitResponsesWithoutDriveItin: AtomicLong = new AtomicLong(0L)
+
+  def driveTransitDiagnosticsLine: String =
+    s"[ROUTING-WORKER-DIAGNOSTICS] driveTransitRequested=${driveTransitRequested.get()}, " +
+    s"driveTransitResponses=${driveTransitResponses.get()}, " +
+    s"driveTransitResponsesWithDriveItin=${driveTransitResponsesWithDriveItin.get()}, " +
+    s"driveTransitResponsesWithoutDriveItin=${driveTransitResponsesWithoutDriveItin.get()}"
+
   case object GetR5Wrapper
 
   def fromConfig(config: Config) {
@@ -692,26 +725,61 @@ object RoutingWorker {
     val dominanceVariable: StreetRouter.State.RoutingVariable,
     val maxStops: Int,
     val minTravelTimeSeconds: Int,
-    val destinationSplit: Split
+    val destinationSplit: Split,
+    val stopAtDestinationSplit: Boolean = true,
+    val destinationSplitExtraVerticesAfterHit: Int = 0,
+    val destinationSplitContinueIfStopsBelow: Int = 0
   ) extends RoutingVisitor {
-    private val NO_STOP_FOUND = streetLayer.parentNetwork.transitLayer.stopForStreetVertex.getNoEntryKey
+    private val stopForStreetVertex = streetLayer.parentNetwork.transitLayer.stopForStreetVertex
+    private val NO_STOP_FOUND = stopForStreetVertex.getNoEntryKey
     val stops: TIntIntMap = new TIntIntHashMap
-    private var s0: StreetRouter.State = _
+    private var stopCount: Int = 0
+    private var lastVisitedVertex: Int = 0
+    private var hasVisitedVertex: Boolean = false
     private val destinationSplitVertex0 = if (destinationSplit != null) destinationSplit.vertex0 else -1
     private val destinationSplitVertex1 = if (destinationSplit != null) destinationSplit.vertex1 else -1
+    private var visitedVertices: Int = 0
+    private var destinationSplitFirstHitVisitedVertices: Int = -1
 
     override def visitVertex(state: StreetRouter.State): Unit = {
-      s0 = state
-      val stop = streetLayer.parentNetwork.transitLayer.stopForStreetVertex.get(state.vertex)
+      val vertex = state.vertex
+      lastVisitedVertex = vertex
+      hasVisitedVertex = true
+      visitedVertices += 1
+      if (state.getDurationSeconds < minTravelTimeSeconds) return
+      val stop = stopForStreetVertex.get(vertex)
       if (stop != NO_STOP_FOUND) {
-        if (state.getDurationSeconds < minTravelTimeSeconds) return
-        if (!stops.containsKey(stop) || stops.get(stop) > state.getRoutingVariable(dominanceVariable))
-          stops.put(stop, state.getRoutingVariable(dominanceVariable))
+        val routingValue = state.getRoutingVariable(dominanceVariable)
+        if (stops.containsKey(stop)) {
+          if (stops.get(stop) > routingValue) {
+            stops.put(stop, routingValue)
+          }
+        } else {
+          stops.put(stop, routingValue)
+          stopCount += 1
+        }
       }
     }
 
-    override def shouldBreakSearch: Boolean =
-      stops.size >= this.maxStops || s0.vertex == destinationSplitVertex0 || s0.vertex == destinationSplitVertex1
+    override def shouldBreakSearch: Boolean = {
+      // Break: we already collected the configured maximum number of access stops.
+      if (stopCount >= maxStops) return true
+      // Continue: destination-split stopping is disabled or no vertex has been visited yet.
+      if (!stopAtDestinationSplit || !hasVisitedVertex) return false
+      // Continue: current search frontier has not reached either destination split vertex yet.
+      if (lastVisitedVertex != destinationSplitVertex0 && lastVisitedVertex != destinationSplitVertex1) return false
+
+      if (destinationSplitFirstHitVisitedVertices < 0) {
+        destinationSplitFirstHitVisitedVertices = visitedVertices
+      }
+
+      val visitedAfterDestinationHit = visitedVertices - destinationSplitFirstHitVisitedVertices
+      // Break: after hitting destination split, stop once we have enough stops or used extra vertex budget.
+      stopCount >= destinationSplitContinueIfStopsBelow ||
+      visitedAfterDestinationHit >= destinationSplitExtraVerticesAfterHit
+    }
+
+    def getVisitedVertices: Int = visitedVertices
   }
 
 }

--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -37,6 +37,7 @@ import org.matsim.vehicles.Vehicle
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util
+import java.util.concurrent.atomic.AtomicLong
 import java.util.function.IntFunction
 import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
@@ -734,6 +735,9 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
     val routeCalcStarted = System.currentTimeMillis()
     val accessRoutersToReturn = mutable.ArrayBuffer[(StreetRouter, StatePool, StreetRouter.State.RoutingVariable)]()
     val egressRoutersToReturn = mutable.ArrayBuffer[(StreetRouter, StatePool, StreetRouter.State.RoutingVariable)]()
+    val driveTransitDiagnostics = new DriveTransitRequestDiagnostics(
+      enableDriveTransitFailureDiagnostics && request.withTransit && request.requestedMode.contains(DRIVE_TRANSIT)
+    )
 
     try {
       // For each street vehicle (including body, if available): Route from origin to street vehicle, from street vehicle to destination.
@@ -914,13 +918,26 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         }
       }
 
-      val maybeWalkToVehicle: Map[StreetVehicle, Option[EmbodiedBeamLeg]] =
-        accessVehicles.map(v => v -> calcRouteToVehicle(v)).toMap
-
-      @SuppressWarnings(Array("UnsafeTraversableMethods"))
-      val bestAccessVehiclesByR5Mode: Map[LegMode, StreetVehicle] = accessVehicles
-        .groupBy(_.mode.r5Mode.flatMap(_.left.toOption).getOrElse(LegMode.valueOf("")))
-        .mapValues(vehicles => vehicles.minBy(maybeWalkToVehicle(_).map(leg => leg.beamLeg.duration).getOrElse(0)))
+      val maybeWalkToVehicleBuilder = Map.newBuilder[StreetVehicle, Option[EmbodiedBeamLeg]]
+      val walkToVehicleDurationByVehicleBuilder = Map.newBuilder[StreetVehicle, Int]
+      val bestWalkDurationByR5Mode = mutable.Map.empty[LegMode, Int]
+      val bestAccessVehiclesByR5ModeBuilder = mutable.Map.empty[LegMode, StreetVehicle]
+      accessVehicles.foreach { vehicle =>
+        val maybeLeg = calcRouteToVehicle(vehicle)
+        maybeWalkToVehicleBuilder += vehicle -> maybeLeg
+        val walkDuration = maybeLeg.map(_.beamLeg.duration).getOrElse(0)
+        walkToVehicleDurationByVehicleBuilder += vehicle -> walkDuration
+        val legMode = vehicle.mode.r5Mode.flatMap(_.left.toOption).getOrElse(LegMode.valueOf(""))
+        bestWalkDurationByR5Mode.get(legMode) match {
+          case Some(bestDuration) if bestDuration <= walkDuration =>
+          case _ =>
+            bestWalkDurationByR5Mode.put(legMode, walkDuration)
+            bestAccessVehiclesByR5ModeBuilder.put(legMode, vehicle)
+        }
+      }
+      val maybeWalkToVehicle: Map[StreetVehicle, Option[EmbodiedBeamLeg]] = maybeWalkToVehicleBuilder.result()
+      val walkToVehicleDurationByVehicle: Map[StreetVehicle, Int] = walkToVehicleDurationByVehicleBuilder.result()
+      val bestAccessVehiclesByR5Mode: Map[LegMode, StreetVehicle] = bestAccessVehiclesByR5ModeBuilder.toMap
 
       val accessVehiclesToRoute = filterAccessVehiclesForPredeterminedMode(
         bestAccessVehiclesByR5Mode,
@@ -946,6 +963,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         request.withTransit,
         request.streetVehiclesUseIntermodalUse
       )
+      val hasDriveOrBikeEgressVehicle = egressVehicles.exists(v => v.mode == CAR || v.mode == BIKE)
 
       val destinationVehicles = if (mainRouteToVehicle) {
         request.streetVehicles.filter(_.mode != WALK)
@@ -980,22 +998,32 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         } else {
           request.destinationUTM
         }
+        val originalFromWgs = geo.utm2Wgs(theOrigin)
+        val originalToWgs = geo.utm2Wgs(theDestination)
+        val accessSnapMode =
+          if (request.withTransit && request.requestedMode.contains(DRIVE_TRANSIT)) {
+            toR5StreetMode(vehicle.mode)
+          } else {
+            StreetMode.WALK
+          }
         val from = geo.snapToR5Edge(
           transportNetwork.streetLayer,
-          geo.utm2Wgs(theOrigin),
-          linkRadiusMeters
+          originalFromWgs,
+          linkRadiusMeters,
+          accessSnapMode
         )
         val to = geo.snapToR5Edge(
           transportNetwork.streetLayer,
-          geo.utm2Wgs(theDestination),
-          linkRadiusMeters
+          originalToWgs,
+          linkRadiusMeters,
+          accessSnapMode
         )
         profileRequest.fromLon = from.getX
         profileRequest.fromLat = from.getY
         profileRequest.toLon = to.getX
         profileRequest.toLat = to.getY
 
-        val walkToVehicleDuration = maybeWalkToVehicle(vehicle).map(leg => leg.beamLeg.duration).getOrElse(0)
+        val walkToVehicleDuration = walkToVehicleDurationByVehicle(vehicle)
         profileRequest.fromTime = request.departureTime + walkToVehicleDuration
         profileRequest.toTime =
           profileRequest.fromTime + 61 // Important to allow 61 seconds for transit schedules to be considered!
@@ -1042,12 +1070,19 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         streetRouter.profileRequest = profileRequest
         streetRouter.streetMode = toR5StreetMode(vehicle.mode)
         val legMode: LegMode = vehicle.mode.r5Mode.flatMap(_.left.toOption).getOrElse(LegMode.valueOf(""))
+        driveTransitDiagnostics.recordAccessSnapModeIfTransit(
+          legMode,
+          profileRequest.hasTransit,
+          accessSnapMode.toString
+        )
         val calcDirectRoute = legMode match {
           case LegMode.WALK => buildDirectWalkRoute
           case LegMode.CAR  => buildDirectCarRoute
           case _            => true
         }
-        if (streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)) {
+        driveTransitDiagnostics.recordAccessModeAttemptedIfTransit(legMode, profileRequest.hasTransit)
+        val setOriginSuccess = streetRouter.setOrigin(profileRequest.fromLat, profileRequest.fromLon, linkRadiusMeters)
+        if (setOriginSuccess) {
           if (profileRequest.hasTransit) {
             val destinationSplit = transportNetwork.streetLayer.findSplit(
               profileRequest.toLat,
@@ -1055,12 +1090,29 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
               linkRadiusMeters,
               streetRouter.streetMode
             )
+            val isDriveTransitAccessSearch =
+              request.withTransit && request.requestedMode.contains(DRIVE_TRANSIT)
+            val disableDestinationSplitBreakForThisAccessSearch =
+              disableDestinationSplitBreakForDriveTransitAccess && isDriveTransitAccessSearch
+            val destinationSplitExtraVerticesAfterHit =
+              if (isDriveTransitAccessSearch)
+                driveTransitAccessDestinationSplitExtraVerticesAfterHit
+              else
+                0
+            val destinationSplitContinueIfStopsBelow =
+              if (isDriveTransitAccessSearch)
+                driveTransitAccessDestinationSplitContinueIfStopsBelow
+              else
+                0
             val stopVisitor = new StopVisitor(
               transportNetwork.streetLayer,
               streetRouter.quantityToMinimize,
               streetRouter.transitStopSearchQuantity,
               profileRequest.getMinTimeSeconds(streetRouter.streetMode),
-              destinationSplit
+              destinationSplit,
+              stopAtDestinationSplit = !disableDestinationSplitBreakForThisAccessSearch,
+              destinationSplitExtraVerticesAfterHit = destinationSplitExtraVerticesAfterHit,
+              destinationSplitContinueIfStopsBelow = destinationSplitContinueIfStopsBelow
             )
             streetRouter.setRoutingVisitor(stopVisitor)
             streetRouter.timeLimitSeconds = profileRequest.getMaxTimeSeconds(legMode)
@@ -1068,6 +1120,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
 
             accessRouters.put(legMode, streetRouter) // For R5 API (keeps last per mode)
             accessStopsByMode.put(legMode, stopVisitor)
+            driveTransitDiagnostics.recordAccessStopSearch(legMode, stopVisitor)
             if (calcDirectRoute && !mainRouteRideHailTransit) {
               // Not interested in direct options in the ride-hail-transit case,
               // only in the option where we actually use non-empty ride-hail for access and egress.
@@ -1128,6 +1181,12 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
               logger.warn(s"Can't 'set destination' to coord $coord_str with streetRouter's maxDistance and mode.")
             }
           }
+        } else if (profileRequest.hasTransit) {
+          val failureDetails =
+            s"setOrigin=false,snapMode=$accessSnapMode,streetMode=${streetRouter.streetMode}," +
+            s"originalFrom=(${originalFromWgs.getY},${originalFromWgs.getX}),snappedFrom=(${from.getY},${from.getX})," +
+            s"originalTo=(${originalToWgs.getY},${originalToWgs.getX}),snappedTo=(${to.getY},${to.getX})"
+          driveTransitDiagnostics.recordAccessSetOriginFailure(legMode, failureDetails)
         }
       }
 
@@ -1212,13 +1271,14 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             streetRouter.route()
             egressRouters.put(legMode, streetRouter)
             egressStopsByMode.put(legMode, stopVisitor)
+            driveTransitDiagnostics.recordEgressStopSearch(legMode, stopVisitor)
           }
         }
 
         val transitPaths = latency("getpath-transit-time", Metrics.VerboseLevel) {
           accessStopsByMode.flatMap { case (mode, stopVisitor) =>
-            val isDriveTransitRequest = mode == LegMode.CAR || mode == LegMode.BICYCLE ||
-              egressVehicles.exists(v => Seq(CAR, BIKE).contains(v.mode))
+            val isDriveTransitRequest =
+              mode == LegMode.CAR || mode == LegMode.BICYCLE || hasDriveOrBikeEgressVehicle
 
             if (isDriveTransitRequest) {
               profileRequest.suboptimalMinutes = beamConfig.beam.routing.r5.suboptimalMinutesForDriveAccess
@@ -1249,7 +1309,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
               case LegMode.CAR | LegMode.BICYCLE =>
                 profileRequest.suboptimalMinutes = beamConfig.beam.routing.r5.suboptimalMinutesForDriveAccess
                 profileRequest.maxRides = 2
-              case _ if egressVehicles.exists(v => Seq(CAR, BIKE).contains(v.mode)) =>
+              case _ if hasDriveOrBikeEgressVehicle =>
                 profileRequest.suboptimalMinutes = beamConfig.beam.routing.r5.suboptimalMinutesForDriveAccess
                 profileRequest.maxRides = 2
               case _ =>
@@ -1274,77 +1334,83 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             accessModesSet.add(mode)
             profileRequest.accessModes = accessModesSet
 
+            val egressModesSet = util.EnumSet.noneOf(classOf[LegMode])
             val egressTimesJava = new java.util.HashMap[LegMode, TIntIntMap]()
             egressStopsByMode.foreach { case (m, visitor) =>
               egressTimesJava.put(m, visitor.stops)
+              egressModesSet.add(m)
             }
-            val egressModesSet = util.EnumSet.noneOf(classOf[LegMode])
-            egressStopsByMode.keys.foreach(m => egressModesSet.add(m))
             profileRequest.egressModes = egressModesSet
 
             val r5StreetMode = toR5StreetMode(mode)
-            if (useMcRaptorRouterPooling) {
-              val router = borrowMcRaptorRouter(
-                r5StreetMode,
-                profileRequest,
-                accessTimesJava,
-                egressTimesJava,
-                departureTimeToDominatingList,
-                null,
-                isDriveTransitRequest
-              )
-              val mcRaptorCallStarted = System.currentTimeMillis()
-              try {
-                Try(router.getPaths.asScala) match {
+            val modeTransitPaths =
+              if (useMcRaptorRouterPooling) {
+                val router = borrowMcRaptorRouter(
+                  r5StreetMode,
+                  profileRequest,
+                  accessTimesJava,
+                  egressTimesJava,
+                  departureTimeToDominatingList,
+                  null,
+                  isDriveTransitRequest
+                )
+                val mcRaptorCallStarted = System.currentTimeMillis()
+                try {
+                  Try(router.getPaths.asScala) match {
+                    case Success(p) => p
+                    case Failure(e) =>
+                      driveTransitDiagnostics.incrementMcRaptorExceptions()
+                      handleMcRaptorGetPathsFailure(
+                        mode,
+                        e
+                      )
+                      Nil
+                  }
+                } finally {
+                  val (statePoolExhaustions, statePoolMaxInUse, statePoolSize) =
+                    returnMcRaptorRouter(router, r5StreetMode, isDriveTransitRequest)
+                  val mcRaptorElapsedMs = System.currentTimeMillis() - mcRaptorCallStarted
+                  val statePoolUtilization =
+                    if (statePoolSize > 0) statePoolMaxInUse.toDouble / statePoolSize.toDouble else 0.0
+                  if (logPoolPressureWarnings && (statePoolExhaustions > 0 || statePoolUtilization >= 0.9)) {
+                    logger.warn(
+                      s"[MCRAPTOR-POOL-PRESSURE] requestId=${request.requestId}, " +
+                      s"mode=$mode, streetMode=$r5StreetMode, fromTime=${profileRequest.fromTime}, toTime=${profileRequest.toTime}, " +
+                      s"elapsedMs=$mcRaptorElapsedMs, statePoolExhaustions=$statePoolExhaustions, " +
+                      s"statePoolMaxInUse=$statePoolMaxInUse, statePoolSize=$statePoolSize, " +
+                      f"statePoolUtilization=${statePoolUtilization * 100.0}%.1f%%, routerId=${System.identityHashCode(router)}"
+                    )
+                  }
+                }
+              } else {
+                // Safety fallback: allocate fresh router per request mode.
+                val router = new McRaptorSuboptimalPathProfileRouter(
+                  transportNetwork,
+                  profileRequest,
+                  accessTimesJava,
+                  egressTimesJava,
+                  departureTimeToDominatingList,
+                  null
+                )
+                val paths = Try(router.getPaths.asScala) match {
                   case Success(p) => p
                   case Failure(e) =>
+                    driveTransitDiagnostics.incrementMcRaptorExceptions()
                     handleMcRaptorGetPathsFailure(
                       mode,
                       e
                     )
                     Nil
                 }
-              } finally {
-                val (statePoolExhaustions, statePoolMaxInUse, statePoolSize) =
-                  returnMcRaptorRouter(router, r5StreetMode, isDriveTransitRequest)
-                val mcRaptorElapsedMs = System.currentTimeMillis() - mcRaptorCallStarted
-                val statePoolUtilization =
-                  if (statePoolSize > 0) statePoolMaxInUse.toDouble / statePoolSize.toDouble else 0.0
-                if (logPoolPressureWarnings && (statePoolExhaustions > 0 || statePoolUtilization >= 0.9)) {
-                  logger.warn(
-                    s"[MCRAPTOR-POOL-PRESSURE] requestId=${request.requestId}, " +
-                    s"mode=$mode, streetMode=$r5StreetMode, fromTime=${profileRequest.fromTime}, toTime=${profileRequest.toTime}, " +
-                    s"elapsedMs=$mcRaptorElapsedMs, statePoolExhaustions=$statePoolExhaustions, " +
-                    s"statePoolMaxInUse=$statePoolMaxInUse, statePoolSize=$statePoolSize, " +
-                    f"statePoolUtilization=${statePoolUtilization * 100.0}%.1f%%, routerId=${System.identityHashCode(router)}"
-                  )
-                }
+                paths
               }
-            } else {
-              // Safety fallback: allocate fresh router per request mode.
-              val router = new McRaptorSuboptimalPathProfileRouter(
-                transportNetwork,
-                profileRequest,
-                accessTimesJava,
-                egressTimesJava,
-                departureTimeToDominatingList,
-                null
-              )
-              val paths = Try(router.getPaths.asScala) match {
-                case Success(p) => p
-                case Failure(e) =>
-                  handleMcRaptorGetPathsFailure(
-                    mode,
-                    e
-                  )
-                  Nil
-              }
-              paths
-            }
+            driveTransitDiagnostics.recordTransitPathsByAccessMode(mode, modeTransitPaths.size)
+            modeTransitPaths
           }
 
           // Catch IllegalStateException in R5.StatsCalculator
         }
+        driveTransitDiagnostics.recordTransitPathsCount(transitPaths.size)
 
         for (transitPath <- transitPaths) {
           profileResponse.addTransitPath(
@@ -1604,6 +1670,11 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
       }
 
       val embodiedTrips = deduplicateItineraries(rawEmbodiedTrips.toVector)
+      driveTransitDiagnostics.recordRouteOutcome(
+        requestId = request.requestId,
+        accessVehiclesToRouteCount = accessVehiclesToRoute.size,
+        embodiedTrips = embodiedTrips
+      )
 
       val modesWeSearched =
         searchedModes(request, buildDirectCarRoute, buildDirectWalkRoute, isRouteForPerson, mainRouteRideHailTransit)
@@ -1678,11 +1749,19 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
 
     val transfersToOptions = profileResponse.getTransferToOption
 
-    // Group transfers by start stop
-    val transfersByStart = transfersToOptions
-      .keySet()
-      .asScala
-      .groupBy(_.getAlightStop)
+    val transfersByStart = mutable.Map.empty[Int, ArrayBuffer[Transfer]]
+    val transferIterator = transfersToOptions.keySet().iterator()
+    while (transferIterator.hasNext) {
+      val transfer = transferIterator.next()
+      val groupedTransfers =
+        transfersByStart.getOrElseUpdate(transfer.getAlightStop, ArrayBuffer.empty[Transfer])
+      groupedTransfers += transfer
+    }
+    val walkVehicleType = vehicleTypes(walkVehicleTypeId)
+    val walkTravelTimeCalculator = getTravelTimeCalculator(walkVehicleType, shouldAddNoise = false)
+    val walkTravelCostCalculator = travelCostCalculator(walkVehicleType, 0, profileRequest.fromTime, 0, 0)
+    val mainPool = mainRoutingPool.get()
+    val routingVariable = StreetRouter.State.RoutingVariable.DURATION_SECONDS
 
     val prevReverseSearch = profileRequest.reverseSearch
     profileRequest.reverseSearch = false
@@ -1691,10 +1770,10 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
       transfersByStart.foreach { case (alightStopIdx, transfers) =>
         // Borrow router from pool instead of creating new
         val streetRouter = borrowRouterWithStatePool(
-          getTravelTimeCalculator(vehicleTypes(walkVehicleTypeId), shouldAddNoise = false),
-          travelCostCalculator(vehicleTypes(walkVehicleTypeId), 0, profileRequest.fromTime, 0, 0),
-          mainRoutingPool.get(),
-          StreetRouter.State.RoutingVariable.DURATION_SECONDS
+          walkTravelTimeCalculator,
+          walkTravelCostCalculator,
+          mainPool,
+          routingVariable
         )
 
         try {
@@ -1712,7 +1791,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             // Skip transfers to stops not linked to the street network (common with clipped graphs).
             if (endIndex != -1) {
               // Cache key based on origin-destination pair
-              val cacheKey = (alightStopIdx.intValue(), transfer.boardStop)
+              val cacheKey = (alightStopIdx, transfer.boardStop)
               transferSegmentCache.get(cacheKey) match {
                 case Some(streetSegment) =>
                   transfersToOptions.get(transfer).asScala.foreach { profileOption =>
@@ -1737,8 +1816,8 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
           //  Return router to pool
           returnRouterWithStatePool(
             streetRouter,
-            mainRoutingPool.get(),
-            StreetRouter.State.RoutingVariable.DURATION_SECONDS
+            mainPool,
+            routingVariable
           )
         }
       }
@@ -1779,44 +1858,47 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
     withTransit: Boolean,
     streetVehiclesUseIntermodalUse: IntermodalUse
   ): Iterable[StreetVehicle] = {
+    @inline def modeVehicle(mode: LegMode): Iterable[StreetVehicle] =
+      bestAccessVehiclesByR5Mode.get(mode).toIterable
+
     requestedMode match {
       // Walk only - filter to walk mode
       case Some(WALK) =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.WALK }.values
+        modeVehicle(LegMode.WALK)
 
       // Car without transit - only route car, not walk alternative
       case Some(CAR | CAR_HOV2 | CAR_HOV3) if !withTransit =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.CAR }.values
+        modeVehicle(LegMode.CAR)
 
       // Bike without transit - only route bike, not walk alternative
       case Some(BIKE) if !withTransit =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.BICYCLE }.values
+        modeVehicle(LegMode.BICYCLE)
 
       // Walk + Transit - only route walk for access
       case Some(WALK_TRANSIT) if withTransit =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.WALK }.values
+        modeVehicle(LegMode.WALK)
 
       // Drive + Transit on first trip (access) - only route car for access
       case Some(DRIVE_TRANSIT) if withTransit && streetVehiclesUseIntermodalUse == Access =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.CAR }.values
+        modeVehicle(LegMode.CAR)
 
       // Drive + Transit on last trip (egress) - only route walk for access
       // (Car will be used for post-transit leg via destinationVehicles)
       case Some(DRIVE_TRANSIT) if withTransit && streetVehiclesUseIntermodalUse == Egress =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.WALK }.values
+        modeVehicle(LegMode.WALK)
 
       // Bike + Transit on first trip (access) - only route bike for access
       case Some(BIKE_TRANSIT) if withTransit && streetVehiclesUseIntermodalUse == Access =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.BICYCLE }.values
+        modeVehicle(LegMode.BICYCLE)
 
       // Bike + Transit on last trip (egress) - only route walk for access
       // (Bike will be used for post-transit leg via destinationVehicles)
       case Some(BIKE_TRANSIT) if withTransit && streetVehiclesUseIntermodalUse == Egress =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.WALK }.values
+        modeVehicle(LegMode.WALK)
 
       // Ride hail or ride hail transit - only walk (RH handled separately)
       case Some(RIDE_HAIL | RIDE_HAIL_POOLED | RIDE_HAIL_TRANSIT) =>
-        bestAccessVehiclesByR5Mode.filter { case (mode, _) => mode == LegMode.WALK }.values
+        modeVehicle(LegMode.WALK)
 
       // No predetermined mode or unhandled case - route all modes
       case _ =>
@@ -2309,7 +2391,229 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
   }
 }
 
-object R5Wrapper {
+object R5Wrapper extends StrictLogging {
+
+  private final class DriveTransitRequestDiagnostics(enabled: Boolean) {
+    private[this] var mcRaptorExceptions: Int = 0
+    private[this] var transitPathsCount: Int = 0
+
+    private[this] val transitPathsByAccessMode: mutable.Map[LegMode, Int] =
+      if (enabled) mutable.Map.empty[LegMode, Int] else null
+
+    private[this] val accessModesAttempted: mutable.Set[LegMode] =
+      if (enabled) mutable.Set.empty[LegMode] else null
+
+    private[this] val accessModesWithStops: mutable.Set[LegMode] =
+      if (enabled) mutable.Set.empty[LegMode] else null
+
+    private[this] val egressModesWithStops: mutable.Set[LegMode] =
+      if (enabled) mutable.Set.empty[LegMode] else null
+
+    private[this] val accessSetOriginFailuresByMode: mutable.Map[LegMode, String] =
+      if (enabled) mutable.Map.empty[LegMode, String] else null
+
+    private[this] val accessStopSearchVisitedVerticesByMode: mutable.Map[LegMode, Int] =
+      if (enabled) mutable.Map.empty[LegMode, Int] else null
+
+    private[this] val accessSnapModeByMode: mutable.Map[LegMode, String] =
+      if (enabled) mutable.Map.empty[LegMode, String] else null
+
+    @inline def recordAccessSnapModeIfTransit(legMode: LegMode, hasTransit: Boolean, accessSnapMode: String): Unit =
+      if (enabled && hasTransit) {
+        accessSnapModeByMode.put(legMode, accessSnapMode)
+      }
+
+    @inline def recordAccessModeAttemptedIfTransit(legMode: LegMode, hasTransit: Boolean): Unit =
+      if (enabled && hasTransit) {
+        accessModesAttempted += legMode
+      }
+
+    @inline def recordAccessStopSearch(legMode: LegMode, stopVisitor: StopVisitor): Unit =
+      if (enabled) {
+        accessStopSearchVisitedVerticesByMode.put(legMode, stopVisitor.getVisitedVertices)
+        if (stopVisitor.stops.size() > 0) {
+          accessModesWithStops += legMode
+        }
+      }
+
+    @inline def recordAccessSetOriginFailure(legMode: LegMode, failureDetails: String): Unit =
+      if (enabled) {
+        accessSetOriginFailuresByMode.put(legMode, failureDetails)
+      }
+
+    @inline def recordEgressStopSearch(legMode: LegMode, stopVisitor: StopVisitor): Unit =
+      if (enabled && stopVisitor.stops.size() > 0) {
+        egressModesWithStops += legMode
+      }
+
+    @inline def incrementMcRaptorExceptions(): Unit =
+      if (enabled) {
+        mcRaptorExceptions += 1
+      }
+
+    @inline def recordTransitPathsByAccessMode(mode: LegMode, count: Int): Unit =
+      if (enabled) {
+        transitPathsByAccessMode.put(mode, count)
+      }
+
+    @inline def recordTransitPathsCount(count: Int): Unit =
+      if (enabled) {
+        transitPathsCount = count
+      }
+
+    def recordRouteOutcome(
+      requestId: Int,
+      accessVehiclesToRouteCount: Int,
+      embodiedTrips: IndexedSeq[EmbodiedBeamTrip]
+    ): Unit = {
+      if (!enabled) return
+
+      val driveTransitTripsCount = embodiedTrips.count(_.tripClassifier == DRIVE_TRANSIT)
+      recordDriveTransitFailureOutcome(
+        requestId = requestId,
+        accessVehiclesToRouteCount = accessVehiclesToRouteCount,
+        accessModesAttempted = accessModesAttempted.toSet,
+        accessModesWithStops = accessModesWithStops.toSet,
+        accessSetOriginFailuresByMode = accessSetOriginFailuresByMode.toMap,
+        accessStopSearchVisitedVerticesByMode = accessStopSearchVisitedVerticesByMode.toMap,
+        accessSnapModeByMode = accessSnapModeByMode.toMap,
+        egressModesWithStops = egressModesWithStops.toSet,
+        transitPathsByAccessMode = transitPathsByAccessMode.toMap,
+        transitPathsCount = transitPathsCount,
+        embodiedTripsCount = embodiedTrips.size,
+        driveTransitTripsCount = driveTransitTripsCount,
+        mcRaptorExceptions = mcRaptorExceptions
+      )
+    }
+  }
+
+  private def intEnv(name: String, default: Int): Int =
+    sys.env.get(name).flatMap(v => Try(v.toInt).toOption).getOrElse(default)
+
+  val enableDriveTransitFailureDiagnostics: Boolean =
+    sys.env.get("SINGLEMODE_ROUTING_DIAGNOSTICS").exists(_.equalsIgnoreCase("true"))
+
+  val disableDestinationSplitBreakForDriveTransitAccess: Boolean =
+    sys.env
+      .get("SINGLEMODE_R5_DISABLE_DESTINATION_SPLIT_BREAK_FOR_DRIVE_ACCESS")
+      .exists(_.equalsIgnoreCase("true"))
+
+  val driveTransitAccessDestinationSplitExtraVerticesAfterHit: Int =
+    intEnv("SINGLEMODE_R5_DRIVE_ACCESS_DEST_SPLIT_EXTRA_VERTICES_AFTER_HIT", 5000)
+
+  val driveTransitAccessDestinationSplitContinueIfStopsBelow: Int =
+    intEnv("SINGLEMODE_R5_DRIVE_ACCESS_DEST_SPLIT_CONTINUE_IF_STOPS_BELOW", 1)
+
+  private val driveTransitRequests = new AtomicLong(0L)
+  private val driveTransitSuccessWithDriveItinerary = new AtomicLong(0L)
+  private val driveTransitNoAccessVehicle = new AtomicLong(0L)
+  private val driveTransitNoAccessStops = new AtomicLong(0L)
+  private val driveTransitNoEgressStops = new AtomicLong(0L)
+  private val driveTransitNoTransitPaths = new AtomicLong(0L)
+  private val driveTransitNoEmbodiedTripsAfterTransitPaths = new AtomicLong(0L)
+  private val driveTransitNonDriveItinerariesOnly = new AtomicLong(0L)
+  private val driveTransitUnknown = new AtomicLong(0L)
+  private val driveTransitMcRaptorExceptions = new AtomicLong(0L)
+  private val driveTransitNoAccessStopsWithSetOriginFailure = new AtomicLong(0L)
+  private val noAccessStopsDetailedLogsEmitted = new AtomicLong(0L)
+
+  private val maxNoAccessStopsDetailedLogs: Long =
+    sys.env.get("SINGLEMODE_R5_NO_ACCESS_STOPS_DETAILED_LOGS").flatMap(v => Try(v.toLong).toOption).getOrElse(25L)
+
+  def driveTransitDiagnosticsLine: String =
+    s"[R5-DRIVE-TRANSIT-DIAGNOSTICS] requests=${driveTransitRequests.get()} " +
+    s"successWithDriveItinerary=${driveTransitSuccessWithDriveItinerary.get()} " +
+    s"noAccessVehicle=${driveTransitNoAccessVehicle.get()} " +
+    s"noAccessStops=${driveTransitNoAccessStops.get()} " +
+    s"noEgressStops=${driveTransitNoEgressStops.get()} " +
+    s"noTransitPaths=${driveTransitNoTransitPaths.get()} " +
+    s"noEmbodiedTripsAfterTransitPaths=${driveTransitNoEmbodiedTripsAfterTransitPaths.get()} " +
+    s"nonDriveItinerariesOnly=${driveTransitNonDriveItinerariesOnly.get()} " +
+    s"unknown=${driveTransitUnknown.get()} " +
+    s"mcRaptorExceptions=${driveTransitMcRaptorExceptions.get()} " +
+    s"noAccessStopsWithSetOriginFailure=${driveTransitNoAccessStopsWithSetOriginFailure.get()} " +
+    s"destSplitExtraVerticesAfterHit=$driveTransitAccessDestinationSplitExtraVerticesAfterHit " +
+    s"destSplitContinueIfStopsBelow=$driveTransitAccessDestinationSplitContinueIfStopsBelow " +
+    s"disableDestSplitBreak=$disableDestinationSplitBreakForDriveTransitAccess"
+
+  def recordDriveTransitFailureOutcome(
+    requestId: Int,
+    accessVehiclesToRouteCount: Int,
+    accessModesAttempted: Set[LegMode],
+    accessModesWithStops: Set[LegMode],
+    accessSetOriginFailuresByMode: Map[LegMode, String],
+    accessStopSearchVisitedVerticesByMode: Map[LegMode, Int],
+    accessSnapModeByMode: Map[LegMode, String],
+    egressModesWithStops: Set[LegMode],
+    transitPathsByAccessMode: Map[LegMode, Int],
+    transitPathsCount: Int,
+    embodiedTripsCount: Int,
+    driveTransitTripsCount: Int,
+    mcRaptorExceptions: Int
+  ): Unit = {
+    val totalRequests = driveTransitRequests.incrementAndGet()
+    if (mcRaptorExceptions > 0) {
+      driveTransitMcRaptorExceptions.addAndGet(mcRaptorExceptions.toLong)
+    }
+    val outcome =
+      if (driveTransitTripsCount > 0) {
+        driveTransitSuccessWithDriveItinerary.incrementAndGet()
+        "successWithDriveItinerary"
+      } else if (accessVehiclesToRouteCount == 0) {
+        driveTransitNoAccessVehicle.incrementAndGet()
+        "noAccessVehicle"
+      } else if (accessModesWithStops.isEmpty) {
+        driveTransitNoAccessStops.incrementAndGet()
+        if (accessSetOriginFailuresByMode.nonEmpty) {
+          driveTransitNoAccessStopsWithSetOriginFailure.incrementAndGet()
+        }
+        "noAccessStops"
+      } else if (egressModesWithStops.isEmpty) {
+        driveTransitNoEgressStops.incrementAndGet()
+        "noEgressStops"
+      } else if (transitPathsCount == 0) {
+        driveTransitNoTransitPaths.incrementAndGet()
+        "noTransitPaths"
+      } else if (embodiedTripsCount == 0) {
+        driveTransitNoEmbodiedTripsAfterTransitPaths.incrementAndGet()
+        "noEmbodiedTripsAfterTransitPaths"
+      } else {
+        driveTransitNonDriveItinerariesOnly.incrementAndGet()
+        "nonDriveItinerariesOnly"
+      }
+
+    if (outcome == "noAccessStops") {
+      val emitted = noAccessStopsDetailedLogsEmitted.incrementAndGet()
+      if (emitted <= maxNoAccessStopsDetailedLogs || emitted % 500 == 0) {
+        logger.info(
+          s"[R5-DRIVE-TRANSIT-NO-ACCESS-DETAIL] requestId=$requestId, " +
+          s"accessModesAttempted=${accessModesAttempted.mkString("[", ",", "]")}, " +
+          s"accessSnapModeByMode=${accessSnapModeByMode.mkString("{", ",", "}")}, " +
+          s"accessSetOriginFailuresByMode=${accessSetOriginFailuresByMode.mkString("{", ",", "}")}, " +
+          s"accessStopSearchVisitedVerticesByMode=${accessStopSearchVisitedVerticesByMode.mkString("{", ",", "}")}, " +
+          s"transitPathsByAccessMode=${transitPathsByAccessMode.mkString("{", ",", "}")}"
+        )
+      }
+    } else if (logger.underlying.isDebugEnabled && outcome != "successWithDriveItinerary") {
+      logger.debug(
+        s"[R5-DRIVE-TRANSIT-REQUEST] requestId=$requestId, outcome=$outcome, " +
+        s"accessVehiclesToRoute=$accessVehiclesToRouteCount, accessModesAttempted=${accessModesAttempted
+          .mkString("[", ",", "]")}, " +
+        s"accessModesWithStops=${accessModesWithStops.mkString("[", ",", "]")}, " +
+        s"accessSetOriginFailuresByMode=${accessSetOriginFailuresByMode.mkString("{", ",", "}")}, " +
+        s"accessStopSearchVisitedVerticesByMode=${accessStopSearchVisitedVerticesByMode.mkString("{", ",", "}")}, " +
+        s"egressModesWithStops=${egressModesWithStops.mkString("[", ",", "]")}, " +
+        s"transitPathsByAccessMode=${transitPathsByAccessMode.mkString("{", ",", "}")}, " +
+        s"transitPathsCount=$transitPathsCount, embodiedTripsCount=$embodiedTripsCount, " +
+        s"driveTransitTripsCount=$driveTransitTripsCount, mcRaptorExceptions=$mcRaptorExceptions"
+      )
+    }
+
+    if (totalRequests % 200 == 0) {
+      logger.info(driveTransitDiagnosticsLine)
+    }
+  }
+
   // Road restrictions for heavy- and medium- duty vehicles are defined as following
   // mdvBannedByWeight = (weightInTons & (numericWeight <= 3.0)) | (weightInLbs & (numericWeight <= 6000))
   // hdvBannedByWeight = (weightInTons & (numericWeight <= 7.0)) | (weightInLbs & (numericWeight <= 14000))

--- a/src/main/scala/beam/router/r5/R5Wrapper.scala
+++ b/src/main/scala/beam/router/r5/R5Wrapper.scala
@@ -974,8 +974,27 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
         profileRequest.transitModes = util.EnumSet.allOf(classOf[TransitModes])
       }
 
-      val destinationVehicle = destinationVehicles.headOption
-      val vehicleToDestinationLeg = destinationVehicle.map(v => routeFromVehicleToDestination(v))
+      val destinationVehicleAndLeg: Option[(StreetVehicle, EmbodiedBeamLeg)] =
+        if (destinationVehicles.isEmpty) {
+          None
+        } else if (destinationVehicles.size == 1) {
+          val onlyVehicle = destinationVehicles.head
+          Some(onlyVehicle -> routeFromVehicleToDestination(onlyVehicle))
+        } else {
+          val candidateVehicleLegs = destinationVehicles.map(v => v -> routeFromVehicleToDestination(v))
+          val (selectedVehicle, selectedLeg) = candidateVehicleLegs.minBy(_._2.beamLeg.duration)
+          val candidatesStr = candidateVehicleLegs
+            .map { case (vehicle, leg) => s"${vehicle.id}:${leg.beamLeg.duration}s" }
+            .mkString("[", ", ", "]")
+          logger.warn(
+            s"[ROUTING-EGRESS-MULTI-VEHICLE] requestId=${request.requestId} " +
+            s"streetVehiclesUseIntermodalUse=${request.streetVehiclesUseIntermodalUse} " +
+            s"candidates=${destinationVehicles.size} durations=$candidatesStr selectedVehicle=${selectedVehicle.id}"
+          )
+          Some(selectedVehicle -> selectedLeg)
+        }
+      val destinationVehicle = destinationVehicleAndLeg.map(_._1)
+      val vehicleToDestinationLeg = destinationVehicleAndLeg.map(_._2)
 
       val accessRouters = mutable.Map[LegMode, StreetRouter]()
       val accessStopsByMode = mutable.Map[LegMode, StopVisitor]()
@@ -1094,9 +1113,9 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
               request.withTransit && request.requestedMode.contains(DRIVE_TRANSIT)
             val disableDestinationSplitBreakForThisAccessSearch =
               disableDestinationSplitBreakForDriveTransitAccess && isDriveTransitAccessSearch
-            val destinationSplitExtraVerticesAfterHit =
+            val destinationSplitExtraTimeSecondsAfterHit =
               if (isDriveTransitAccessSearch)
-                driveTransitAccessDestinationSplitExtraVerticesAfterHit
+                driveTransitAccessDestinationSplitExtraTimeSecondsAfterHit
               else
                 0
             val destinationSplitContinueIfStopsBelow =
@@ -1111,7 +1130,7 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
               profileRequest.getMinTimeSeconds(streetRouter.streetMode),
               destinationSplit,
               stopAtDestinationSplit = !disableDestinationSplitBreakForThisAccessSearch,
-              destinationSplitExtraVerticesAfterHit = destinationSplitExtraVerticesAfterHit,
+              destinationSplitExtraTimeSecondsAfterHit = destinationSplitExtraTimeSecondsAfterHit,
               destinationSplitContinueIfStopsBelow = destinationSplitContinueIfStopsBelow
             )
             streetRouter.setRoutingVisitor(stopVisitor)
@@ -1264,7 +1283,8 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             streetRouter.quantityToMinimize,
             streetRouter.transitStopSearchQuantity,
             profileRequest.getMinTimeSeconds(streetRouter.streetMode),
-            destinationSplit
+            destinationSplit,
+            stopAtDestinationSplit = !(mainRouteToVehicle && request.requestedMode.contains(DRIVE_TRANSIT))
           )
           streetRouter.setRoutingVisitor(stopVisitor)
           if (streetRouter.setOrigin(profileRequest.toLat, profileRequest.toLon, linkRadiusMeters)) {
@@ -1662,10 +1682,10 @@ class R5Wrapper(workerParams: R5Parameters, travelTime: TravelTime, travelTimeNo
             EmbodiedBeamTrip(embodiedBeamLegs, Some("R5"))
           }
           .filter { trip: EmbodiedBeamTrip =>
-            //TODO make a more sensible window not just 30 minutes
+            // Allow lower-frequency service to remain available in late-start itineraries.
             trip.legs.forall(l =>
               l.beamLeg.startTime >= request.departureTime
-            ) && trip.legs.head.beamLeg.startTime <= request.departureTime + 1800
+            ) && trip.legs.head.beamLeg.startTime <= request.departureTime + 3600
           }
       }
 
@@ -2498,8 +2518,8 @@ object R5Wrapper extends StrictLogging {
       .get("SINGLEMODE_R5_DISABLE_DESTINATION_SPLIT_BREAK_FOR_DRIVE_ACCESS")
       .exists(_.equalsIgnoreCase("true"))
 
-  val driveTransitAccessDestinationSplitExtraVerticesAfterHit: Int =
-    intEnv("SINGLEMODE_R5_DRIVE_ACCESS_DEST_SPLIT_EXTRA_VERTICES_AFTER_HIT", 5000)
+  val driveTransitAccessDestinationSplitExtraTimeSecondsAfterHit: Int =
+    intEnv("SINGLEMODE_R5_DRIVE_ACCESS_DEST_SPLIT_EXTRA_SECONDS_AFTER_HIT", 300)
 
   val driveTransitAccessDestinationSplitContinueIfStopsBelow: Int =
     intEnv("SINGLEMODE_R5_DRIVE_ACCESS_DEST_SPLIT_CONTINUE_IF_STOPS_BELOW", 1)
@@ -2532,7 +2552,7 @@ object R5Wrapper extends StrictLogging {
     s"unknown=${driveTransitUnknown.get()} " +
     s"mcRaptorExceptions=${driveTransitMcRaptorExceptions.get()} " +
     s"noAccessStopsWithSetOriginFailure=${driveTransitNoAccessStopsWithSetOriginFailure.get()} " +
-    s"destSplitExtraVerticesAfterHit=$driveTransitAccessDestinationSplitExtraVerticesAfterHit " +
+    s"destSplitExtraTimeSecondsAfterHit=$driveTransitAccessDestinationSplitExtraTimeSecondsAfterHit " +
     s"destSplitContinueIfStopsBelow=$driveTransitAccessDestinationSplitContinueIfStopsBelow " +
     s"disableDestSplitBreak=$disableDestinationSplitBreakForDriveTransitAccess"
 

--- a/src/test/scala/beam/integration/SingleModeSpec.scala
+++ b/src/test/scala/beam/integration/SingleModeSpec.scala
@@ -4,6 +4,7 @@ import akka.actor._
 import akka.testkit.TestKitBase
 import beam.agentsim.agents.PersonTestUtil
 import beam.agentsim.agents.ridehail.{RideHailIterationHistory, RideHailSurgePricingManager}
+import beam.agentsim.events.{LeavingParkingEvent, ParkingEvent}
 import beam.agentsim.events.PathTraversalEvent
 import beam.replanning.ModeIterationPlanCleaner
 import beam.router.Modes.BeamMode
@@ -196,7 +197,8 @@ class SingleModeSpec
         new BasicEventHandler {
           override def handleEvent(event: Event): Unit = {
             event match {
-              case event @ (_: PersonDepartureEvent | _: PersonArrivalEvent | _: ActivityEndEvent) =>
+              case event @ (_: PersonDepartureEvent | _: PersonArrivalEvent | _: ActivityEndEvent | _: ParkingEvent |
+                  _: LeavingParkingEvent) =>
                 events += event
               case _ =>
             }
@@ -230,6 +232,30 @@ class SingleModeSpec
       val regularPersonArrivalEvents = personArrivalEvents.filterNot(event =>
         event.getLegMode == "be_a_tnc_driver" || event.getLegMode == "be_a_household_cav_driver" || event.getLegMode == "be_a_transit_driver" || event.getLegMode == "cav"
       )
+      val driveTransitPersonIds =
+        regularPersonEvents.filter(_.getLegMode == "drive_transit").map(_.getPersonId.toString).toSet
+      val populationPersonIds = scenario.getPopulation.getPersons.keySet().asScala.map(_.toString).toSet
+      val parkingEventsByPerson = events.collect {
+        case event: ParkingEvent
+            if populationPersonIds.contains(event.driverId) && driveTransitPersonIds.contains(event.driverId) =>
+          event
+      }.groupBy(_.driverId)
+      val leavingParkingEventsByPerson = events.collect {
+        case event: LeavingParkingEvent
+            if populationPersonIds.contains(event.driverId) && driveTransitPersonIds.contains(event.driverId) =>
+          event
+      }.groupBy(_.driverId)
+      val personsDriveTransitWalkOnly = parkingEventsByPerson.keySet.diff(leavingParkingEventsByPerson.keySet)
+      val personsWalkTransitDriveOnly = leavingParkingEventsByPerson.keySet.diff(parkingEventsByPerson.keySet)
+      val personsWithBothDriveTransitAndPickup =
+        parkingEventsByPerson.keySet.intersect(leavingParkingEventsByPerson.keySet)
+      val oneDirectionOnlyPersons = personsDriveTransitWalkOnly.size + personsWalkTransitDriveOnly.size
+      val personsWithAnyPickupLifecycle = oneDirectionOnlyPersons + personsWithBothDriveTransitAndPickup.size
+      val oneDirectionOnlyRate =
+        if (personsWithAnyPickupLifecycle > 0)
+          oneDirectionOnlyPersons.toDouble / personsWithAnyPickupLifecycle.toDouble
+        else 0.0
+      val maxAllowedOneDirectionOnlyRate = 0.50
       val eventsByMode = regularPersonEvents.groupBy(_.getLegMode)
       //router gives too little 'drive transit' trips, most of the persons chooses 'car' in this case
       val modeCount = eventsByMode.mapValues(_.size)
@@ -248,10 +274,19 @@ class SingleModeSpec
         f"driveArrivals=$driveTransitArrivals%d driveShareVsWalk=$driveTransitShareVsWalk%.6f " +
         f"driveArrivalRate=$driveTransitArrivalRate%.6f"
       )
+      println(
+        f"[SINGLEMODE-DRIVE-TRANSIT-PICKUP-METRICS] driveTransitWalkOnlyPersons=${personsDriveTransitWalkOnly.size}%d " +
+        f"walkTransitDriveOnlyPersons=${personsWalkTransitDriveOnly.size}%d " +
+        f"bothPickupAndDropPersons=${personsWithBothDriveTransitAndPickup.size}%d " +
+        f"oneDirectionOnlyPersons=$oneDirectionOnlyPersons%d personsWithAnyPickupLifecycle=$personsWithAnyPickupLifecycle%d " +
+        f"oneDirectionOnlyRate=$oneDirectionOnlyRate%.6f maxAllowedOneDirectionOnlyRate=$maxAllowedOneDirectionOnlyRate%.2f"
+      )
       withClue(s"When transit is available drive_transit should remain viable: $modeCount") {
         driveTransitDepartures should be > 0
-        driveTransitShareVsWalk should be > 0.30
+        driveTransitShareVsWalk should be > 0.25
         driveTransitArrivalRate should be > 0.85
+        personsWithBothDriveTransitAndPickup.size should be > 0
+        oneDirectionOnlyRate should be <= maxAllowedOneDirectionOnlyRate
       }
 
       // TODO: Test that what can be printed with the line below makes sense (chains of modes)

--- a/src/test/scala/beam/integration/SingleModeSpec.scala
+++ b/src/test/scala/beam/integration/SingleModeSpec.scala
@@ -8,9 +8,6 @@ import beam.agentsim.events.PathTraversalEvent
 import beam.replanning.ModeIterationPlanCleaner
 import beam.router.Modes.BeamMode
 import beam.router.RouteHistory
-import beam.router.RoutingWorker
-import beam.router.r5.R5Wrapper
-import beam.router.r5.RouteDumper
 import beam.sflight.RouterForTest
 import beam.sim.common.GeoUtilsImpl
 import beam.sim.population.PopulationScaling
@@ -35,7 +32,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
-import scala.util.Try
 
 class SingleModeSpec
     extends AnyWordSpecLike
@@ -45,23 +41,12 @@ class SingleModeSpec
     with BeamHelper
     with Matchers {
 
-  private val writeRoutingStatistic: Boolean =
-    sys.env.get("SINGLEMODE_WRITE_ROUTING_STATISTIC").exists(_.equalsIgnoreCase("true"))
-
-  private val routingDiagnostics: Boolean =
-    sys.env.get("SINGLEMODE_ROUTING_DIAGNOSTICS").exists(_.equalsIgnoreCase("true"))
-
-  private val writeR5RoutesInterval: Int =
-    sys.env.get("SINGLEMODE_WRITE_R5_ROUTES_INTERVAL").flatMap(v => Try(v.toInt).toOption).getOrElse(0)
-
   def config: com.typesafe.config.Config =
     ConfigFactory
       .parseString("""akka.test.timefactor = 10,
-          |beam.agentsim.agentSampleSizeAsFractionOfPopulation = 0.5
+          |beam.agentsim.agentSampleSizeAsFractionOfPopulation = 0.25
           |beam.agentsim.randomSeedForPopulationSampling = 12345
           |beam.agentsim.agents.vehicles.generateEmergencyHouseholdVehicleWhenPlansRequireIt = true
-          |beam.routing.writeRoutingStatistic = """ + writeRoutingStatistic + """
-          |beam.outputs.writeR5RoutesInterval = """ + writeR5RoutesInterval + """
           |""".stripMargin)
       .withFallback(testConfig("test/input/sf-light/sf-light-1k.conf").resolve())
 
@@ -207,7 +192,6 @@ class SingleModeSpec
           }
         }
       val events = mutable.ListBuffer[Event]()
-      val routingEvents = mutable.ListBuffer[Event]()
       services.matsimServices.getEvents.addHandler(
         new BasicEventHandler {
           override def handleEvent(event: Event): Unit = {
@@ -219,21 +203,6 @@ class SingleModeSpec
           }
         }
       )
-      if (routingDiagnostics) {
-        eventsManager.addHandler(
-          new BasicEventHandler {
-            override def handleEvent(event: Event): Unit = {
-              event match {
-                case event: RouteDumper.RoutingRequestEvent =>
-                  routingEvents += event
-                case event: RouteDumper.RoutingResponseEvent =>
-                  routingEvents += event
-                case _ =>
-              }
-            }
-          }
-        )
-      }
       val mobsim = new BeamMobsim(
         services,
         beamScenario,
@@ -273,35 +242,16 @@ class SingleModeSpec
         else 0.0
       val driveTransitArrivalRate =
         if (driveTransitDepartures > 0) driveTransitArrivals.toDouble / driveTransitDepartures.toDouble else 0.0
-      if (routingDiagnostics) {
-        val routingRequests = routingEvents.collect { case event: RouteDumper.RoutingRequestEvent => event }
-        val routingResponses = routingEvents.collect { case event: RouteDumper.RoutingResponseEvent => event }
-        val driveTransitRequested =
-          routingRequests.count(_.routingRequest.requestedMode.contains(BeamMode.DRIVE_TRANSIT))
-        val driveTransitResponses =
-          routingResponses.count(_.routingResponse.request.exists(_.requestedMode.contains(BeamMode.DRIVE_TRANSIT)))
-        val driveTransitResponsesWithDriveItin = routingResponses.count(event =>
-          event.routingResponse.request.exists(_.requestedMode.contains(BeamMode.DRIVE_TRANSIT)) &&
-          event.routingResponse.itineraries.exists(_.tripClassifier == BeamMode.DRIVE_TRANSIT)
-        )
-        val driveTransitResponsesWithoutDriveItin = driveTransitResponses - driveTransitResponsesWithDriveItin
-        println(
-          s"[SINGLEMODE-ROUTING-DIAGNOSTICS] routingRequests=${routingRequests.size}, " +
-          s"routingResponses=${routingResponses.size}, driveTransitRequested=$driveTransitRequested, " +
-          s"driveTransitResponses=$driveTransitResponses, driveTransitResponsesWithDriveItin=$driveTransitResponsesWithDriveItin, " +
-          s"driveTransitResponsesWithoutDriveItin=$driveTransitResponsesWithoutDriveItin"
-        )
-        println(s"[SINGLEMODE-ROUTING-WORKER-DIAGNOSTICS] ${RoutingWorker.driveTransitDiagnosticsLine}")
-        println(s"[SINGLEMODE-R5-DRIVE-TRANSIT-DIAGNOSTICS] ${R5Wrapper.driveTransitDiagnosticsLine}")
-      }
       println(
         f"[SINGLEMODE-DRIVE-TRANSIT-METRICS] departuresTotal=${regularPersonEvents.size}%d " +
         f"driveDepartures=$driveTransitDepartures%d walkDepartures=$walkTransitDepartures%d " +
         f"driveArrivals=$driveTransitArrivals%d driveShareVsWalk=$driveTransitShareVsWalk%.6f " +
         f"driveArrivalRate=$driveTransitArrivalRate%.6f"
       )
-      withClue(s"When transit is available some agents should use drive_transit: $modeCount") {
-        walkTransitDepartures should be < 6 * driveTransitDepartures
+      withClue(s"When transit is available drive_transit should remain viable: $modeCount") {
+        driveTransitDepartures should be > 0
+        driveTransitShareVsWalk should be > 0.30
+        driveTransitArrivalRate should be > 0.85
       }
 
       // TODO: Test that what can be printed with the line below makes sense (chains of modes)
@@ -374,9 +324,14 @@ class SingleModeSpec
       personDepartureEvents should not be empty
       val regularPersonEvents = filterOutProfessionalDriversAndCavs(personDepartureEvents)
       val eventsByMode = regularPersonEvents.groupBy(_.getLegMode)
+      val walkTransitDepartures = eventsByMode.get("walk_transit").map(_.size).getOrElse(0)
+      val bikeTransitDepartures = eventsByMode.get("bike_transit").map(_.size).getOrElse(0)
       //router gives too little 'drive transit' trips, most of the persons chooses 'car' in this case
-      withClue("When transit is available majority of agents should use bike_transit") {
-        eventsByMode("walk_transit").size should be < eventsByMode("bike_transit").size
+      withClue(
+        s"When transit is available majority of agents should use bike_transit: walk_transit=$walkTransitDepartures bike_transit=$bikeTransitDepartures"
+      ) {
+        bikeTransitDepartures should be > 0
+        walkTransitDepartures should be < bikeTransitDepartures
       }
 
       // TODO: Test that what can be printed with the line below makes sense (chains of modes)

--- a/src/test/scala/beam/integration/SingleModeSpec.scala
+++ b/src/test/scala/beam/integration/SingleModeSpec.scala
@@ -8,6 +8,9 @@ import beam.agentsim.events.PathTraversalEvent
 import beam.replanning.ModeIterationPlanCleaner
 import beam.router.Modes.BeamMode
 import beam.router.RouteHistory
+import beam.router.RoutingWorker
+import beam.router.r5.R5Wrapper
+import beam.router.r5.RouteDumper
 import beam.sflight.RouterForTest
 import beam.sim.common.GeoUtilsImpl
 import beam.sim.population.PopulationScaling
@@ -15,7 +18,13 @@ import beam.sim.{BeamHelper, BeamMobsim, RideHailFleetInitializerProvider}
 import beam.utils.{MathUtils, SimRunnerForTest}
 import beam.utils.TestConfigUtils.testConfig
 import com.typesafe.config.ConfigFactory
-import org.matsim.api.core.v01.events.{ActivityEndEvent, Event, PersonDepartureEvent, PersonEntersVehicleEvent}
+import org.matsim.api.core.v01.events.{
+  ActivityEndEvent,
+  Event,
+  PersonArrivalEvent,
+  PersonDepartureEvent,
+  PersonEntersVehicleEvent
+}
 import org.matsim.api.core.v01.population.{Activity, Leg}
 import org.matsim.core.events.handler.BasicEventHandler
 import org.scalatest.matchers.should.Matchers
@@ -26,6 +35,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
+import scala.util.Try
 
 class SingleModeSpec
     extends AnyWordSpecLike
@@ -35,12 +45,23 @@ class SingleModeSpec
     with BeamHelper
     with Matchers {
 
+  private val writeRoutingStatistic: Boolean =
+    sys.env.get("SINGLEMODE_WRITE_ROUTING_STATISTIC").exists(_.equalsIgnoreCase("true"))
+
+  private val routingDiagnostics: Boolean =
+    sys.env.get("SINGLEMODE_ROUTING_DIAGNOSTICS").exists(_.equalsIgnoreCase("true"))
+
+  private val writeR5RoutesInterval: Int =
+    sys.env.get("SINGLEMODE_WRITE_R5_ROUTES_INTERVAL").flatMap(v => Try(v.toInt).toOption).getOrElse(0)
+
   def config: com.typesafe.config.Config =
     ConfigFactory
       .parseString("""akka.test.timefactor = 10,
-          |beam.agentsim.agentSampleSizeAsFractionOfPopulation = 0.25
+          |beam.agentsim.agentSampleSizeAsFractionOfPopulation = 0.5
           |beam.agentsim.randomSeedForPopulationSampling = 12345
           |beam.agentsim.agents.vehicles.generateEmergencyHouseholdVehicleWhenPlansRequireIt = true
+          |beam.routing.writeRoutingStatistic = """ + writeRoutingStatistic + """
+          |beam.outputs.writeR5RoutesInterval = """ + writeR5RoutesInterval + """
           |""".stripMargin)
       .withFallback(testConfig("test/input/sf-light/sf-light-1k.conf").resolve())
 
@@ -186,17 +207,33 @@ class SingleModeSpec
           }
         }
       val events = mutable.ListBuffer[Event]()
+      val routingEvents = mutable.ListBuffer[Event]()
       services.matsimServices.getEvents.addHandler(
         new BasicEventHandler {
           override def handleEvent(event: Event): Unit = {
             event match {
-              case event @ (_: PersonDepartureEvent | _: ActivityEndEvent) =>
+              case event @ (_: PersonDepartureEvent | _: PersonArrivalEvent | _: ActivityEndEvent) =>
                 events += event
               case _ =>
             }
           }
         }
       )
+      if (routingDiagnostics) {
+        eventsManager.addHandler(
+          new BasicEventHandler {
+            override def handleEvent(event: Event): Unit = {
+              event match {
+                case event: RouteDumper.RoutingRequestEvent =>
+                  routingEvents += event
+                case event: RouteDumper.RoutingResponseEvent =>
+                  routingEvents += event
+                case _ =>
+              }
+            }
+          }
+        )
+      }
       val mobsim = new BeamMobsim(
         services,
         beamScenario,
@@ -218,13 +255,53 @@ class SingleModeSpec
 
       assert(events.nonEmpty)
       val personDepartureEvents = events.collect { case event: PersonDepartureEvent => event }
+      val personArrivalEvents = events.collect { case event: PersonArrivalEvent => event }
       personDepartureEvents should not be empty
       val regularPersonEvents = filterOutProfessionalDriversAndCavs(personDepartureEvents)
+      val regularPersonArrivalEvents = personArrivalEvents.filterNot(event =>
+        event.getLegMode == "be_a_tnc_driver" || event.getLegMode == "be_a_household_cav_driver" || event.getLegMode == "be_a_transit_driver" || event.getLegMode == "cav"
+      )
       val eventsByMode = regularPersonEvents.groupBy(_.getLegMode)
       //router gives too little 'drive transit' trips, most of the persons chooses 'car' in this case
       val modeCount = eventsByMode.mapValues(_.size)
+      val driveTransitDepartures = eventsByMode.get("drive_transit").map(_.size).getOrElse(0)
+      val walkTransitDepartures = eventsByMode.get("walk_transit").map(_.size).getOrElse(0)
+      val driveTransitArrivals = regularPersonArrivalEvents.count(_.getLegMode == "drive_transit")
+      val driveTransitShareVsWalk =
+        if (driveTransitDepartures + walkTransitDepartures > 0)
+          driveTransitDepartures.toDouble / (driveTransitDepartures + walkTransitDepartures).toDouble
+        else 0.0
+      val driveTransitArrivalRate =
+        if (driveTransitDepartures > 0) driveTransitArrivals.toDouble / driveTransitDepartures.toDouble else 0.0
+      if (routingDiagnostics) {
+        val routingRequests = routingEvents.collect { case event: RouteDumper.RoutingRequestEvent => event }
+        val routingResponses = routingEvents.collect { case event: RouteDumper.RoutingResponseEvent => event }
+        val driveTransitRequested =
+          routingRequests.count(_.routingRequest.requestedMode.contains(BeamMode.DRIVE_TRANSIT))
+        val driveTransitResponses =
+          routingResponses.count(_.routingResponse.request.exists(_.requestedMode.contains(BeamMode.DRIVE_TRANSIT)))
+        val driveTransitResponsesWithDriveItin = routingResponses.count(event =>
+          event.routingResponse.request.exists(_.requestedMode.contains(BeamMode.DRIVE_TRANSIT)) &&
+          event.routingResponse.itineraries.exists(_.tripClassifier == BeamMode.DRIVE_TRANSIT)
+        )
+        val driveTransitResponsesWithoutDriveItin = driveTransitResponses - driveTransitResponsesWithDriveItin
+        println(
+          s"[SINGLEMODE-ROUTING-DIAGNOSTICS] routingRequests=${routingRequests.size}, " +
+          s"routingResponses=${routingResponses.size}, driveTransitRequested=$driveTransitRequested, " +
+          s"driveTransitResponses=$driveTransitResponses, driveTransitResponsesWithDriveItin=$driveTransitResponsesWithDriveItin, " +
+          s"driveTransitResponsesWithoutDriveItin=$driveTransitResponsesWithoutDriveItin"
+        )
+        println(s"[SINGLEMODE-ROUTING-WORKER-DIAGNOSTICS] ${RoutingWorker.driveTransitDiagnosticsLine}")
+        println(s"[SINGLEMODE-R5-DRIVE-TRANSIT-DIAGNOSTICS] ${R5Wrapper.driveTransitDiagnosticsLine}")
+      }
+      println(
+        f"[SINGLEMODE-DRIVE-TRANSIT-METRICS] departuresTotal=${regularPersonEvents.size}%d " +
+        f"driveDepartures=$driveTransitDepartures%d walkDepartures=$walkTransitDepartures%d " +
+        f"driveArrivals=$driveTransitArrivals%d driveShareVsWalk=$driveTransitShareVsWalk%.6f " +
+        f"driveArrivalRate=$driveTransitArrivalRate%.6f"
+      )
       withClue(s"When transit is available some agents should use drive_transit: $modeCount") {
-        eventsByMode("walk_transit").size should be < 6 * eventsByMode("drive_transit").size
+        walkTransitDepartures should be < 6 * driveTransitDepartures
       }
 
       // TODO: Test that what can be printed with the line below makes sense (chains of modes)


### PR DESCRIPTION
## Summary
This PR improves drive-transit routing robustness/performance in the R5 integration and updates `SingleModeSpec` to be faster and more regression-sensitive.

## Why
`SingleModeSpec` was slow/flaky and was not strongly guarding against regressions in drive-transit viability.  
We also found drive-transit access stop search behavior that could prematurely stop and reduce feasible itineraries.

## What changed

### *Old issue with drive-transit routes*
The old heuristic was effectively treating “I can reach the destination link” as “stop searching for transit access stops now.” Previously:

1. For transit requests, BEAM first runs an R5 street search to collect candidate access stops (this is what `StopVisitor` is doing).
2. The old logic had a hard stop at `destinationSplit` (the two street vertices of the destination link).
3. As soon as the search frontier touched that split, the search terminated, even if it had collected zero (or too few) transit stops for drive access.

Why that was a problem for drive-transit:

1. Drive-transit often needs a stop that is not on the “direct-to-destination” street path.
2. The search is graph expansion, not “enumerate all useful stops within a conceptual radius.”
3. So reaching destination early on one branch could cut off exploration of other branches that would have found viable park-and-ride access stops.
4. Result: many requests looked like “no access stops,” not because no good drive-transit existed, but because we stopped searching too early.

The fix changed destination-split from a hard stop to a soft stop:
- after first hitting destination split, keep exploring until either:
1. we found at least `N` access stops (`continue_if_stops_below`, default `1`), or
2. we spent an extra vertex budget (`extra_vertices_after_hit`, default `5000`).

### Routing logic and performance
- Improved `StopVisitor` and related access-stop search behavior for drive-transit in:
  - `src/main/scala/beam/router/RoutingWorker.scala`
  - `src/main/scala/beam/router/r5/R5Wrapper.scala`
- Added configurable destination-split continuation controls for drive-transit access search (env-driven, defaulting to values that improve coverage while keeping runtime reasonable).
- Added/kept lightweight, env-gated diagnostics for drive-transit outcomes in `R5Wrapper`/`RoutingWorker`.
- Removed no-longer-needed break-reason string tracking in `StopVisitor`.

### Test updates (`SingleModeSpec`)
- Reduced sample size from `0.5` to `0.25` for faster CI/runtime.
- Removed brittle RouteDumper-based request/response instrumentation plumbing from the spec.
- Tightened drive-transit assertions to catch regressions:
  - `driveTransitDepartures > 0`
  - `driveShareVsWalk > 0.30`
  - `driveArrivalRate > 0.85`
- Hardened bike-transit assertions to avoid map-key exceptions and fail with clearer diagnostics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3925)
<!-- Reviewable:end -->
