### PR TITLE
tour vehicle handling improvements

### DIFF
--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -683,7 +683,22 @@ class PersonAgent(
         logDebug(s"wants to go to ${nextAct.getType} @ $tick")
         holdTickAndTriggerId(tick, triggerId)
         val modeOfNextLeg = _experiencedBeamPlan.getTripStrategy[TripModeChoiceStrategy](nextAct).mode
+        val currentTour = _experiencedBeamPlan.getTourContaining(nextAct)
         val currentTourModeChoiceStrategy = _experiencedBeamPlan.getTourStrategy[TourModeChoiceStrategy](nextAct)
+        val sanitizedCurrentTourModeChoiceStrategy =
+          currentTourModeChoiceStrategy.tourVehicle match {
+            case Some(vehicleId)
+                if BeamVehicle.isEmergencyVehicle(vehicleId) &&
+                  !beamVehicles.contains(vehicleId) =>
+              logger.debug(
+                s"Person ${this.id}: Clearing stale emergency tour vehicle $vehicleId before ChoosingMode"
+              )
+              val updatedStrategy = TourModeChoiceStrategy(currentTourModeChoiceStrategy.tourMode, None)
+              _experiencedBeamPlan.putStrategy(currentTour, updatedStrategy)
+              updatedStrategy
+            case _ =>
+              currentTourModeChoiceStrategy
+          }
         val currentCoord = currentActivity(data).getCoord
         val nextCoord = nextActivity(data).get.getCoord
 
@@ -693,12 +708,12 @@ class PersonAgent(
             // If we have the currentTourPersonalVehicle then we should use it
             // use the mode of the next leg as the new trip mode.
             currentTripMode = modeOfNextLeg,
-            currentTourMode = currentTourModeChoiceStrategy.tourMode,
+            currentTourMode = sanitizedCurrentTourModeChoiceStrategy.tourMode,
             // Prefer the currently carried vehicle over the current tour strategy. During replanning, the
             // current tour strategy may be cleared while the person still needs to hold onto a parent-tour
             // vehicle that remains physically available.
             currentTourPersonalVehicle =
-              data.currentTourPersonalVehicle.orElse(currentTourModeChoiceStrategy.tourVehicle),
+              data.currentTourPersonalVehicle.orElse(sanitizedCurrentTourModeChoiceStrategy.tourVehicle),
             passengerSchedule = PassengerSchedule(),
             numberOfReplanningAttempts = 0,
             failedTrips = IndexedSeq.empty,

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -695,7 +695,7 @@ class PersonAgent(
             currentTripMode = modeOfNextLeg,
             currentTourMode = currentTourModeChoiceStrategy.tourMode,
             currentTourPersonalVehicle =
-              currentTourModeChoiceStrategy.tourVehicle.orElse(data.currentTourPersonalVehicle),
+              data.currentTourPersonalVehicle.orElse(currentTourModeChoiceStrategy.tourVehicle),
             passengerSchedule = PassengerSchedule(),
             numberOfReplanningAttempts = 0,
             failedTrips = IndexedSeq.empty,
@@ -801,12 +801,24 @@ class PersonAgent(
             s"Person ${this.id}: Current tour strategy references vehicle $currentTourVehicle " +
             s"in $context, but it's not available. Available vehicles: ${availableVehicleIds.mkString(", ")}"
           )
+          logTourVehicleDiagnostics(
+            newPersonData,
+            availableVehicles,
+            context,
+            s"current-tour-strategy vehicle $currentTourVehicle missing from available vehicle set"
+          )
         }
         // Also check if personData is being reset to None while strategy has vehicle
         if (newPersonData.currentTourPersonalVehicle.isEmpty) {
           logger.warn(
             s"Person ${this.id}: currentTourPersonalVehicle reset to None in $context, " +
             s"but current tour strategy still references vehicle $currentTourVehicle"
+          )
+          logTourVehicleDiagnostics(
+            newPersonData,
+            availableVehicles,
+            context,
+            s"current-tour-strategy vehicle $currentTourVehicle set while personData currentTourPersonalVehicle is empty"
           )
         }
       case None => // No current tour vehicle, that's fine
@@ -821,12 +833,24 @@ class PersonAgent(
             s"Person ${this.id}: Parent tour strategy references vehicle $parentTourVehicle " +
             s"in $context, but it's not available. Available vehicles: ${availableVehicleIds.mkString(", ")}"
           )
+          logTourVehicleDiagnostics(
+            newPersonData,
+            availableVehicles,
+            context,
+            s"parent-tour-strategy vehicle $parentTourVehicle missing from available vehicle set"
+          )
         }
         // Also check if personData is being reset to None while parent strategy has vehicle
         if (newPersonData.currentTourPersonalVehicle.isEmpty) {
           logger.warn(
             s"Person ${this.id}: currentTourPersonalVehicle reset to None in $context, " +
             s"but parent tour strategy still references vehicle $parentTourVehicle"
+          )
+          logTourVehicleDiagnostics(
+            newPersonData,
+            availableVehicles,
+            context,
+            s"parent-tour-strategy vehicle $parentTourVehicle set while personData currentTourPersonalVehicle is empty"
           )
         }
       case Some(parentTourVehicle) =>
@@ -836,6 +860,61 @@ class PersonAgent(
         )
       case _ => // No parent tour vehicle, that's fine
     }
+  }
+
+  protected def logTourVehicleDiagnostics(
+    data: BasePersonData,
+    availableVehicles: Vector[VehicleOrToken],
+    context: String,
+    reason: String
+  ): Unit = {
+    def formatCoord(coord: Coord): String =
+      if (coord == null) "null" else f"(${coord.getX}%.1f,${coord.getY}%.1f)"
+
+    def formatActivity(activity: Activity): String =
+      s"${activity.getType}@${formatCoord(activity.getCoord)} link=${Option(activity.getLinkId).map(_.toString).getOrElse("null")}"
+
+    def formatLeg(leg: Leg): String = {
+      val attrs = leg.getAttributes
+      val tourId = Option(attrs.getAttribute("tour_id")).getOrElse("null")
+      val tourMode = Option(attrs.getAttribute("tour_mode")).getOrElse("null")
+      val tourVehicle = Option(attrs.getAttribute("tour_vehicle")).getOrElse("null")
+      s"mode=${leg.getMode},tourId=$tourId,tourMode=$tourMode,tourVehicle=$tourVehicle"
+    }
+
+    def formatTour(tour: Tour): String = {
+      val strategy = _experiencedBeamPlan.getStrategy[TourModeChoiceStrategy](tour)
+      val acts = tour.activities.map(_.getType).mkString("->")
+      val origin = tour.originActivity.map(_.getType).getOrElse("none")
+      s"id=${tour.tourId},origin=$origin,activities=$acts,strategy=$strategy"
+    }
+
+    val currentActOpt = Try(currentActivity(data)).toOption
+    val nextActOpt = nextActivity(data)
+    val currentTourOpt = Try(currentTour(data)).toOption
+    val currentTourStrategyOpt = Try(getCurrentTourStrategy(data)).toOption
+    val parentTourOpt =
+      currentTourOpt.flatMap(_.originActivity.flatMap(act => Try(_experiencedBeamPlan.getTourContaining(act)).toOption))
+    val parentTourStrategyOpt = Try(getParentTourStrategy(data)).toOption.flatten
+    val nextTripLegOpt = nextActOpt.flatMap(act => Try(_experiencedBeamPlan.getTripContaining(act).leg).toOption.flatten)
+    val availableVehicleIds = availableVehicles.map(_.id).mkString(", ")
+    val beamVehicleIds = beamVehicles.keys.map(_.toString).toVector.sorted.mkString(", ")
+    val allTours = _experiencedBeamPlan.tours.map(formatTour).mkString(" || ")
+    val tripStrategyOpt = nextActOpt.map(act => _experiencedBeamPlan.getTripStrategy[TripModeChoiceStrategy](act))
+
+    logger.debug(
+      s"Person ${this.id}: Tour vehicle diagnostics [$reason] in $context. " +
+      s"state=$stateName, tick=${_currentTick.getOrElse(-1)}, currentActivityIndex=${data.currentActivityIndex}, " +
+      s"currentActivity=${currentActOpt.map(formatActivity).getOrElse("none")}, " +
+      s"nextActivity=${nextActOpt.map(formatActivity).getOrElse("none")}, " +
+      s"personData(currentTripMode=${data.currentTripMode}, currentTourMode=${data.currentTourMode}, " +
+      s"currentTourPersonalVehicle=${data.currentTourPersonalVehicle}, hasDeparted=${data.hasDeparted}, " +
+      s"numberOfReplanningAttempts=${data.numberOfReplanningAttempts}), " +
+      s"tripStrategy=${tripStrategyOpt.getOrElse("none")}, currentTour=${currentTourOpt.map(formatTour).getOrElse("none")}, " +
+      s"currentTourStrategy=${currentTourStrategyOpt.getOrElse("none")}, parentTour=${parentTourOpt.map(formatTour).getOrElse("none")}, " +
+      s"parentTourStrategy=${parentTourStrategyOpt.getOrElse("none")}, nextTripLeg=${nextTripLegOpt.map(formatLeg).getOrElse("none")}, " +
+      s"availableVehicleIds=[$availableVehicleIds], beamVehicleIds=[$beamVehicleIds], allTours=[$allTours]"
+    )
   }
 
   private def canUseCars(currentCoord: Coord, nextCoord: Coord): Boolean = {
@@ -911,6 +990,7 @@ class PersonAgent(
       rideHail2TransitRoutingResponse = None,
       rideHail2TransitAccessResult = None,
       rideHail2TransitEgressResult = None,
+      allAvailableStreetVehicles = beamVehicles.values.toVector,
       isWithinTripReplanning = true,
       excludeModes = (if (data.numberOfReplanningAttempts > 0) Set(RIDE_HAIL, RIDE_HAIL_POOLED, RIDE_HAIL_TRANSIT)
                       else Set()) ++ (if (canUseCars(currentCoord, nextCoord)) Set.empty[BeamMode]
@@ -971,6 +1051,7 @@ class PersonAgent(
         rideHail2TransitRoutingResponse = None,
         rideHail2TransitAccessResult = None,
         rideHail2TransitEgressResult = None,
+        allAvailableStreetVehicles = beamVehicles.values.toVector,
         isWithinTripReplanning = true,
         excludeModes = excludedMode.toSet ++ (
           if (canUseCars(currentCoord, nextCoord)) Set.empty
@@ -1460,6 +1541,7 @@ class PersonAgent(
         rideHail2TransitRoutingResponse = None,
         rideHail2TransitAccessResult = None,
         rideHail2TransitEgressResult = None,
+        allAvailableStreetVehicles = beamVehicles.values.toVector,
         isWithinTripReplanning = true,
         excludeModes = excludedMode.toSet ++ (if (canUseCars(currentCoord, nextCoord)) Set.empty
                                               else Set(BeamMode.RIDE_HAIL, BeamMode.CAR, BeamMode.CAV))
@@ -1685,7 +1767,8 @@ class PersonAgent(
             triggerId,
             Vector(ScheduleTrigger(ActivityEndTrigger(nextLegDepartureTime), self))
           )
-          val currentTourStrategy = _experiencedBeamPlan.getStrategy[TourModeChoiceStrategy](currentTour(data))
+          val currentTourAtArrival = currentTour(data)
+          val currentTourStrategy = _experiencedBeamPlan.getStrategy[TourModeChoiceStrategy](currentTourAtArrival)
 
           goto(PerformingActivity) using data.copy(
             currentActivityIndex = data.currentActivityIndex + 1,
@@ -1696,10 +1779,47 @@ class PersonAgent(
               case Some(personalVehId) if beamVehicles.contains(personalVehId) =>
                 val personalVeh = beamVehicles(personalVehId).asInstanceOf[ActualVehicle].vehicle
                 if (atHome(activity) && _experiencedBeamPlan.isLastElementInTour(activity)) {
-                  potentiallyChargingBeamVehicles.put(personalVeh.id, beamVehicles(personalVeh.id))
-                  beamVehicles -= personalVeh.id
-                  personalVeh.getManager.get ! ReleaseVehicle(personalVeh, triggerId)
-                  None
+                  val parentStrategyOpt = getParentTourStrategy(data)
+                  val nextActivityAfterArrival = _experiencedBeamPlan.activities.lift(data.currentActivityIndex + 2)
+                  val nextTourStrategyOpt =
+                    nextActivityAfterArrival.map(_experiencedBeamPlan.getTourStrategy[TourModeChoiceStrategy])
+                  val currentTourOriginReason = currentTourAtArrival.originActivity.flatMap { act =>
+                    val originType = act.getType
+                    if (originType.equalsIgnoreCase("home") || originType.equalsIgnoreCase("work")) None
+                    else Some(s"completed tour origin is $originType")
+                  }
+                  val suppressReleaseReasons = Vector(
+                    currentTourOriginReason,
+                    parentStrategyOpt.filter(_.tourVehicle.contains(personalVehId)).map(_ =>
+                      s"parent tour still references vehicle $personalVehId"
+                    ),
+                    nextTourStrategyOpt.filter(_.tourVehicle.contains(personalVehId)).map(_ =>
+                      s"next activity's tour strategy still references vehicle $personalVehId"
+                    )
+                  ).flatten
+                  val postArrivalLookahead =
+                    s"postArrivalNextActivity=${nextActivityAfterArrival.map(_.getType).getOrElse("none")}, " +
+                    s"postArrivalNextTourStrategy=${nextTourStrategyOpt.getOrElse("none")}"
+
+                  if (suppressReleaseReasons.nonEmpty) {
+                    logger.debug(
+                      s"Suppressing release of vehicle $personalVehId for person ${this.id} at end-of-tour home " +
+                      s"arrival because ${suppressReleaseReasons.mkString("; ")}. $postArrivalLookahead"
+                    )
+                    logTourVehicleDiagnostics(
+                      data,
+                      beamVehicles.values.toVector,
+                      "Arriving at home on last element in current tour",
+                      s"suppressed release of vehicle $personalVehId because ${suppressReleaseReasons.mkString("; ")}; " +
+                        postArrivalLookahead
+                    )
+                    data.currentTourPersonalVehicle
+                  } else {
+                    potentiallyChargingBeamVehicles.put(personalVeh.id, beamVehicles(personalVeh.id))
+                    beamVehicles -= personalVeh.id
+                    personalVeh.getManager.get ! ReleaseVehicle(personalVeh, triggerId)
+                    None
+                  }
                 } else if (_experiencedBeamPlan.isLastElementInTour(data.currentActivityIndex + 1)) {
                   getParentTourStrategy(data) match {
                     case Some(parentStrategy) =>
@@ -1713,7 +1833,7 @@ class PersonAgent(
                           .map(x => x.toString)
                           .getOrElse("HOME")}, but not currently on a " +
                         s"subtour. Keeping my current vehicle. Perhaps there was a malformed tour for " +
-                        s"person ${this.id}: ${currentTour(data).activities.map(act => act.getType + "->")}"
+                        s"person ${this.id}: ${currentTourAtArrival.activities.map(act => act.getType + "->")}"
                       )
                       data.currentTourPersonalVehicle
                   }

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -1233,6 +1233,10 @@ class PersonAgent(
         nextNotifyVehicleResourceIdle.foreach(notifyVehicleIdle =>
           currentBeamVehicle.getManager match {
             case Some(manager) => manager ! notifyVehicleIdle
+            case None if BeamVehicle.isSharedTeleportationVehicle(currentBeamVehicle.id) =>
+              logger.debug(
+                s"Dropping shared teleportation vehicle ${currentBeamVehicle.id} without idle notification"
+              )
             case None =>
               logger.error(
                 s"Vehicle ${currentBeamVehicle.id} does not have a manager, " +
@@ -1256,7 +1260,16 @@ class PersonAgent(
             )) || BeamVehicle.isSharedTeleportationVehicle(currentBeamVehicle.id)
           ) {
             // Is a shared vehicle. Give it up.
-            currentBeamVehicle.getManager.get ! ReleaseVehicle(currentBeamVehicle, triggerId)
+            currentBeamVehicle.getManager match {
+              case Some(manager) =>
+                manager ! ReleaseVehicle(currentBeamVehicle, triggerId)
+              case _ if BeamVehicle.isSharedTeleportationVehicle(currentBeamVehicle.id) =>
+                logger.debug(
+                  s"Dropping shared teleportation vehicle ${currentBeamVehicle.id} without manager release"
+                )
+              case _ =>
+                logger.warn(s"Giving up vehicle ${currentBeamVehicle.id}, which doesn't have a manager set")
+            }
             beamVehicles -= data.currentVehicle.head
           }
         }
@@ -1315,13 +1328,13 @@ class PersonAgent(
       _experiencedBeamPlan.putStrategy(nextAct, TripModeChoiceStrategy(mode = None))
       val (updatedTourMode, updatedTourPersonalVehicle): (Option[BeamTourMode], Option[Id[BeamVehicle]]) =
         if (nextAct.getType.equalsIgnoreCase("Home")) { (None, None) }
-        else { (basePersonData.currentTourMode, basePersonData.currentTourPersonalVehicle) }
+        else { (basePersonData.currentTourMode, sanitizeTourPersonalVehicle(basePersonData.currentTourPersonalVehicle)) }
       goto(ChoosingMode) using ChoosesModeData.validated(
         basePersonData.copy(
           currentTrip = None,
           restOfCurrentTrip = List.empty[EmbodiedBeamLeg],
           currentTripMode = Some(WALK_TRANSIT),
-          currentTourPersonalVehicle = updatedTourPersonalVehicle,
+          currentTourPersonalVehicle = sanitizeTourPersonalVehicle(updatedTourPersonalVehicle),
           passengerSchedule = PassengerSchedule(),
           numberOfReplanningAttempts = basePersonData.numberOfReplanningAttempts + 1,
           failedTrips = basePersonData.failedTrips ++ basePersonData.currentTrip.map(trip =>
@@ -1663,7 +1676,7 @@ class PersonAgent(
           val nextTripTourPersonalVehicle = if (activity.getType.equalsIgnoreCase("Home")) {
             None
           } else {
-            data.currentTourPersonalVehicle
+            sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle)
           }
           goto(PerformingActivity) using data.copy(
             currentActivityIndex = data.currentActivityIndex + 1,
@@ -1775,7 +1788,7 @@ class PersonAgent(
             currentTrip = None,
             restOfCurrentTrip = List(),
             currentTripMode = None,
-            currentTourPersonalVehicle = data.currentTourPersonalVehicle match {
+            currentTourPersonalVehicle = sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle) match {
               case Some(personalVehId) if beamVehicles.contains(personalVehId) =>
                 val personalVeh = beamVehicles(personalVehId).asInstanceOf[ActualVehicle].vehicle
                 if (atHome(activity) && _experiencedBeamPlan.isLastElementInTour(activity)) {
@@ -1813,11 +1826,23 @@ class PersonAgent(
                       s"suppressed release of vehicle $personalVehId because ${suppressReleaseReasons.mkString("; ")}; " +
                         postArrivalLookahead
                     )
-                    data.currentTourPersonalVehicle
+                    sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle)
                   } else {
-                    potentiallyChargingBeamVehicles.put(personalVeh.id, beamVehicles(personalVeh.id))
+                    val personalVehState = beamVehicles(personalVeh.id)
                     beamVehicles -= personalVeh.id
-                    personalVeh.getManager.get ! ReleaseVehicle(personalVeh, triggerId)
+                    if (BeamVehicle.isSharedTeleportationVehicle(personalVeh.id)) {
+                      logger.debug(
+                        s"Dropping shared teleportation vehicle ${personalVeh.id} at home arrival without manager release"
+                      )
+                    } else {
+                      potentiallyChargingBeamVehicles.put(personalVeh.id, personalVehState)
+                      personalVeh.getManager match {
+                        case Some(manager) =>
+                          manager ! ReleaseVehicle(personalVeh, triggerId)
+                        case _ =>
+                          logger.warn(s"Giving up vehicle ${personalVeh.id}, which doesn't have a manager set")
+                      }
+                    }
                     None
                   }
                 } else if (_experiencedBeamPlan.isLastElementInTour(data.currentActivityIndex + 1)) {
@@ -1835,11 +1860,16 @@ class PersonAgent(
                         s"subtour. Keeping my current vehicle. Perhaps there was a malformed tour for " +
                         s"person ${this.id}: ${currentTourAtArrival.activities.map(act => act.getType + "->")}"
                       )
-                      data.currentTourPersonalVehicle
+                      sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle)
                   }
                 } else {
-                  data.currentTourPersonalVehicle
+                  sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle)
                 }
+              case Some(personalVehId) if BeamVehicle.isSharedTeleportationVehicle(personalVehId) =>
+                logger.debug(
+                  s"Shared teleportation vehicle $personalVehId was already dropped for person ${this.id}"
+                )
+                None
               case Some(personalVehId) =>
                 logger.error(s"Vehicle ${personalVehId.toString} seems to have disappeared")
                 logger.warn("Events leading up to this point:\n\t" + getLog.mkString("\n\t"))
@@ -2118,6 +2148,11 @@ class PersonAgent(
       }
     }
   }
+
+  private def sanitizeTourPersonalVehicle(
+    vehicleId: Option[Id[BeamVehicle]]
+  ): Option[Id[BeamVehicle]] =
+    vehicleId.filterNot(BeamVehicle.isSharedTeleportationVehicle)
 
   protected def getParentTourStrategy(
     data: BasePersonData

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -896,7 +896,8 @@ class PersonAgent(
     val parentTourOpt =
       currentTourOpt.flatMap(_.originActivity.flatMap(act => Try(_experiencedBeamPlan.getTourContaining(act)).toOption))
     val parentTourStrategyOpt = Try(getParentTourStrategy(data)).toOption.flatten
-    val nextTripLegOpt = nextActOpt.flatMap(act => Try(_experiencedBeamPlan.getTripContaining(act).leg).toOption.flatten)
+    val nextTripLegOpt =
+      nextActOpt.flatMap(act => Try(_experiencedBeamPlan.getTripContaining(act).leg).toOption.flatten)
     val availableVehicleIds = availableVehicles.map(_.id).mkString(", ")
     val beamVehicleIds = beamVehicles.keys.map(_.toString).toVector.sorted.mkString(", ")
     val allTours = _experiencedBeamPlan.tours.map(formatTour).mkString(" || ")
@@ -911,8 +912,10 @@ class PersonAgent(
       s"currentTourPersonalVehicle=${data.currentTourPersonalVehicle}, hasDeparted=${data.hasDeparted}, " +
       s"numberOfReplanningAttempts=${data.numberOfReplanningAttempts}), " +
       s"tripStrategy=${tripStrategyOpt.getOrElse("none")}, currentTour=${currentTourOpt.map(formatTour).getOrElse("none")}, " +
-      s"currentTourStrategy=${currentTourStrategyOpt.getOrElse("none")}, parentTour=${parentTourOpt.map(formatTour).getOrElse("none")}, " +
-      s"parentTourStrategy=${parentTourStrategyOpt.getOrElse("none")}, nextTripLeg=${nextTripLegOpt.map(formatLeg).getOrElse("none")}, " +
+      s"currentTourStrategy=${currentTourStrategyOpt
+        .getOrElse("none")}, parentTour=${parentTourOpt.map(formatTour).getOrElse("none")}, " +
+      s"parentTourStrategy=${parentTourStrategyOpt
+        .getOrElse("none")}, nextTripLeg=${nextTripLegOpt.map(formatLeg).getOrElse("none")}, " +
       s"availableVehicleIds=[$availableVehicleIds], beamVehicleIds=[$beamVehicleIds], allTours=[$allTours]"
     )
   }
@@ -1328,7 +1331,9 @@ class PersonAgent(
       _experiencedBeamPlan.putStrategy(nextAct, TripModeChoiceStrategy(mode = None))
       val (updatedTourMode, updatedTourPersonalVehicle): (Option[BeamTourMode], Option[Id[BeamVehicle]]) =
         if (nextAct.getType.equalsIgnoreCase("Home")) { (None, None) }
-        else { (basePersonData.currentTourMode, sanitizeTourPersonalVehicle(basePersonData.currentTourPersonalVehicle)) }
+        else {
+          (basePersonData.currentTourMode, sanitizeTourPersonalVehicle(basePersonData.currentTourPersonalVehicle))
+        }
       goto(ChoosingMode) using ChoosesModeData.validated(
         basePersonData.copy(
           currentTrip = None,
@@ -1803,12 +1808,12 @@ class PersonAgent(
                   }
                   val suppressReleaseReasons = Vector(
                     currentTourOriginReason,
-                    parentStrategyOpt.filter(_.tourVehicle.contains(personalVehId)).map(_ =>
-                      s"parent tour still references vehicle $personalVehId"
-                    ),
-                    nextTourStrategyOpt.filter(_.tourVehicle.contains(personalVehId)).map(_ =>
-                      s"next activity's tour strategy still references vehicle $personalVehId"
-                    )
+                    parentStrategyOpt
+                      .filter(_.tourVehicle.contains(personalVehId))
+                      .map(_ => s"parent tour still references vehicle $personalVehId"),
+                    nextTourStrategyOpt
+                      .filter(_.tourVehicle.contains(personalVehId))
+                      .map(_ => s"next activity's tour strategy still references vehicle $personalVehId")
                   ).flatten
                   val postArrivalLookahead =
                     s"postArrivalNextActivity=${nextActivityAfterArrival.map(_.getType).getOrElse("none")}, " +
@@ -1824,7 +1829,7 @@ class PersonAgent(
                       beamVehicles.values.toVector,
                       "Arriving at home on last element in current tour",
                       s"suppressed release of vehicle $personalVehId because ${suppressReleaseReasons.mkString("; ")}; " +
-                        postArrivalLookahead
+                      postArrivalLookahead
                     )
                     sanitizeTourPersonalVehicle(data.currentTourPersonalVehicle)
                   } else {

--- a/src/main/scala/beam/agentsim/agents/PersonAgent.scala
+++ b/src/main/scala/beam/agentsim/agents/PersonAgent.scala
@@ -694,6 +694,9 @@ class PersonAgent(
             // use the mode of the next leg as the new trip mode.
             currentTripMode = modeOfNextLeg,
             currentTourMode = currentTourModeChoiceStrategy.tourMode,
+            // Prefer the currently carried vehicle over the current tour strategy. During replanning, the
+            // current tour strategy may be cleared while the person still needs to hold onto a parent-tour
+            // vehicle that remains physically available.
             currentTourPersonalVehicle =
               data.currentTourPersonalVehicle.orElse(currentTourModeChoiceStrategy.tourVehicle),
             passengerSchedule = PassengerSchedule(),

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -853,28 +853,6 @@ trait ChoosesMode {
         )
       }
 
-      // If person plan doesn't have a route for an activity create and save it
-      for {
-        activity <- nextActivity(choosesModeData.personData)
-        leg      <- _experiencedBeamPlan.getTripContaining(activity).leg if leg.getRoute == null
-      } {
-        val links =
-          response.itineraries
-            .flatMap(_.beamLegs)
-            .find(_.mode == BeamMode.CAR)
-            .map { beamLeg =>
-              beamLeg.travelPath.linkIds
-                .map(id => Id.create(id, classOf[Link]))
-                .toList
-            }
-            .getOrElse(List.empty)
-
-        if (links.nonEmpty) {
-          val route = RouteUtils.createNetworkRoute(JavaConverters.seqAsJavaList(links), beamScenario.network)
-          leg.setRoute(route)
-        }
-      }
-
       stay() using newData
 
     case Event(theRideHailResult: RideHailResponse, choosesModeData: ChoosesModeData) =>
@@ -1213,10 +1191,14 @@ trait ChoosesMode {
   ): Option[Id[BeamVehicle]] = {
     getParentTourStrategy(personData)
       .flatMap(_.tourVehicle)
+      .filterNot(BeamVehicle.isSharedTeleportationVehicle)
       .filter { parentVehicleId =>
         availableVehicles.exists(_.id == parentVehicleId)
       }
   }
+
+  private def sanitizeTourVehicleId(vehicleId: Option[Id[BeamVehicle]]): Option[Id[BeamVehicle]] =
+    vehicleId.filterNot(BeamVehicle.isSharedTeleportationVehicle)
 
   case object FinishingModeChoice extends BeamAgentState
 
@@ -1742,11 +1724,13 @@ trait ChoosesMode {
       def resolvedCurrentTourPersonalVehicle(chosenTrip: EmbodiedBeamTrip): Option[Id[BeamVehicle]] =
         // Keep the already-held vehicle unless this choice selected a more specific one. This allows a failed or
         // reset subtour to continue carrying an inherited parent-tour vehicle through replanning.
-        chosenCurrentTourPersonalVehicle
+        sanitizeTourVehicleId(
+          chosenCurrentTourPersonalVehicle
           .get(chosenTrip)
           .flatten
           .orElse(choosesModeData.personData.currentTourPersonalVehicle)
           .orElse(getInheritedTourVehicle(choosesModeData.personData, allAvailableStreetVehicles))
+        )
 
       def gotoFinishingModeChoice(chosenTrip: EmbodiedBeamTrip) = {
         goto(FinishingModeChoice) using choosesModeData.safeCopy(
@@ -3199,7 +3183,8 @@ trait ChoosesMode {
               None
           }
 
-        val effectiveTourVehicle = choosesModeData.personData.currentTourPersonalVehicle
+        val effectiveTourVehicle = sanitizeTourVehicleId(
+          choosesModeData.personData.currentTourPersonalVehicle
           .orElse(
             // Check if current tour strategy has a vehicle that's available
             currentTourStrategy.tourVehicle.filter(vehicleId => distinctAvailableVehicles.exists(_.id == vehicleId))
@@ -3207,6 +3192,7 @@ trait ChoosesMode {
           .orElse(getInheritedTourVehicle(choosesModeData.personData, distinctAvailableVehicles))
           .orElse(recoveredVehicleFromItineraries)
           .orElse(recoveredVehicleFromAvailableVehicles)
+        )
 
         (
           Some(tourMode),
@@ -3276,10 +3262,11 @@ trait ChoosesMode {
                         if tourMode
                           .allowedBeamModesGivenAvailableVehicles(availableVehicles, firstOrLastLeg = true)
                           .contains(itin.tripClassifier) =>
-                      itin.vehiclesInTrip
+                      sanitizeTourVehicleId(
+                        itin.vehiclesInTrip
                         .find(availableVehicles.map(_.id).contains)
                         .orElse(parentTourStrategy.flatMap(_.tourVehicle).filter(itin.vehiclesInTrip.contains))
-                        .map(vid => itin -> Some(vid))
+                      ).map(vid => itin -> Some(vid))
                   }
                   .flatten
                   .toMap
@@ -3387,6 +3374,16 @@ trait ChoosesMode {
         )
     }
 
+    for {
+      chosenTrip <- chosenTripMaybe
+      destinationActivity <- nextActivity(data.personData)
+      leg <- _experiencedBeamPlan.getTripContaining(destinationActivity).leg
+      originLinkId <- Option(_experiencedBeamPlan.activities(data.personData.currentActivityIndex).getLinkId)
+      destinationLinkId <- Option(destinationActivity.getLinkId)
+    } {
+      updateMatsimPlanLegRoute(leg, chosenTrip, originLinkId, destinationLinkId)
+    }
+
     val tripId: String = _experiencedBeamPlan.trips
       .lift(data.personData.currentActivityIndex + 1) match {
       case Some(trip) =>
@@ -3420,6 +3417,34 @@ trait ChoosesMode {
       tripId
     )
     eventsManager.processEvent(modeChoiceEvent)
+  }
+
+  private def updateMatsimPlanLegRoute(
+    leg: Leg,
+    chosenTrip: EmbodiedBeamTrip,
+    originLinkId: Id[Link],
+    destinationLinkId: Id[Link]
+  ): Unit = {
+    val networkLegOpt = chosenTrip.legs.find { embodiedLeg =>
+      embodiedLeg.asDriver &&
+      embodiedLeg.beamLeg.mode != WALK &&
+      !embodiedLeg.beamLeg.mode.isTransit &&
+      embodiedLeg.beamLeg.travelPath.linkIds.nonEmpty
+    }
+
+    val route =
+      networkLegOpt match {
+        case Some(networkLeg) =>
+          val links = networkLeg.beamLeg.travelPath.linkIds.map(id => Id.create(id, classOf[Link])).toList
+          RouteUtils.createNetworkRoute(JavaConverters.seqAsJavaList(links), beamScenario.network)
+        case _ =>
+          RouteUtils.createGenericRouteImpl(originLinkId, destinationLinkId)
+      }
+
+    route.setTravelTime(chosenTrip.totalTravelTimeInSecs.toDouble)
+    route.setDistance(chosenTrip.totalDistanceInM)
+    leg.setRoute(route)
+    leg.setTravelTime(chosenTrip.totalTravelTimeInSecs)
   }
 
   private def updateTourModeStrategy(
@@ -3477,6 +3502,7 @@ trait ChoosesMode {
     vehicles: Vector[VehicleOrToken],
     allowVehicleBasedTourWithoutVehicle: Boolean = false
   ): TourModeChoiceStrategy = {
+    val sanitizedTourVehicle = sanitizeTourVehicleId(newTourVehicle)
     (newTourMode, newTourVehicle) match {
       case (Some(tourMode), None) if tourMode.isVehicleBased && allowVehicleBasedTourWithoutVehicle =>
         logger.debug(
@@ -3514,7 +3540,7 @@ trait ChoosesMode {
     val updatedTourStrategy =
       TourModeChoiceStrategy(
         newTourMode,
-        newTourVehicle
+        sanitizedTourVehicle
       )
     _experiencedBeamPlan.putStrategy(tour, updatedTourStrategy)
     updatedTourStrategy

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -65,7 +65,7 @@ trait ChoosesMode {
   this: PersonAgent => // Self type restricts this trait to only mix into a PersonAgent
 
   private val BUFFER_PER_REPLANNING_ATTEMPT_IN_SEC: Int = 5
-  private val MAX_FINAL_INTERMODAL_EGRESS_ROUTE_ATTEMPTS: Int = 3
+  private val MAX_FINAL_INTERMODAL_EGRESS_ROUTE_ATTEMPTS: Int = 2
 
   private val dummyRHVehicle: StreetVehicle = createDummyVehicle(
     RideHailVehicleId.dummyVehicleId,
@@ -182,16 +182,19 @@ trait ChoosesMode {
           .mkString("[", ", ", "]")
       }
 
-    val requestSummary = routingResponseOpt.flatMap(_.request).map { request =>
-      val requestVehicleIds = request.streetVehicles.map(_.id.toString).mkString("[", ", ", "]")
-      val possibleEgressVehicleIds = request.possibleEgressVehicles.map(_.id.toString).mkString("[", ", ", "]")
-      s"requestId=${request.requestId}, departureTime=${request.departureTime}, withTransit=${request.withTransit}, " +
-      s"requestedMode=${request.requestedMode.map(_.value).getOrElse("None")}, " +
-      s"intermodalUse=${request.streetVehiclesUseIntermodalUse}, searchedModes=${routingResponseOpt
-        .map(_.searchedModes.map(_.value).toVector.sorted.mkString("[", ", ", "]"))
-        .getOrElse("[]")}, heldVehicleInRequest=${request.streetVehicles.exists(_.id == vehicleId)}, " +
-      s"requestStreetVehicles=$requestVehicleIds, possibleEgressVehicles=$possibleEgressVehicleIds"
-    }.getOrElse("request=none")
+    val requestSummary = routingResponseOpt
+      .flatMap(_.request)
+      .map { request =>
+        val requestVehicleIds = request.streetVehicles.map(_.id.toString).mkString("[", ", ", "]")
+        val possibleEgressVehicleIds = request.possibleEgressVehicles.map(_.id.toString).mkString("[", ", ", "]")
+        s"requestId=${request.requestId}, departureTime=${request.departureTime}, withTransit=${request.withTransit}, " +
+        s"requestedMode=${request.requestedMode.map(_.value).getOrElse("None")}, " +
+        s"intermodalUse=${request.streetVehiclesUseIntermodalUse}, searchedModes=${routingResponseOpt
+          .map(_.searchedModes.map(_.value).toVector.sorted.mkString("[", ", ", "]"))
+          .getOrElse("[]")}, heldVehicleInRequest=${request.streetVehicles.exists(_.id == vehicleId)}, " +
+        s"requestStreetVehicles=$requestVehicleIds, possibleEgressVehicles=$possibleEgressVehicleIds"
+      }
+      .getOrElse("request=none")
 
     val heldVehicleLocation = routingResponseOpt
       .flatMap(_.request)
@@ -1392,15 +1395,16 @@ trait ChoosesMode {
 
     def logDangerousEmergencyVehicleDrop(beamVehicle: BeamVehicle, branch: String): Unit = {
       val reasons = Vector(
-        personData.currentTourPersonalVehicle.filter(_ == beamVehicle.id).map(_ =>
-          s"personData.currentTourPersonalVehicle=${beamVehicle.id}"
-        ),
-        currentTourStrategy.tourVehicle.filter(_ == beamVehicle.id).map(_ =>
-          s"currentTourStrategy.tourVehicle=${beamVehicle.id}"
-        ),
-        parentTourStrategy.flatMap(_.tourVehicle).filter(_ == beamVehicle.id).map(_ =>
-          s"parentTourStrategy.tourVehicle=${beamVehicle.id}"
-        )
+        personData.currentTourPersonalVehicle
+          .filter(_ == beamVehicle.id)
+          .map(_ => s"personData.currentTourPersonalVehicle=${beamVehicle.id}"),
+        currentTourStrategy.tourVehicle
+          .filter(_ == beamVehicle.id)
+          .map(_ => s"currentTourStrategy.tourVehicle=${beamVehicle.id}"),
+        parentTourStrategy
+          .flatMap(_.tourVehicle)
+          .filter(_ == beamVehicle.id)
+          .map(_ => s"parentTourStrategy.tourVehicle=${beamVehicle.id}")
       ).flatten
 
       if (BeamVehicle.isEmergencyVehicle(beamVehicle.id) && reasons.nonEmpty) {
@@ -1851,8 +1855,8 @@ trait ChoosesMode {
           // Send non-chosen trips to skimmer if configured to do so
           combinedItinerariesForChoice.foreach {
             case possibleTrip
-          if (possibleTrip != chosenTrip) && beamScenario.beamConfig.beam.router.skim.sendNonChosenTripsToSkimmer && !choosesModeData.personData.currentTourMode
-            .contains(FREIGHT_TOUR) =>
+                if (possibleTrip != chosenTrip) && beamScenario.beamConfig.beam.router.skim.sendNonChosenTripsToSkimmer && !choosesModeData.personData.currentTourMode
+                  .contains(FREIGHT_TOUR) =>
               generateSkimData(
                 possibleTrip.legs.lastOption.map(_.beamLeg.endTime).getOrElse(_currentTick.get),
                 possibleTrip,
@@ -1869,9 +1873,9 @@ trait ChoosesMode {
           )
           val shouldRefreshTourStrategy =
             currentTourStrategy.tourMode.isEmpty ||
-              currentTourStrategy.tourMode != chosenCurrentTourMode ||
-              currentTourStrategy.tourVehicle != chosenTourVehicle ||
-              strategyVehicleMissing
+            currentTourStrategy.tourMode != chosenCurrentTourMode ||
+            currentTourStrategy.tourVehicle != chosenTourVehicle ||
+            strategyVehicleMissing
 
           if (shouldRefreshTourStrategy) {
             updateTourModeStrategy(
@@ -2089,8 +2093,8 @@ trait ChoosesMode {
                     personData.currentTourPersonalVehicle.isDefined &&
                     (
                       (isLastTripWithinTour(nextAct) &&
-                        !shouldRetryFinalIntermodalEgressWithBuffer) ||
-                        personData.numberOfReplanningAttempts > 2
+                      !shouldRetryFinalIntermodalEgressWithBuffer) ||
+                      personData.numberOfReplanningAttempts > 2
                     )
                   ) {
                     // Abandon the vehicle because we have no route to get it home
@@ -3158,12 +3162,49 @@ trait ChoosesMode {
 
     currentTourStrategy.tourMode match {
       case Some(tourMode) =>
+        val distinctAvailableVehicles = availableVehicles.foldLeft(Vector.empty[VehicleOrToken]) {
+          case (acc, vehicle) if acc.exists(_.id == vehicle.id) => acc
+          case (acc, vehicle)                                   => acc :+ vehicle
+        }
+
+        val recoveredVehicleFromItineraries = firstLegItineraries
+          .flatMap(_.legs.find(leg => leg.asDriver && leg.beamLeg.mode != WALK).map(_.beamVehicleId))
+          .distinct
+          .filter(vehicleId => distinctAvailableVehicles.exists(_.id == vehicleId)) match {
+          case Seq(vehicleId) =>
+            logger.debug(
+              s"Person ${this.id}: Recovered missing $tourMode tour vehicle $vehicleId from available itineraries"
+            )
+            Some(vehicleId)
+          case _ =>
+            None
+        }
+
+        val recoveredVehicleFromAvailableVehicles =
+          distinctAvailableVehicles
+            .filterNot(_.vehicle.isSharedVehicle)
+            .filter(vehicle =>
+              tourMode.allowedBeamModesGivenAvailableVehicles(Vector(vehicle), firstOrLastLeg = true).nonEmpty
+            )
+            .map(_.id)
+            .distinct match {
+            case Seq(vehicleId) if recoveredVehicleFromItineraries.isEmpty =>
+              logger.debug(
+                s"Person ${this.id}: Recovered missing $tourMode tour vehicle $vehicleId from unique available vehicle"
+              )
+              Some(vehicleId)
+            case _ =>
+              None
+          }
+
         val effectiveTourVehicle = choosesModeData.personData.currentTourPersonalVehicle
           .orElse(
             // Check if current tour strategy has a vehicle that's available
-            currentTourStrategy.tourVehicle.filter(vehicleId => availableVehicles.exists(_.id == vehicleId))
+            currentTourStrategy.tourVehicle.filter(vehicleId => distinctAvailableVehicles.exists(_.id == vehicleId))
           )
-          .orElse(getInheritedTourVehicle(choosesModeData.personData, availableVehicles))
+          .orElse(getInheritedTourVehicle(choosesModeData.personData, distinctAvailableVehicles))
+          .orElse(recoveredVehicleFromItineraries)
+          .orElse(recoveredVehicleFromAvailableVehicles)
 
         (
           Some(tourMode),
@@ -3174,7 +3215,7 @@ trait ChoosesMode {
               if (tourMode != FREIGHT_TOUR) {
                 logger.warn(
                   f"Vehicle based tour mode without vehicle defined: Person ${this.id}, " +
-                  f"tour: $currentTourStrategy. Available vehicles: $availableVehicles"
+                  f"tour: $currentTourStrategy. Available vehicles: $distinctAvailableVehicles"
                 )
               }
               itin -> itin.legs.find(l => l.asDriver && (l.beamLeg.mode != WALK)).map(_.beamVehicleId)
@@ -3445,7 +3486,8 @@ trait ChoosesMode {
         logger.debug(s"Resetting tour mode to None for person ${this.id}")
       case _ =>
     }
-    val legStrategies = tour.trips.flatMap(_.leg).map(leg => _experiencedBeamPlan.getStrategy[TripModeChoiceStrategy](leg))
+    val legStrategies =
+      tour.trips.flatMap(_.leg).map(leg => _experiencedBeamPlan.getStrategy[TripModeChoiceStrategy](leg))
 
     val mismatchedLegStrategies = newTourMode match {
       case Some(tourMode) =>

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -65,6 +65,7 @@ trait ChoosesMode {
   this: PersonAgent => // Self type restricts this trait to only mix into a PersonAgent
 
   private val BUFFER_PER_REPLANNING_ATTEMPT_IN_SEC: Int = 5
+  private val MAX_FINAL_INTERMODAL_EGRESS_ROUTE_ATTEMPTS: Int = 3
 
   private val dummyRHVehicle: StreetVehicle = createDummyVehicle(
     RideHailVehicleId.dummyVehicleId,
@@ -158,6 +159,79 @@ trait ChoosesMode {
     vehicle
   }
 
+  private def logIntermodalVehicleAbandonment(
+    mode: BeamMode,
+    vehicleId: Id[BeamVehicle],
+    choosesModeData: ChoosesModeData,
+    nextAct: Activity
+  ): Unit = {
+    val routingResponseOpt = choosesModeData.routingResponse
+    val itineraries = routingResponseOpt.map(_.itineraries).getOrElse(Vector.empty)
+    val totalItineraries = itineraries.size
+    val transitItineraries = itineraries.count(_.legModes.exists(_.isTransit))
+    val requestedModeItineraries = itineraries.count(_.tripClassifier == mode)
+    val itinerariesWithHeldVehicle = itineraries.count(_.vehiclesInTrip.contains(vehicleId))
+    val returnedModes =
+      if (itineraries.isEmpty) "none"
+      else {
+        itineraries
+          .groupBy(_.tripClassifier)
+          .toVector
+          .sortBy(_._1.value)
+          .map { case (tripMode, trips) => s"${tripMode.value}:${trips.size}" }
+          .mkString("[", ", ", "]")
+      }
+
+    val requestSummary = routingResponseOpt.flatMap(_.request).map { request =>
+      val requestVehicleIds = request.streetVehicles.map(_.id.toString).mkString("[", ", ", "]")
+      val possibleEgressVehicleIds = request.possibleEgressVehicles.map(_.id.toString).mkString("[", ", ", "]")
+      s"requestId=${request.requestId}, departureTime=${request.departureTime}, withTransit=${request.withTransit}, " +
+      s"requestedMode=${request.requestedMode.map(_.value).getOrElse("None")}, " +
+      s"intermodalUse=${request.streetVehiclesUseIntermodalUse}, searchedModes=${routingResponseOpt
+        .map(_.searchedModes.map(_.value).toVector.sorted.mkString("[", ", ", "]"))
+        .getOrElse("[]")}, heldVehicleInRequest=${request.streetVehicles.exists(_.id == vehicleId)}, " +
+      s"requestStreetVehicles=$requestVehicleIds, possibleEgressVehicles=$possibleEgressVehicleIds"
+    }.getOrElse("request=none")
+
+    val heldVehicleLocation = routingResponseOpt
+      .flatMap(_.request)
+      .flatMap(_.streetVehicles.find(_.id == vehicleId).map(_.locationUTM.loc))
+      .orElse(beamVehicles.get(vehicleId).map(_.vehicle.spaceTime).filter(_ != null).map(_.loc))
+
+    val originToDestinationMeters =
+      geo.distUTMInMeters(choosesModeData.currentLocation.loc, nextAct.getCoord)
+    val heldVehicleToDestinationMeters =
+      heldVehicleLocation.map(loc => geo.distUTMInMeters(loc, nextAct.getCoord))
+    val originToHeldVehicleMeters =
+      heldVehicleLocation.map(loc => geo.distUTMInMeters(choosesModeData.currentLocation.loc, loc))
+
+    logger.warn(
+      s"Agent ${this.id} is abandoning vehicle $vehicleId after ${choosesModeData.personData.numberOfReplanningAttempts + 1} " +
+      s"failed attempts to find a route to take it home on a ${mode.toString} trip. $requestSummary, " +
+      s"itineraries(total=$totalItineraries, transit=$transitItineraries, requestedMode=$requestedModeItineraries, " +
+      s"withHeldVehicle=$itinerariesWithHeldVehicle, returnedModes=$returnedModes), " +
+      f"distances(originToDestination=${originToDestinationMeters}%.0f m, " +
+      f"heldVehicleToDestination=${heldVehicleToDestinationMeters.getOrElse(Double.NaN)}%.0f m, " +
+      f"originToHeldVehicle=${originToHeldVehicleMeters.getOrElse(Double.NaN)}%.0f m)"
+    )
+
+    if (itineraries.nonEmpty) {
+      val itinerarySamples = itineraries
+        .take(3)
+        .map { trip =>
+          val vehiclesInTrip = trip.vehiclesInTrip
+            .filterNot(_.toString.startsWith("body"))
+            .mkString("[", ", ", "]")
+          s"${trip.tripClassifier.value}:${trip.legModes.mkString(">")}:vehicles=$vehiclesInTrip:" +
+          s"time=${trip.totalTravelTimeInSecs}s:dist=${trip.totalDistanceInM.toInt}m"
+        }
+        .mkString(" || ")
+      logger.debug(
+        s"Agent ${this.id} abandon-route samples for vehicle $vehicleId on ${mode.toString}: $itinerarySamples"
+      )
+    }
+  }
+
   def bodyVehiclePersonId: PersonIdWithActorRef = PersonIdWithActorRef(id, self)
 
   onTransition { case _ -> ChoosingMode =>
@@ -178,6 +252,12 @@ trait ChoosesMode {
               f"Something is broken in the current plan for agent ${this.id}. " +
               f"Tour vehicle ${data.personData.currentTourPersonalVehicle.get} doesn't exist. " +
               f"Problematic activity sequence ${_experiencedBeamPlan.activities.map(_.getType).toString()}. Re-requesting vehicles."
+            )
+            logTourVehicleDiagnostics(
+              data.personData,
+              beamVehicles.values.toVector,
+              "ChoosingMode transition for vehicle-based tour",
+              s"tour vehicle ${data.personData.currentTourPersonalVehicle.get} missing from beamVehicles before requesting replacements"
             )
             implicit val executionContext: ExecutionContext = context.system.dispatcher
             requestAvailableVehicles(
@@ -257,12 +337,27 @@ trait ChoosesMode {
           case _ =>
             if (parentTourStrategy.exists(_.tourMode.contains(CAR_BASED))) {
               logError(s"Agent ${this.id} is on a car tour without an appropriate car. Generating an emergency one")
-              if (parentTourStrategy.exists(_.tourVehicle.nonEmpty)) {
-                logError(
-                  s"Removing vehicle ${parentTourStrategy.get.tourVehicle.get} " +
-                  s"from BeamVehicles for agent ${this.id}"
-                )
-                beamVehicles.remove(parentTourStrategy.get.tourVehicle.get)
+              logTourVehicleDiagnostics(
+                data.personData,
+                beamVehicles.values.toVector,
+                "ChoosingMode transition for car or drive-transit trip with car-based parent tour",
+                parentTourStrategy
+                  .flatMap(_.tourVehicle)
+                  .map(vehicleId => s"parent car tour expects vehicle $vehicleId but it is not available")
+                  .getOrElse("parent car tour expects a vehicle but no tourVehicle is stored")
+              )
+              parentTourStrategy.flatMap(_.tourVehicle).foreach { vehicleId =>
+                if (beamVehicles.contains(vehicleId)) {
+                  logError(
+                    s"Removing stale vehicle $vehicleId from BeamVehicles for agent ${this.id}"
+                  )
+                  beamVehicles.remove(vehicleId)
+                } else {
+                  logWarn(
+                    s"Parent tour strategy references missing vehicle $vehicleId for agent ${this.id}; " +
+                    s"BeamVehicles already does not contain it"
+                  )
+                }
               }
             }
             implicit val executionContext: ExecutionContext = context.system.dispatcher
@@ -498,6 +593,7 @@ trait ChoosesMode {
       val otherNewAndTourVehicles = filterAvailableVehicles(
         availablePersonalStreetVehicles ++ availableEmergencyVehicles,
         currentTourStrategy,
+        personData,
         parentTourStrategy.nonEmpty
       ).distinct
 
@@ -1282,15 +1378,44 @@ trait ChoosesMode {
   private def filterAvailableVehicles(
     allAvailableStreetVehicles: Vector[VehicleOrToken],
     currentTourStrategy: TourModeChoiceStrategy,
+    personData: BasePersonData,
     onSubTour: Boolean = false
   ): Vector[VehicleOrToken] = {
     val tourVehicle = currentTourStrategy.tourVehicle
     val tourMode = currentTourStrategy.tourMode
+    val parentTourStrategy = getParentTourStrategy(personData)
     val newAndTourVehicles = allAvailableStreetVehicles ++ currentTourStrategy.tourVehicle
       .flatMap(v => beamVehicles.get(v))
       .filterNot(v => v.vehicle.isSharedVehicle && !BeamVehicle.isEmergencyVehicle(v.id))
       .toVector
       .distinct
+
+    def logDangerousEmergencyVehicleDrop(beamVehicle: BeamVehicle, branch: String): Unit = {
+      val reasons = Vector(
+        personData.currentTourPersonalVehicle.filter(_ == beamVehicle.id).map(_ =>
+          s"personData.currentTourPersonalVehicle=${beamVehicle.id}"
+        ),
+        currentTourStrategy.tourVehicle.filter(_ == beamVehicle.id).map(_ =>
+          s"currentTourStrategy.tourVehicle=${beamVehicle.id}"
+        ),
+        parentTourStrategy.flatMap(_.tourVehicle).filter(_ == beamVehicle.id).map(_ =>
+          s"parentTourStrategy.tourVehicle=${beamVehicle.id}"
+        )
+      ).flatten
+
+      if (BeamVehicle.isEmergencyVehicle(beamVehicle.id) && reasons.nonEmpty) {
+        logger.warn(
+          s"Person ${this.id}: About to remove emergency vehicle ${beamVehicle.id} in $branch while still referenced by " +
+          s"${reasons.mkString(", ")}"
+        )
+        logTourVehicleDiagnostics(
+          personData,
+          beamVehicles.values.toVector,
+          s"filterAvailableVehicles:$branch",
+          s"about to remove emergency vehicle ${beamVehicle.id} while still referenced by ${reasons.mkString(", ")}"
+        )
+      }
+    }
 
     newAndTourVehicles.flatMap {
       case ActualVehicle(beamVehicle) if tourVehicle.contains(beamVehicle.id) => Some(ActualVehicle(beamVehicle))
@@ -1298,13 +1423,22 @@ trait ChoosesMode {
         Some(ActualVehicle(beamVehicle))
       case ActualVehicle(beamVehicle)
           if tourVehicle.isEmpty && tourMode.isDefined && beamVehicle.isMustBeDrivenHome && !onSubTour =>
-        logger.debug(
-          s"Person person ${this.id} is already on a walk based tour, and we have access to vehicle " +
-          s" ${beamVehicle.id}, and we're" +
-          " on the way home, but it is not our tour personal vehicle. Going to abandon it."
-        )
-        beamVehicles.remove(beamVehicle.id)
-        None
+        if (personData.currentTourPersonalVehicle.contains(beamVehicle.id)) {
+          logger.debug(
+            s"Person ${this.id} is keeping must-be-driven-home vehicle ${beamVehicle.id} because " +
+            s"personData.currentTourPersonalVehicle still references it"
+          )
+          Some(ActualVehicle(beamVehicle))
+        } else {
+          logger.debug(
+            s"Person person ${this.id} is already on a walk based tour, and we have access to vehicle " +
+            s" ${beamVehicle.id}, and we're" +
+            " on the way home, but it is not our tour personal vehicle. Going to abandon it."
+          )
+          logDangerousEmergencyVehicleDrop(beamVehicle, "walk-based-must-be-driven-home cleanup")
+          beamVehicles.remove(beamVehicle.id)
+          None
+        }
       case ActualVehicle(beamVehicle)
           if tourVehicle
             .exists(newAndTourVehicles.contains) && BeamVehicle.isEmergencyVehicle(beamVehicle.id) =>
@@ -1312,6 +1446,7 @@ trait ChoosesMode {
           s"Person person ${this.id} is already on a car based tour, and we have access to vehicle " +
           s" ${beamVehicle.id}, and we shouldn't need it. Going to abandon it."
         )
+        logDangerousEmergencyVehicleDrop(beamVehicle, "car-based-emergency cleanup")
         beamVehicles.remove(beamVehicle.id)
         None
       case ActualVehicle(beamVehicle) =>
@@ -1600,26 +1735,20 @@ trait ChoosesMode {
           .asInstanceOf[AttributesOfIndividual]
       val availableAlts = Some(itinerariesOfCorrectMode.map(_.tripClassifier).mkString(":"))
 
+      def resolvedCurrentTourPersonalVehicle(chosenTrip: EmbodiedBeamTrip): Option[Id[BeamVehicle]] =
+        chosenCurrentTourPersonalVehicle
+          .get(chosenTrip)
+          .flatten
+          .orElse(choosesModeData.personData.currentTourPersonalVehicle)
+          .orElse(getInheritedTourVehicle(choosesModeData.personData, allAvailableStreetVehicles))
+
       def gotoFinishingModeChoice(chosenTrip: EmbodiedBeamTrip) = {
         goto(FinishingModeChoice) using choosesModeData.safeCopy(
           personData = personData.copy(
             restOfCurrentTrip = List.empty[EmbodiedBeamLeg],
             currentTripMode = Some(chosenTrip.tripClassifier),
             currentTourMode = chosenCurrentTourMode,
-            currentTourPersonalVehicle = chosenCurrentTourMode match {
-              // if they're on a walk based tour we let them keep access to whatever personal vehicle they used on the
-              // first leg or in a parent tour
-              case Some(WALK_BASED) => choosesModeData.personData.currentTourPersonalVehicle
-              // Otherwise they keep track of the chosen vehicle
-              case _ =>
-                chosenCurrentTourPersonalVehicle
-                  .get(chosenTrip)
-                  .flatten // If we're on a subtour and it uses no vehicle, we still pass on any tour vehicle from parent tours
-                  .orElse(
-                    choosesModeData.personData.currentTourPersonalVehicle
-                  )
-                  .orElse(getInheritedTourVehicle(choosesModeData.personData, allAvailableStreetVehicles))
-            },
+            currentTourPersonalVehicle = resolvedCurrentTourPersonalVehicle(chosenTrip),
             passengerSchedule = PassengerSchedule()
           ),
           pendingChosenTrip = Some(chosenTrip),
@@ -1722,8 +1851,8 @@ trait ChoosesMode {
           // Send non-chosen trips to skimmer if configured to do so
           combinedItinerariesForChoice.foreach {
             case possibleTrip
-                if (possibleTrip != chosenTrip) && beamScenario.beamConfig.beam.router.skim.sendNonChosenTripsToSkimmer && !choosesModeData.personData.currentTourMode
-                  .contains(FREIGHT_TOUR) =>
+          if (possibleTrip != chosenTrip) && beamScenario.beamConfig.beam.router.skim.sendNonChosenTripsToSkimmer && !choosesModeData.personData.currentTourMode
+            .contains(FREIGHT_TOUR) =>
               generateSkimData(
                 possibleTrip.legs.lastOption.map(_.beamLeg.endTime).getOrElse(_currentTick.get),
                 possibleTrip,
@@ -1734,16 +1863,22 @@ trait ChoosesMode {
               )
             case _ =>
           }
-          if (
-            currentTourStrategy.tourMode.isEmpty || (currentTourStrategy.tourMode.exists(
-              _.isVehicleBased
-            ) && currentTourStrategy.tourVehicle.isEmpty)
-          ) {
+          val chosenTourVehicle = resolvedCurrentTourPersonalVehicle(chosenTrip)
+          val strategyVehicleMissing = currentTourStrategy.tourVehicle.exists(vehicleId =>
+            !(newAndTourVehicles ++ availableEmergencyVehicles).exists(_.id == vehicleId)
+          )
+          val shouldRefreshTourStrategy =
+            currentTourStrategy.tourMode.isEmpty ||
+              currentTourStrategy.tourMode != chosenCurrentTourMode ||
+              currentTourStrategy.tourVehicle != chosenTourVehicle ||
+              strategyVehicleMissing
+
+          if (shouldRefreshTourStrategy) {
             updateTourModeStrategy(
               chosenCurrentTourMode,
-              chosenCurrentTourPersonalVehicle.getOrElse(chosenTrip, None),
+              chosenTourVehicle,
               nextAct,
-              newAndTourVehicles
+              newAndTourVehicles ++ availableEmergencyVehicles
             )
           }
           val dataForNextStep =
@@ -1751,15 +1886,12 @@ trait ChoosesMode {
               personData = personData.copy(
                 currentTripMode = Some(chosenTrip.tripClassifier),
                 currentTourMode = chosenCurrentTourMode,
-                currentTourPersonalVehicle = chosenCurrentTourPersonalVehicle
-                  .get(chosenTrip)
-                  .flatten // If we're on a subtour and it uses no vehicle, we still pass on any tour vehicle from parent tours
-                  .orElse(personData.currentTourPersonalVehicle)
-                  .orElse(getInheritedTourVehicle(choosesModeData.personData, allAvailableStreetVehicles))
+                currentTourPersonalVehicle = chosenTourVehicle
               ),
               pendingChosenTrip = Some(chosenTrip),
+              allAvailableStreetVehicles = beamVehicles.values.toVector,
               availableAlternatives = availableAlts,
-              context = "After successfully selecting mode cohice alternative"
+              context = "After successfully selecting mode choice alternative"
             )(agent = this)
           goto(FinishingModeChoice) using dataForNextStep
         case None =>
@@ -1844,6 +1976,8 @@ trait ChoosesMode {
             case Some(CAR)
                 if newAndTourVehicles.isEmpty &&
                   beamScenario.beamConfig.beam.agentsim.agents.vehicles.generateEmergencyHouseholdVehicleWhenPlansRequireIt =>
+              val refreshedAvailableVehicles = beamVehicles.values.toVector
+              clearMissingTourVehicleReferences(nextAct, refreshedAvailableVehicles)
               logger.warn(
                 s"Person ${this.id} ended up stuck without a car despite having car in plans, so sending the request " +
                 s"back through in order to create an emergency vehicle. Tick ${_currentTick.getOrElse(-1)} and " +
@@ -1852,6 +1986,7 @@ trait ChoosesMode {
               )
               goto(ChoosingMode) using choosesModeData.safeUpdatePersonData(
                 personData.copy(currentTourPersonalVehicle = None),
+                newAllAvailableStreetVehicles = refreshedAvailableVehicles,
                 context = "Replanning after giving up tour vehicle"
               )(agent = this)
 
@@ -1911,11 +2046,22 @@ trait ChoosesMode {
                   )
                 else choosesModeData.allAvailableStreetVehicles
 
+              val isFinalIntermodalEgressWithHeldVehicle =
+                (mode == DRIVE_TRANSIT || mode == BIKE_TRANSIT) &&
+                isLastTripWithinTour(nextAct) &&
+                personData.currentTourPersonalVehicle.isDefined
+              val shouldRetryFinalIntermodalEgressWithBuffer =
+                isFinalIntermodalEgressWithHeldVehicle &&
+                (personData.numberOfReplanningAttempts + 1) < MAX_FINAL_INTERMODAL_EGRESS_ROUTE_ATTEMPTS
+
               // If we've done a comprehensive routing query, we can reuse results without more routing
               if (
                 choosesModeData.routingResponse.exists(
                   _.request.exists(_.withTransit)
-                ) && choosesModeData.rideHail2TransitRoutingRequestId.nonEmpty && !choosesModeData.isWithinTripReplanning && personData.numberOfReplanningAttempts == 0
+                ) && choosesModeData.rideHail2TransitRoutingRequestId.nonEmpty &&
+                !choosesModeData.isWithinTripReplanning &&
+                personData.numberOfReplanningAttempts == 0 &&
+                !shouldRetryFinalIntermodalEgressWithBuffer
               ) {
                 self ! RetryModeChoice(getCurrentTriggerId.get)
                 val updatedTripStrategy = TripModeChoiceStrategy(None)
@@ -1939,16 +2085,17 @@ trait ChoosesMode {
               } else {
                 val (updatedVehicles, newCurrentTourVehicle) =
                   if (
-                    (mode == DRIVE_TRANSIT || mode == BIKE_TRANSIT) && (isLastTripWithinTour(
-                      nextAct
-                    ) || personData.numberOfReplanningAttempts > 2) && personData.currentTourPersonalVehicle.isDefined
+                    (mode == DRIVE_TRANSIT || mode == BIKE_TRANSIT) &&
+                    personData.currentTourPersonalVehicle.isDefined &&
+                    (
+                      (isLastTripWithinTour(nextAct) &&
+                        !shouldRetryFinalIntermodalEgressWithBuffer) ||
+                        personData.numberOfReplanningAttempts > 2
+                    )
                   ) {
                     // Abandon the vehicle because we have no route to get it home
                     val vehicleId = personData.currentTourPersonalVehicle.get
-                    logger.warn(
-                      s"Agent ${this.id} is abandoning vehicle $vehicleId after ${personData.numberOfReplanningAttempts + 1} " +
-                      s"failed attempts to find a route to take it home on a ${mode.toString} trip."
-                    )
+                    logIntermodalVehicleAbandonment(mode, vehicleId, choosesModeData, nextAct)
 
                     val remainingVehicles = availableVehicles.filterNot(v => v.id == vehicleId)
                     updateTourModeStrategy(
@@ -1957,6 +2104,7 @@ trait ChoosesMode {
                       nextActivity(choosesModeData.personData).get,
                       remainingVehicles
                     )
+                    clearMissingTourVehicleReferences(nextActivity(choosesModeData.personData).get, remainingVehicles)
                     // Release the vehicle
                     if (beamVehicles.contains(vehicleId)) {
                       val vehicle = beamVehicles(vehicleId).vehicle
@@ -1984,12 +2132,13 @@ trait ChoosesMode {
                         nextActivity(choosesModeData.personData).get,
                         availableVehicles
                       )
+                      clearMissingTourVehicleReferences(nextActivity(choosesModeData.personData).get, availableVehicles)
                     }
                     (availableVehicles, newTourVehicle)
                   }
 
                 // Need to gather more routing options
-                self ! MobilityStatusResponse(availableVehicles, getCurrentTriggerId.get)
+                self ! MobilityStatusResponse(updatedVehicles, getCurrentTriggerId.get)
                 logger.debug(
                   "Person {} replanning because planned mode {} not available",
                   body.id,
@@ -2000,6 +2149,12 @@ trait ChoosesMode {
                   _experiencedBeamPlan.getTripContaining(nextActivity(choosesModeData.personData).get),
                   updatedTripStrategy
                 )
+                val excludeModesForRetry =
+                  if (shouldRetryFinalIntermodalEgressWithBuffer) {
+                    choosesModeData.excludeModes
+                  } else {
+                    choosesModeData.excludeModes ++ choosesModeData.personData.currentTripMode
+                  }
                 stay() using ChoosesModeData.validated(
                   personData = personData.copy(
                     currentTripMode = None,
@@ -2009,7 +2164,7 @@ trait ChoosesMode {
                   ),
                   allAvailableStreetVehicles = updatedVehicles,
                   currentLocation = choosesModeData.currentLocation,
-                  excludeModes = choosesModeData.excludeModes ++ choosesModeData.personData.currentTripMode,
+                  excludeModes = excludeModesForRetry,
                   parkingRequestIds = Map.empty // Clear any pending parking requests
                 )(agent = this, context = f"Replanning after failed mode choice, with planned mode $mode")
               }
@@ -2377,7 +2532,10 @@ trait ChoosesMode {
                   logger.debug(f"Releasing emergency vehicle for person ${this.id}")
                   manager ! ReleaseVehicle(vehicle, triggerId)
                 case Some(manager) => manager ! ReleaseVehicle(vehicle, triggerId)
-                case _             => logger.warn(s"Giving up vehicle ${vehicle.id}, which doesn't have a manager set")
+                case _ if BeamVehicle.isSharedTeleportationVehicle(vehicle.id) =>
+                  logger.debug(s"Dropping shared teleportation vehicle ${vehicle.id} without manager release")
+                case _ =>
+                  logger.warn(s"Giving up vehicle ${vehicle.id}, which doesn't have a manager set")
               }
             case ActualVehicle(vehicle) =>
               logger.info(f"This should have already been deleted: ${vehicle.id}")
@@ -3227,16 +3385,67 @@ trait ChoosesMode {
     nextActivity: Activity,
     vehicles: Vector[VehicleOrToken]
   ): TourModeChoiceStrategy = {
+    updateTourModeStrategyForTour(
+      newTourMode,
+      newTourVehicle,
+      _experiencedBeamPlan.getTourContaining(nextActivity),
+      vehicles
+    )
+  }
+
+  private def clearMissingTourVehicleReferences(nextActivity: Activity, vehicles: Vector[VehicleOrToken]): Unit = {
+    val availableVehicleIds = vehicles.map(_.id).toSet
+    val currentTour = _experiencedBeamPlan.getTourContaining(nextActivity)
+
+    def clearMissingVehicleReference(
+      tour: beam.agentsim.agents.planning.Tour,
+      branch: String
+    ): Unit = {
+      val strategy = _experiencedBeamPlan.getStrategy[TourModeChoiceStrategy](tour)
+      strategy.tourVehicle.filterNot(availableVehicleIds.contains).foreach { missingVehicleId =>
+        logger.debug(
+          s"Person ${this.id}: Clearing missing vehicle $missingVehicleId from $branch tour strategy before replanning"
+        )
+        updateTourModeStrategyForTour(
+          strategy.tourMode,
+          None,
+          tour,
+          vehicles,
+          allowVehicleBasedTourWithoutVehicle = true
+        )
+      }
+    }
+
+    clearMissingVehicleReference(currentTour, "current")
+    currentTour.originActivity match {
+      case Some(originActivity) if !originActivity.getType.equalsIgnoreCase("home") =>
+        val parentTour = _experiencedBeamPlan.getTourContaining(originActivity)
+        if (parentTour != currentTour) {
+          clearMissingVehicleReference(parentTour, "parent")
+        }
+      case _ =>
+    }
+  }
+
+  private def updateTourModeStrategyForTour(
+    newTourMode: Option[BeamTourMode],
+    newTourVehicle: Option[Id[BeamVehicle]],
+    tour: beam.agentsim.agents.planning.Tour,
+    vehicles: Vector[VehicleOrToken],
+    allowVehicleBasedTourWithoutVehicle: Boolean = false
+  ): TourModeChoiceStrategy = {
     (newTourMode, newTourVehicle) match {
+      case (Some(tourMode), None) if tourMode.isVehicleBased && allowVehicleBasedTourWithoutVehicle =>
+        logger.debug(
+          s"Person ${this.id}: Clearing vehicle reference while preserving $tourMode during replanning"
+        )
       case (Some(CAR_BASED), None) =>
         logger.error(f"Why are we going into a car based tour without a car? Person: ${this.id}")
       case (None, _) =>
         logger.debug(s"Resetting tour mode to None for person ${this.id}")
       case _ =>
     }
-    val currentTour = _experiencedBeamPlan.getTourContaining(nextActivity)
-    val legStrategies =
-      currentTour.trips.flatMap(_.leg).map(leg => _experiencedBeamPlan.getStrategy[TripModeChoiceStrategy](leg))
+    val legStrategies = tour.trips.flatMap(_.leg).map(leg => _experiencedBeamPlan.getStrategy[TripModeChoiceStrategy](leg))
 
     val mismatchedLegStrategies = newTourMode match {
       case Some(tourMode) =>
@@ -3252,7 +3461,7 @@ trait ChoosesMode {
     }
 
     mismatchedLegStrategies.foreach { case (st, idx) =>
-      _experiencedBeamPlan.putStrategy(currentTour.trips.apply(idx), TripModeChoiceStrategy(None))
+      _experiencedBeamPlan.putStrategy(tour.trips.apply(idx), TripModeChoiceStrategy(None))
       logger.debug(
         f"Replacing person ${this.id}'s planned ${st.mode.get} trip with none because of conflict with tour mode ${newTourMode.get}"
       )
@@ -3263,7 +3472,7 @@ trait ChoosesMode {
         newTourMode,
         newTourVehicle
       )
-    _experiencedBeamPlan.putStrategy(currentTour, updatedTourStrategy)
+    _experiencedBeamPlan.putStrategy(tour, updatedTourStrategy)
     updatedTourStrategy
   }
 }
@@ -3420,7 +3629,10 @@ object ChoosesMode {
         newAllAvailableStreetVehicles,
         s"ChoosesModeData.safeUpdatePersonData: $context"
       )
-      data.copy(personData = newPersonData)
+      data.copy(
+        personData = newPersonData,
+        allAvailableStreetVehicles = newAllAvailableStreetVehicles
+      )
     }
 
     def safeCopy(

--- a/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
+++ b/src/main/scala/beam/agentsim/agents/modalbehaviors/ChoosesMode.scala
@@ -1740,6 +1740,8 @@ trait ChoosesMode {
       val availableAlts = Some(itinerariesOfCorrectMode.map(_.tripClassifier).mkString(":"))
 
       def resolvedCurrentTourPersonalVehicle(chosenTrip: EmbodiedBeamTrip): Option[Id[BeamVehicle]] =
+        // Keep the already-held vehicle unless this choice selected a more specific one. This allows a failed or
+        // reset subtour to continue carrying an inherited parent-tour vehicle through replanning.
         chosenCurrentTourPersonalVehicle
           .get(chosenTrip)
           .flatten

--- a/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
@@ -1043,14 +1043,14 @@ class PersonWithPersonalVehiclePlanSpec
             lastSender ! walkResponse(req)
             finished = true
           }
-        case _: Event =>
+        case _: Event        =>
         case _: HasTriggerId =>
       }
     }
 
     expectMsgType[CompletionNotice]
     receiveWhile() {
-      case _: Event =>
+      case _: Event        =>
       case _: HasTriggerId =>
     }
   }

--- a/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithPersonalVehiclePlanSpec.scala
@@ -6,7 +6,7 @@ import akka.testkit.{ImplicitSender, TestActorRef, TestKitBase, TestProbe}
 import akka.util.Timeout
 import beam.agentsim.agents.PersonTestUtil._
 import beam.agentsim.agents.choice.mode.ModeChoiceUniformRandom
-import beam.agentsim.agents.household.HouseholdActor.HouseholdActor
+import beam.agentsim.agents.household.HouseholdActor.{HouseholdActor, ReleaseVehicle}
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles.{BeamVehicle, _}
 import beam.agentsim.events._
@@ -18,13 +18,16 @@ import beam.agentsim.infrastructure.{
 }
 import beam.agentsim.scheduler.BeamAgentScheduler
 import beam.agentsim.scheduler.BeamAgentScheduler.{CompletionNotice, ScheduleTrigger, SchedulerProps, StartSchedule}
+import beam.agentsim.scheduler.HasTriggerId
 import beam.integration.Repeated
 import beam.router.BeamRouter._
 import beam.router.Modes.BeamMode
-import beam.router.Modes.BeamMode.{BIKE, CAR, WALK}
+import beam.router.Modes.BeamMode.{BIKE, BIKE_TRANSIT, CAR, DRIVE_TRANSIT, WALK}
 import beam.router.RouteHistory
 import beam.router.model.{EmbodiedBeamLeg, _}
 import beam.router.skim.core.AbstractSkimmerEvent
+import beam.router.TourModes.BeamTourMode
+import beam.router.TourModes.BeamTourMode.{BIKE_BASED, CAR_BASED}
 import beam.sim.vehicles.VehiclesAdjustment
 import beam.tags.FlakyTest
 import beam.utils.TestConfigUtils.testConfig
@@ -80,6 +83,7 @@ class PersonWithPersonalVehiclePlanSpec
   override def outputDirPath: String = TestConfigUtils.testOutputDir
 
   private val householdsFactory: HouseholdsFactoryImpl = new HouseholdsFactoryImpl()
+  private val hoseHoldDummyId = Id.create("dummy", classOf[Household])
 
   private lazy val modeChoiceCalculator = new ModeChoiceUniformRandom(beamConfig)
 
@@ -87,8 +91,6 @@ class PersonWithPersonalVehiclePlanSpec
   val workLocation = new Coord(169346.4, 876.7536)
 
   describe("A PersonAgent") {
-
-    val hoseHoldDummyId = Id.create("dummy", classOf[Household])
 
     it("should know how to take a car trip when it's already in its plan") {
       val eventsManager = new EventsManagerImpl()
@@ -720,6 +722,11 @@ class PersonWithPersonalVehiclePlanSpec
       expectMsgType[CompletionNotice]
     }
 
+    it("should retry final drive_transit and bike_transit egress before abandoning the held vehicle") {
+      runFinalIntermodalEgressRetryRegression(DRIVE_TRANSIT, CAR_BASED, "beamVilleCar", "drive")
+      runFinalIntermodalEgressRetryRegression(BIKE_TRANSIT, BIKE_BASED, "BIKE-DEFAULT", "bike")
+    }
+
     it("should walk to a car that is far away (if told so by the router") {
       val eventsManager = new EventsManagerImpl()
       eventsManager.addHandler(
@@ -902,6 +909,184 @@ class PersonWithPersonalVehiclePlanSpec
     workActivity.setEndTime(61200) //5:00:00 PM
     workActivity.setCoord(workLocation)
     plan.addActivity(workActivity)
+    person.addPlan(plan)
+    person
+  }
+
+  private def runFinalIntermodalEgressRetryRegression(
+    tripMode: BeamMode,
+    tourMode: BeamTourMode,
+    vehicleTypeId: String,
+    vehicleIdPrefix: String
+  ): Unit = {
+    val eventsManager = new EventsManagerImpl()
+    eventsManager.addHandler(
+      new BasicEventHandler {
+        override def handleEvent(event: Event): Unit = {
+          event match {
+            case _: AbstractSkimmerEvent => // ignore
+            case _                       => self ! event
+          }
+        }
+      }
+    )
+
+    val vehicleManager = TestProbe()
+    val vehicleType = beamScenario.vehicleTypes(Id.create(vehicleTypeId, classOf[BeamVehicleType]))
+    val vehicleId = Id.createVehicleId(s"$vehicleIdPrefix-${tripMode.value}")
+    val beamVehicle = new BeamVehicle(vehicleId, new Powertrain(0.0), vehicleType)
+    beamVehicle.setManager(Some(vehicleManager.ref))
+
+    val household = householdsFactory.createHousehold(hoseHoldDummyId)
+    val population = PopulationUtils.createPopulation(ConfigUtils.createConfig())
+    val person: Person = createIntermodalTourPerson(
+      Id.createPersonId(s"retry-${tripMode.value}"),
+      vehicleId,
+      tripMode,
+      tourMode
+    )
+    population.addPerson(person)
+    household.setMemberIds(JavaConverters.bufferAsJavaList(mutable.Buffer(person.getId)))
+
+    val scheduler = TestActorRef[BeamAgentScheduler](
+      SchedulerProps(
+        beamConfig,
+        stopTick = 24 * 60 * 60,
+        maxWindow = 10,
+        new StuckFinder(beamConfig.beam.debug.stuckAgentDetection)
+      )
+    )
+    val parkingManager = system.actorOf(Props(new TrivialParkingManager))
+
+    val householdActor = TestActorRef[HouseholdActor](
+      new HouseholdActor(
+        services,
+        beamScenario,
+        _ => modeChoiceCalculator,
+        scheduler,
+        beamScenario.transportNetwork,
+        services.tollCalculator,
+        self,
+        self,
+        parkingManager,
+        self,
+        eventsManager,
+        population,
+        household,
+        Map(beamVehicle.id -> beamVehicle),
+        new Coord(0.0, 0.0),
+        Vector(),
+        Set(vehicleType),
+        new RouteHistory(beamConfig),
+        VehiclesAdjustment.getVehicleAdjustment(beamScenario),
+        configHolder
+      )
+    )
+    scheduler ! ScheduleTrigger(InitializeTrigger(0), householdActor)
+    scheduler ! StartSchedule(0)
+
+    def emptyResponse(triggerId: Long, requestId: Int) =
+      RoutingResponse(Vector.empty, requestId, None, isEmbodyWithCurrentTravelTime = false, triggerId = triggerId)
+
+    def walkResponse(req: RoutingRequest) =
+      RoutingResponse(
+        itineraries = Vector(
+          EmbodiedBeamTrip(
+            legs = Vector(
+              EmbodiedBeamLeg(
+                beamLeg = BeamLeg(
+                  req.departureTime,
+                  BeamMode.WALK,
+                  50,
+                  BeamPath(
+                    linkIds = Array(1, 2),
+                    linkTravelTime = Array(50, 50),
+                    transitStops = None,
+                    startPoint = SpaceTime(services.geo.utm2Wgs(req.originUTM), req.departureTime),
+                    endPoint = SpaceTime(services.geo.utm2Wgs(req.destinationUTM), req.departureTime + 50),
+                    distanceInM = 100d
+                  )
+                ),
+                beamVehicleId = Id.createVehicleId("body-retry"),
+                Id.create("BODY-TYPE-DEFAULT", classOf[BeamVehicleType]),
+                asDriver = true,
+                cost = 0.0,
+                unbecomeDriverOnCompletion = true
+              )
+            )
+          )
+        ),
+        requestId = req.requestId,
+        request = None,
+        isEmbodyWithCurrentTravelTime = false,
+        triggerId = req.triggerId
+      )
+
+    var routingRequestsSeen = 0
+    var finished = false
+    while (!finished) {
+      expectMsgPF() {
+        case EmbodyWithCurrentTravelTime(_, _, _, _, triggerId) =>
+          lastSender ! emptyResponse(triggerId, 1)
+        case inq: ParkingInquiry =>
+          (parkingManager ? inq).mapTo[ParkingInquiryResponse].map(x => lastSender ! x)
+        case req: RoutingRequest =>
+          routingRequestsSeen += 1
+          if (routingRequestsSeen <= 3) {
+            assert(req.streetVehicles.exists(_.id == beamVehicle.id))
+            lastSender ! emptyResponse(req.triggerId, req.requestId)
+            if (routingRequestsSeen == 3) {
+              vehicleManager.expectMsgType[ReleaseVehicle]
+            }
+          } else {
+            assert(!req.streetVehicles.exists(_.id == beamVehicle.id))
+            lastSender ! walkResponse(req)
+            finished = true
+          }
+        case _: Event =>
+        case _: HasTriggerId =>
+      }
+    }
+
+    expectMsgType[CompletionNotice]
+    receiveWhile() {
+      case _: Event =>
+      case _: HasTriggerId =>
+    }
+  }
+
+  private def createIntermodalTourPerson(
+    personId: Id[Person],
+    vehicleId: Id[Vehicle],
+    tripMode: BeamMode,
+    tourMode: BeamTourMode
+  ): Person = {
+    val person = PopulationUtils.getFactory.createPerson(personId)
+    putDefaultBeamAttributes(person, BeamMode.allModes)
+    val plan = PopulationUtils.getFactory.createPlan()
+    val homeActivity = PopulationUtils.createActivityFromLinkId("home", Id.createLinkId(1))
+    homeActivity.setEndTime(28800)
+    homeActivity.setCoord(homeLocation)
+    plan.addActivity(homeActivity)
+
+    val leg = PopulationUtils.createLeg(tripMode.value)
+    leg.getAttributes.putAttribute("tour_id", "100")
+    leg.getAttributes.putAttribute("tour_mode", tourMode.value)
+    leg.getAttributes.putAttribute("tour_vehicle", vehicleId.toString)
+    val route = RouteUtils.createLinkNetworkRouteImpl(
+      Id.createLinkId(228),
+      Array(206, 180, 178, 184, 102).map(Id.createLinkId(_)),
+      Id.createLinkId(108)
+    )
+    route.setVehicleId(Id.createVehicleId(vehicleId.toString))
+    leg.setRoute(route)
+    plan.addLeg(leg)
+
+    val workActivity = PopulationUtils.createActivityFromLinkId("work", Id.createLinkId(2))
+    workActivity.setEndTime(61200)
+    workActivity.setCoord(workLocation)
+    plan.addActivity(workActivity)
+
     person.addPlan(plan)
     person
   }

--- a/src/test/scala/beam/agentsim/agents/PersonWithTourModeSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithTourModeSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import beam.agentsim.agents.PersonTestUtil._
 import beam.agentsim.agents.choice.logit.TourModeChoiceModel
 import beam.agentsim.agents.choice.mode.ModeChoiceUniformRandom
-import beam.agentsim.agents.household.HouseholdActor.{HouseholdActor, MobilityStatusInquiry, MobilityStatusResponse}
+import beam.agentsim.agents.household.HouseholdActor.{HouseholdActor, MobilityStatusInquiry, MobilityStatusResponse, ReleaseVehicle}
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events._
@@ -87,6 +87,7 @@ class PersonWithTourModeSpec
   override def outputDirPath: String = TestConfigUtils.testOutputDir
 
   private val householdsFactory: HouseholdsFactoryImpl = new HouseholdsFactoryImpl()
+  private val hoseHoldDummyId = Id.create("dummy", classOf[Household])
 
   private lazy val modeChoiceCalculator = new ModeChoiceUniformRandom(beamConfig)
   private lazy val tourModeChoiceCalculator = new TourModeChoiceModel(beamConfig)
@@ -96,8 +97,6 @@ class PersonWithTourModeSpec
   val otherLocation = new Coord(168346.4, 1276.7536)
 
   describe("A PersonAgent") {
-
-    val hoseHoldDummyId = Id.create("dummy", classOf[Household])
 
     it("should know how to take a car trip on a car_based tour when the mode is already in its plan") {
       val eventsManager = new EventsManagerImpl()
@@ -1682,6 +1681,306 @@ class PersonWithTourModeSpec
         case x: HasTriggerId     => println(x.toString)
       }
     }
+
+    it("should keep a personal vehicle available for a later tour after a home boundary") {
+      assertVehicleSurvivesHomeBoundary()
+    }
+  }
+
+  private def assertVehicleSurvivesHomeBoundary(): Unit = {
+    val eventsManager = new EventsManagerImpl()
+    eventsManager.addHandler(
+      new BasicEventHandler {
+        override def handleEvent(event: Event): Unit = {
+          event match {
+            case _: ModeChoiceEvent | _: TourModeChoiceEvent | _: ActivityEndEvent | _: ActivityStartEvent |
+                _: ReplanningEvent =>
+              self ! event
+            case _ =>
+          }
+        }
+      }
+    )
+
+    val vehicleId = Id.createVehicleId("car-dummyAgent-sequential")
+    val vehicleType = beamScenario.vehicleTypes(Id.create("beamVilleCar", classOf[BeamVehicleType]))
+    val beamVehicle = new BeamVehicle(vehicleId, new Powertrain(0.0), vehicleType)
+    val vehicleManager = TestProbe()
+    beamVehicle.setManager(Some(vehicleManager.ref))
+
+    val household = householdsFactory.createHousehold(hoseHoldDummyId)
+    val population = PopulationUtils.createPopulation(ConfigUtils.createConfig())
+    val person: Person =
+      createTestPersonWithSequentialTours(
+        Id.createPersonId("dummyAgent"),
+        Some(CAR_BASED),
+        Some(CAR),
+        Some(vehicleId),
+        Some(CAR_BASED),
+        Some(CAR),
+        Some(vehicleId)
+      )
+    population.addPerson(person)
+    household.setMemberIds(JavaConverters.bufferAsJavaList(mutable.Buffer(person.getId)))
+
+    val scheduler = TestActorRef[BeamAgentScheduler](
+      SchedulerProps(
+        beamConfig,
+        stopTick = 24 * 60 * 60,
+        maxWindow = 10,
+        new StuckFinder(beamConfig.beam.debug.stuckAgentDetection)
+      )
+    )
+    val parkingLocation = new Coord(167138.4, 1117.0)
+    val parkingManager = system.actorOf(Props(new AnotherTrivialParkingManager(parkingLocation)))
+
+    val householdActor = TestActorRef[HouseholdActor](
+      Props(
+        new HouseholdActor(
+          services,
+          beamScenario,
+          _ => modeChoiceCalculator,
+          scheduler,
+          beamScenario.transportNetwork,
+          services.tollCalculator,
+          self,
+          self,
+          parkingManager,
+          self,
+          eventsManager,
+          population,
+          household,
+          Map(beamVehicle.id -> beamVehicle),
+          new Coord(0.0, 0.0),
+          Vector(),
+          Set.empty,
+          new RouteHistory(beamConfig),
+          VehiclesAdjustment.getVehicleAdjustment(beamScenario),
+          configHolder
+        )
+      )
+    )
+    scheduler ! ScheduleTrigger(InitializeTrigger(0), householdActor)
+    scheduler ! StartSchedule(0)
+
+    val linkIds = Array[Int](228, 206, 180, 178, 184, 102)
+
+    def respondToTourRequest(routingRequest: RoutingRequest): Unit = {
+      val personVehicle = routingRequest.streetVehicles.find(_.mode == WALK).get
+      lastSender ! RoutingResponse(
+        Vector(
+          EmbodiedBeamTrip(
+            legs = Vector(
+              EmbodiedBeamLeg.dummyLegAt(
+                routingRequest.departureTime,
+                personVehicle.id,
+                false,
+                services.geo.utm2Wgs(routingRequest.originUTM),
+                WALK,
+                personVehicle.vehicleTypeId
+              ),
+              createEmbodiedBeamLeg(routingRequest, beamVehicle.toStreetVehicle, linkIds, 50d),
+              EmbodiedBeamLeg.dummyLegAt(
+                routingRequest.departureTime + 250,
+                personVehicle.id,
+                true,
+                services.geo.utm2Wgs(routingRequest.destinationUTM),
+                WALK,
+                personVehicle.vehicleTypeId
+              )
+            )
+          ),
+          EmbodiedBeamTrip(legs = Vector(createEmbodiedBeamLeg(routingRequest, personVehicle, linkIds, 150d)))
+        ),
+        requestId = routingRequest.requestId,
+        request = Some(routingRequest),
+        isEmbodyWithCurrentTravelTime = false,
+        triggerId = routingRequest.triggerId
+      )
+    }
+
+    val firstRoutingRequest = expectMsgType[RoutingRequest]
+    assert(firstRoutingRequest.withTransit === false)
+    respondToTourRequest(firstRoutingRequest)
+
+    val firstTourModeChoice = expectMsgType[TourModeChoiceEvent]
+    assert(firstTourModeChoice.availablePersonalStreetVehiclesString.contains("beamVilleCar"))
+    expectMsgType[ModeChoiceEvent]
+    expectMsgType[ActivityEndEvent]
+
+    val parkingRoutingRequest = expectMsgType[RoutingRequest]
+    assert(parkingRoutingRequest.destinationUTM == parkingLocation)
+    lastSender ! RoutingResponse(
+      itineraries = Vector(
+        EmbodiedBeamTrip(
+          legs = Vector(
+            EmbodiedBeamLeg(
+              beamLeg = BeamLeg(
+                startTime = parkingRoutingRequest.departureTime,
+                mode = BeamMode.CAR,
+                duration = 50,
+                travelPath = BeamPath(
+                  linkIds = Array(142, 60, 58, 62, 80),
+                  linkTravelTime = Array(50, 50, 50, 50, 50),
+                  transitStops = None,
+                  startPoint = SpaceTime(
+                    services.geo.utm2Wgs(parkingRoutingRequest.originUTM),
+                    parkingRoutingRequest.departureTime
+                  ),
+                  endPoint =
+                    SpaceTime(services.geo.utm2Wgs(parkingLocation), parkingRoutingRequest.departureTime + 200),
+                  distanceInM = 1000d
+                )
+              ),
+              beamVehicleId = Id.createVehicleId("car-1"),
+              Id.create("TRANSIT-TYPE-DEFAULT", classOf[BeamVehicleType]),
+              asDriver = true,
+              cost = 0.0,
+              unbecomeDriverOnCompletion = true
+            )
+          )
+        )
+      ),
+      requestId = parkingRoutingRequest.requestId,
+      request = None,
+      isEmbodyWithCurrentTravelTime = false,
+      triggerId = parkingRoutingRequest.triggerId
+    )
+
+    val walkFromParkingRoutingRequest = expectMsgType[RoutingRequest]
+    lastSender ! RoutingResponse(
+      itineraries = Vector(
+        EmbodiedBeamTrip(
+          legs = Vector(
+            EmbodiedBeamLeg(
+              beamLeg = BeamLeg(
+                startTime = walkFromParkingRoutingRequest.departureTime,
+                mode = BeamMode.WALK,
+                duration = 50,
+                travelPath = BeamPath(
+                  linkIds = Array(80, 101),
+                  linkTravelTime = Array(50, 50),
+                  transitStops = None,
+                  startPoint =
+                    SpaceTime(services.geo.utm2Wgs(parkingLocation), walkFromParkingRoutingRequest.departureTime),
+                  endPoint = SpaceTime(
+                    services.geo.utm2Wgs(walkFromParkingRoutingRequest.destinationUTM),
+                    walkFromParkingRoutingRequest.departureTime + 50
+                  ),
+                  distanceInM = 100d
+                )
+              ),
+              beamVehicleId = walkFromParkingRoutingRequest.streetVehicles.find(_.mode == WALK).get.id,
+              walkFromParkingRoutingRequest.streetVehicles.find(_.mode == WALK).get.vehicleTypeId,
+              asDriver = true,
+              cost = 0.0,
+              unbecomeDriverOnCompletion = true
+            )
+          )
+        )
+      ),
+      requestId = parkingRoutingRequest.requestId,
+      request = None,
+      isEmbodyWithCurrentTravelTime = false,
+      triggerId = walkFromParkingRoutingRequest.triggerId
+    )
+
+    expectMsgType[ActivityStartEvent]
+    vehicleManager.expectNoMessage(200.millis)
+
+    val secondRoutingRequest = expectMsgType[RoutingRequest]
+    assert(secondRoutingRequest.streetVehicles.exists(_.id == beamVehicle.id))
+    respondToTourRequest(secondRoutingRequest)
+
+    val secondTourModeChoice = expectMsgType[TourModeChoiceEvent]
+    assert(secondTourModeChoice.availablePersonalStreetVehiclesString.contains("beamVilleCar"))
+    expectMsgType[ModeChoiceEvent]
+    expectMsgType[ActivityEndEvent]
+    expectMsgType[ActivityStartEvent]
+
+    val release = vehicleManager.expectMsgType[ReleaseVehicle]
+    assert(release.vehicle.id == beamVehicle.id)
+
+    receiveWhile(500 millis) {
+      case _: SchedulerMessage =>
+      case x: Event            => println(x.toString)
+      case x: HasTriggerId     => println(x.toString)
+    }
+  }
+
+  private def createTestPersonWithSequentialTours(
+    personId: Id[Person],
+    primaryTourMode: Option[BeamTourMode] = None,
+    primaryTourTripMode: Option[BeamMode] = None,
+    primaryTourVehicle: Option[Id[BeamVehicle]] = None,
+    secondaryTourMode: Option[BeamTourMode] = None,
+    secondaryTourTripMode: Option[BeamMode] = None,
+    secondaryTourVehicle: Option[Id[BeamVehicle]] = None
+  ) = {
+    val person = PopulationUtils.getFactory.createPerson(personId)
+    val attributesOfIndividual = AttributesOfIndividual(
+      HouseholdAttributes("1", 200, 300, 400, 500),
+      None,
+      true,
+      Vector(BeamMode.CAR, BeamMode.WALK, BeamMode.BIKE, BeamMode.WALK_TRANSIT),
+      Seq.empty,
+      valueOfTime = 10000000.0,
+      Some(42),
+      Some(1234)
+    )
+    person.getCustomAttributes.put("beam-attributes", attributesOfIndividual)
+
+    val plan = PopulationUtils.getFactory.createPlan()
+    val homeActivity = PopulationUtils.createActivityFromLinkId("home", Id.createLinkId(1))
+    homeActivity.setEndTime(28800)
+    homeActivity.setCoord(homeLocation)
+    plan.addActivity(homeActivity)
+
+    def addTourLeg(tourId: String, tourMode: Option[BeamTourMode], tripMode: Option[BeamMode], vehicle: Option[Id[BeamVehicle]]) = {
+      val leg = PopulationUtils.createLeg(tripMode.map(_.matsimMode).getOrElse(""))
+      leg.getAttributes.putAttribute("tour_id", tourId)
+      tourMode.foreach(mode => leg.getAttributes.putAttribute("tour_mode", mode.value))
+      vehicle.foreach(veh => leg.getAttributes.putAttribute("tour_vehicle", veh.toString))
+      val route = RouteUtils.createLinkNetworkRouteImpl(
+        Id.createLinkId(228),
+        Array(206, 180, 178, 184, 102).map(Id.createLinkId(_)),
+        Id.createLinkId(108)
+      )
+      route.setVehicleId(vehicle.map(_.asInstanceOf[Id[Vehicle]]).getOrElse(Id.createVehicleId("missing-vehicle")))
+      leg.setRoute(route)
+      plan.addLeg(leg)
+    }
+
+    addTourLeg("100", primaryTourMode, primaryTourTripMode, primaryTourVehicle)
+
+    val workActivity = PopulationUtils.createActivityFromLinkId("work", Id.createLinkId(2))
+    workActivity.setEndTime(43200)
+    workActivity.setCoord(workLocation)
+    plan.addActivity(workActivity)
+
+    addTourLeg("100", primaryTourMode, primaryTourTripMode, primaryTourVehicle)
+
+    val homeActivity2 = PopulationUtils.createActivityFromLinkId("home", Id.createLinkId(1))
+    homeActivity2.setEndTime(48600)
+    homeActivity2.setCoord(homeLocation)
+    plan.addActivity(homeActivity2)
+
+    addTourLeg("101", secondaryTourMode, secondaryTourTripMode, secondaryTourVehicle)
+
+    val otherActivity = PopulationUtils.createActivityFromLinkId("other", Id.createLinkId(3))
+    otherActivity.setEndTime(61200)
+    otherActivity.setCoord(workLocation)
+    plan.addActivity(otherActivity)
+
+    addTourLeg("101", secondaryTourMode, secondaryTourTripMode, secondaryTourVehicle)
+
+    val homeActivity3 = PopulationUtils.createActivityFromLinkId("home", Id.createLinkId(1))
+    homeActivity3.setCoord(homeLocation)
+    homeActivity3.setEndTime(65200)
+    plan.addActivity(homeActivity3)
+
+    person.addPlan(plan)
+    person
   }
 
   private def createEmbodiedBeamLeg(

--- a/src/test/scala/beam/agentsim/agents/PersonWithTourModeSpec.scala
+++ b/src/test/scala/beam/agentsim/agents/PersonWithTourModeSpec.scala
@@ -9,7 +9,12 @@ import scala.concurrent.duration._
 import beam.agentsim.agents.PersonTestUtil._
 import beam.agentsim.agents.choice.logit.TourModeChoiceModel
 import beam.agentsim.agents.choice.mode.ModeChoiceUniformRandom
-import beam.agentsim.agents.household.HouseholdActor.{HouseholdActor, MobilityStatusInquiry, MobilityStatusResponse, ReleaseVehicle}
+import beam.agentsim.agents.household.HouseholdActor.{
+  HouseholdActor,
+  MobilityStatusInquiry,
+  MobilityStatusResponse,
+  ReleaseVehicle
+}
 import beam.agentsim.agents.vehicles.EnergyEconomyAttributes.Powertrain
 import beam.agentsim.agents.vehicles._
 import beam.agentsim.events._
@@ -1936,7 +1941,12 @@ class PersonWithTourModeSpec
     homeActivity.setCoord(homeLocation)
     plan.addActivity(homeActivity)
 
-    def addTourLeg(tourId: String, tourMode: Option[BeamTourMode], tripMode: Option[BeamMode], vehicle: Option[Id[BeamVehicle]]) = {
+    def addTourLeg(
+      tourId: String,
+      tourMode: Option[BeamTourMode],
+      tripMode: Option[BeamMode],
+      vehicle: Option[Id[BeamVehicle]]
+    ) = {
       val leg = PopulationUtils.createLeg(tripMode.map(_.matsimMode).getOrElse(""))
       leg.getAttributes.putAttribute("tour_id", tourId)
       tourMode.foreach(mode => leg.getAttributes.putAttribute("tour_mode", mode.value))


### PR DESCRIPTION
## Summary
- Fix tour vehicle handling so personal vehicles are preserved across replanning and home-boundary transitions instead of being dropped too early.
- Retry final `drive_transit` / `bike_transit` egress routing before abandoning the held vehicle, reducing false vehicle drops at the end of a tour.
- Harden tour-vehicle cleanup and release logic, including better recovery/clearing of stale vehicle references and safer handling of shared teleportation vehicles.
- Added code comments clarifying an intentional vehicle-precedence rule during replanning: `currentTourPersonalVehicle` may continue to represent an inherited parent-tour vehicle even when the current subtour strategy is reset, so failed subtour replanning does not force abandonment of the enclosing tour vehicle.


## Testing
- Added regression coverage for final intermodal egress retry behavior.
- Added regression coverage for keeping a personal vehicle available for a later tour after returning home.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LBNL-UCB-STI/beam/3928)
<!-- Reviewable:end -->
